### PR TITLE
refactor!: whole-codebase simplify sweep of the rust crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+- refactor!: **one definition per mechanism across the rust crates.** A
+  whole-codebase simplify pass: the typst session compiles through one
+  `recompile` pipeline whose derived tables (regions, span windows, page hashes)
+  are built per commit instead of per query; the pdf reader's scan plumbing
+  (`object_dict`, `open_trailer`, `dict_end`, `ws_end`) and the page-dict array
+  splice are single definitions shared by stamp and flatten; the flattened PDF
+  is shared by `Arc` instead of copied per render; emission, prescan, payload
+  assembly and validation in core lose their duplicated dispatch and their
+  per-keystroke deep clones. Two outputs shift: a blank pdfform document returns
+  the base PDF unchanged rather than appending a revision carrying two
+  unreferenced font objects, and three `quillmark-pdf` parse-failure messages
+  share one `dict not parseable` spelling (codes unchanged). Dead public API is
+  deleted: `FileTreeNode::{file_exists, dir_exists, list_files,
+  list_subdirectories}`, `Payload::contains_key`, `PayloadItem::nested_comments`,
+  `QuillValue::{string, integer, bool, null}` (the `From` impls and `from_json`
+  are the constructors), `FieldSpec::{with_schema_field, with_value,
+  with_tooltip}` (assign the fields), and `quillmark-content`'s
+  `strip_bidi_formatting` / `fix_html_comment_fences` (internal to
+  `normalize_markdown`). None had a caller in the workspace or bindings.
+
 - fix: **an empty mapping emits as `{}` rather than losing its key.** `emit_field`
   dropped an empty-object field entirely, which composes with the block form of
   its parent into markdown no parser accepts: a `$ext` whose every namespace

--- a/crates/backends/pdfform/src/flatten.rs
+++ b/crates/backends/pdfform/src/flatten.rs
@@ -10,10 +10,10 @@
 //! SVG/PNG raster outputs only; the AcroForm PDF deliverable is stamped.
 
 use quillmark_pdf::{
-    reader::{
-        extract_outer_dict, find_dict_value, find_object_bytes, splice_dict_value, UpdatedObject,
+    reader::{extract_outer_dict, find_dict_value, object_dict, splice_dict_value, UpdatedObject},
+    writer::{
+        alloc_id, append_refs_to_array_key, dict_object, pdf_escape, winansi_encode, OnNonArray,
     },
-    writer::{alloc_id, dict_object, pdf_escape, winansi_encode},
     FieldSpec, FieldType, PdfError, PdfUpdate, CHECKBOX_ON_STATE,
 };
 
@@ -24,7 +24,10 @@ const CODE_PARSE: &str = "pdf::flatten_parse";
 /// Flatten `fields` onto `base` by drawing values as content stream operators.
 /// Backs raster output only, so it stamps no `/Info /Producer`.
 pub fn flatten(base: Vec<u8>, fields: &[FieldSpec]) -> Result<Vec<u8>, PdfError> {
-    if fields.is_empty() {
+    // Nothing to draw is the base itself: an update carrying only the two font
+    // objects would be a revision no page references.
+    let drawable: Vec<&FieldSpec> = fields.iter().filter(|s| has_drawable_value(s)).collect();
+    if drawable.is_empty() {
         return Ok(base);
     }
 
@@ -47,31 +50,24 @@ pub fn flatten(base: Vec<u8>, fields: &[FieldSpec]) -> Result<Vec<u8>, PdfError>
         .push(type1_font_object(zadb_id, typography::CHECK_FONT, None));
 
     let mut fields_by_page: Vec<Vec<&FieldSpec>> = vec![Vec::new(); page_count];
-    for spec in fields {
+    for spec in drawable {
         fields_by_page[spec.page].push(spec);
     }
 
     for (page_idx, page_fields) in fields_by_page.iter().enumerate() {
-        let drawable: Vec<&FieldSpec> = page_fields
-            .iter()
-            .copied()
-            .filter(|s| has_drawable_value(s))
-            .collect();
-        if drawable.is_empty() {
+        if page_fields.is_empty() {
             continue;
         }
 
         let stream_id = alloc_id(&mut up.next_id)?;
         up.objects.push(content_stream_object(
             stream_id,
-            &build_content_stream(&drawable),
+            &build_content_stream(page_fields),
         ));
 
         let page_obj_id = page_ids[page_idx];
-        let (s, e) = find_object_bytes(&pdf, page_obj_id)
-            .ok_or_else(|| PdfError::new(CODE_PARSE, format!("page object {page_obj_id} not found")))?;
-        let pg_dict = extract_outer_dict(&pdf[s..e])
-            .ok_or_else(|| PdfError::new(CODE_PARSE, "page dict not parseable"))?;
+        let what = format!("page object {page_obj_id}");
+        let pg_dict = object_dict(&pdf, page_obj_id, CODE_PARSE, &what)?;
 
         let new_pg = rewrite_page_for_flatten(pg_dict, helv_id, zadb_id, stream_id)?;
         up.objects.push(dict_object(page_obj_id, &new_pg));
@@ -182,52 +178,34 @@ fn rewrite_page_for_flatten(
     zadb_id: u32,
     stream_id: u32,
 ) -> Result<Vec<u8>, PdfError> {
-    let with_stream = add_content_stream(pg_dict, stream_id)?;
-    let with_helv = add_font_resource(&with_stream, "Helv", helv_id)?;
-    add_font_resource(&with_helv, "ZaDb", zadb_id)
+    // A page `/Contents` is legitimately a bare stream reference, so the
+    // flatten stream wraps it rather than refusing it.
+    let with_stream = append_refs_to_array_key(
+        pg_dict,
+        "Contents",
+        &[stream_id],
+        CODE_PARSE,
+        OnNonArray::Wrap,
+    )?;
+    add_font_resources(&with_stream, &[("Helv", helv_id), ("ZaDb", zadb_id)])
 }
 
-fn add_content_stream(pg_dict: &[u8], stream_id: u32) -> Result<Vec<u8>, PdfError> {
-    let ref_str = format!("{stream_id} 0 R");
-    match find_dict_value(pg_dict, "Contents") {
-        None => {
-            let mut out = pg_dict.to_vec();
-            out.extend_from_slice(format!(" /Contents [{ref_str}]").as_bytes());
-            Ok(out)
-        }
-        Some(existing) => {
-            let trimmed = existing.trim_ascii();
-            let new_val = if trimmed.starts_with(b"[") {
-                let end = trimmed
-                    .iter()
-                    .rposition(|&b| b == b']')
-                    .ok_or_else(|| PdfError::new(CODE_PARSE, "/Contents array missing ]"))?;
-                let inner = String::from_utf8_lossy(&trimmed[1..end]);
-                format!("[{} {ref_str}]", inner.trim())
-            } else {
-                format!("[{} {ref_str}]", String::from_utf8_lossy(trimmed).trim())
-            };
-            Ok(splice_dict_value(
-                pg_dict,
-                b"/Contents",
-                existing,
-                new_val.as_bytes(),
-            ))
-        }
-    }
-}
-
-/// Inject `/<name> <font_id> 0 R` into the page's `/Resources /Font` dict,
-/// creating intermediate dicts as needed. An indirect `/Resources` or `/Font`
-/// is an error rather than a skip: a `Tf` name resolves only through the page's
-/// `/Font` subdictionary, so an uninjected name draws nothing.
-fn add_font_resource(pg_dict: &[u8], name: &str, font_id: u32) -> Result<Vec<u8>, PdfError> {
-    let helv_entry = format!("/{name} {font_id} 0 R");
+/// Inject `/<name> <font_id> 0 R` for each of `fonts` into the page's
+/// `/Resources /Font` dict, creating intermediate dicts as needed. An indirect
+/// `/Resources` or `/Font` is an error rather than a skip: a `Tf` name resolves
+/// only through the page's `/Font` subdictionary, so an uninjected name draws
+/// nothing.
+fn add_font_resources(pg_dict: &[u8], fonts: &[(&str, u32)]) -> Result<Vec<u8>, PdfError> {
+    let entries = fonts
+        .iter()
+        .map(|(name, font_id)| format!("/{name} {font_id} 0 R"))
+        .collect::<Vec<_>>()
+        .join(" ");
 
     match find_dict_value(pg_dict, "Resources") {
         None => {
             let mut out = pg_dict.to_vec();
-            out.extend_from_slice(format!(" /Resources << /Font << {helv_entry} >> >>").as_bytes());
+            out.extend_from_slice(format!(" /Resources << /Font << {entries} >> >>").as_bytes());
             Ok(out)
         }
         Some(res_val) => {
@@ -245,7 +223,7 @@ fn add_font_resource(pg_dict: &[u8], name: &str, font_id: u32) -> Result<Vec<u8>
             let new_res_inner: Vec<u8> = match find_dict_value(res_inner, "Font") {
                 None => {
                     let mut out = res_inner.to_vec();
-                    out.extend_from_slice(format!(" /Font << {helv_entry} >>").as_bytes());
+                    out.extend_from_slice(format!(" /Font << {entries} >>").as_bytes());
                     out
                 }
                 Some(font_val) => {
@@ -261,7 +239,7 @@ fn add_font_resource(pg_dict: &[u8], name: &str, font_id: u32) -> Result<Vec<u8>
                     })?;
                     let mut new_font_val = b"<< ".to_vec();
                     new_font_val.extend_from_slice(font_inner);
-                    new_font_val.extend_from_slice(format!(" {helv_entry} >>").as_bytes());
+                    new_font_val.extend_from_slice(format!(" {entries} >>").as_bytes());
 
                     splice_dict_value(res_inner, b"/Font", font_val, &new_font_val)
                 }
@@ -322,14 +300,15 @@ mod tests {
         include_bytes!("../../../fixtures/resources/quills/sample_form/0.1.0/form.pdf");
 
     fn text_field(name: &str, value: &str) -> FieldSpec {
-        FieldSpec::new(
+        let mut spec = FieldSpec::new(
             name.to_string(),
             0,
             [72.0, 700.0, 300.0, 720.0],
             FieldType::Text { multiline: false },
-        )
-        .with_schema_field(name.to_string())
-        .with_value(value.to_string())
+        );
+        spec.schema_field = Some(name.to_string());
+        spec.value = Some(value.to_string());
+        spec
     }
 
     fn checkbox_field(name: &str, checked: bool) -> FieldSpec {
@@ -338,8 +317,8 @@ mod tests {
             0,
             [72.0, 660.0, 90.0, 678.0],
             FieldType::Checkbox,
-        )
-        .with_schema_field(name.to_string());
+        );
+        spec.schema_field = Some(name.to_string());
         spec.value = checked.then(|| CHECKBOX_ON_STATE.to_string());
         spec
     }
@@ -437,6 +416,15 @@ mod tests {
         assert!(
             !contains_window(&unchecked, b"(4) Tj"),
             "unchecked checkbox must not draw the check glyph"
+        );
+    }
+
+    #[test]
+    fn a_form_with_nothing_to_draw_is_returned_unchanged() {
+        assert_eq!(
+            flatten_ok(&[checkbox_field("Agree", false)]),
+            BASE,
+            "no drawable value must append no revision"
         );
     }
 }

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -91,7 +91,7 @@ impl Backend for PdfformBackend {
         let field_specs = resolve_field_specs(&bound, json_data);
 
         // Pre-flatten once so the raster paths need not re-flatten per paint.
-        let flat_pdf = flatten_to_pdf(base_pdf.clone(), &field_specs)?;
+        let flat_pdf = Arc::new(flatten_to_pdf(base_pdf.clone(), &field_specs)?);
 
         Ok(LiveSession::new(
             Box::new(PdfformSession {
@@ -131,7 +131,9 @@ struct PdfformSession {
     /// Cached so `page_size_pt` need not reparse.
     page_boxes: Vec<[f32; 4]>,
     /// Values baked as content-stream operators, ready for hayro rasterisation.
-    flat_pdf: Vec<u8>,
+    /// An `Arc` because hayro takes its bytes as one: a render pass shares them
+    /// rather than copying the whole flattened PDF.
+    flat_pdf: Arc<Vec<u8>>,
 }
 
 impl SessionHandle for PdfformSession {
@@ -175,7 +177,7 @@ impl SessionHandle for PdfformSession {
     }
 
     fn render_rgba(&self, page: usize, scale: f32) -> Option<(u32, u32, Vec<u8>)> {
-        let pdf = HayroPdf::new(self.flat_pdf.clone()).ok()?;
+        let pdf = HayroPdf::new(Arc::clone(&self.flat_pdf)).ok()?;
         let p = pdf.pages().get(page)?;
         let cache = RenderCache::new();
         let interp = standard_font_settings();
@@ -199,7 +201,7 @@ impl SessionHandle for PdfformSession {
     /// never changes, so field deltas are the only visible delta.
     fn update(&mut self, json_data: &serde_json::Value) -> Result<ChangeSet, RenderError> {
         let field_specs = resolve_field_specs(&self.bound, json_data);
-        let flat_pdf = flatten_to_pdf(self.base_pdf.clone(), &field_specs)?;
+        let flat_pdf = Arc::new(flatten_to_pdf(self.base_pdf.clone(), &field_specs)?);
 
         let mut dirty_pages: Vec<usize> = self
             .field_specs
@@ -219,13 +221,19 @@ impl SessionHandle for PdfformSession {
 }
 
 impl PdfformSession {
-    fn render_svg(&self) -> Result<RenderResult, RenderError> {
-        let pdf = HayroPdf::new(self.flat_pdf.clone()).map_err(|_| {
+    /// The pre-flattened PDF parsed for a render pass, refused under the
+    /// caller's own per-format error code.
+    fn open_flat(&self, code: &'static str, label: &str) -> Result<HayroPdf, RenderError> {
+        HayroPdf::new(Arc::clone(&self.flat_pdf)).map_err(|_| {
             engine_err(
-                "pdfform::svg_parse_failed",
-                "failed to parse pre-flattened PDF for SVG render",
+                code,
+                format!("failed to parse pre-flattened PDF for {label} render"),
             )
-        })?;
+        })
+    }
+
+    fn render_svg(&self) -> Result<RenderResult, RenderError> {
+        let pdf = self.open_flat("pdfform::svg_parse_failed", "SVG")?;
         let interp = standard_font_settings();
         let svg_settings = SvgRenderSettings {
             bg_color: [255, 255, 255, 255],
@@ -245,12 +253,7 @@ impl PdfformSession {
 
     /// `scale` is device pixels per PDF point (`ppi / 72`).
     fn render_png(&self, scale: f32) -> Result<RenderResult, RenderError> {
-        let pdf = HayroPdf::new(self.flat_pdf.clone()).map_err(|_| {
-            engine_err(
-                "pdfform::png_parse_failed",
-                "failed to parse pre-flattened PDF for PNG render",
-            )
-        })?;
+        let pdf = self.open_flat("pdfform::png_parse_failed", "PNG")?;
         let interp = standard_font_settings();
         let render_settings = scaled_render_settings(scale);
 

--- a/crates/backends/typst/src/compile.rs
+++ b/crates/backends/typst/src/compile.rs
@@ -14,7 +14,7 @@ use crate::world::QuillWorld;
 use quillmark_core::{Artifact, Diagnostic, OutputFormat, RenderError, RenderResult, Severity};
 use quillmark_pdf::{stamp, StampOptions};
 
-fn render_options(pixel_per_pt: f32) -> RenderOptions {
+pub(crate) fn render_options(pixel_per_pt: f32) -> RenderOptions {
     RenderOptions {
         pixel_per_pt: Scalar::new(pixel_per_pt as f64),
         ..Default::default()

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -271,6 +271,8 @@ struct Emit<'a> {
     /// Whether `out` currently ends at a fresh line, tracked so block
     /// separators land consistently.
     end_newline: bool,
+    /// How far [`Self::overlapping_marks`] has walked `rt.marks`.
+    mark_cursor: usize,
 }
 
 impl<'a> Emit<'a> {
@@ -295,7 +297,25 @@ impl<'a> Emit<'a> {
             out: String::new(),
             segments: Vec::new(),
             end_newline: true,
+            mark_cursor: 0,
         }
+    }
+
+    /// The marks that can overlap `[lo, hi)`, as a slice of `rt.marks`.
+    ///
+    /// Segments are emitted in ascending content order, so a mark ending at or
+    /// before `lo` is behind every segment still to come and the cursor drops it
+    /// for good; `normalize_marks` leaves marks ascending by `start`, so the
+    /// first one starting at or after `hi` ends the slice. Both bounds are
+    /// conservative — [`wraps_and_codes`] still clamps and discards — so the
+    /// only effect is not rescanning the whole mark list per segment.
+    fn overlapping_marks(&mut self, lo: usize, hi: usize) -> &'a [Mark] {
+        let marks: &'a [Mark] = &self.rt.marks;
+        while self.mark_cursor < marks.len() && marks[self.mark_cursor].end <= lo {
+            self.mark_cursor += 1;
+        }
+        let rest = &marks[self.mark_cursor..];
+        &rest[..rest.partition_point(|m| m.start < hi)]
     }
 
     /// Leaf blocks terminate with `\n\n`; lists and quotes carry their own
@@ -590,7 +610,7 @@ impl<'a> Emit<'a> {
     ) -> Vec<(Range<usize>, Range<usize>, EscapeCtx)> {
         let mut runs = Vec::new();
 
-        let (mut wraps, codes) = wraps_and_codes(&self.rt.marks, lo, hi);
+        let (mut wraps, codes) = wraps_and_codes(self.overlapping_marks(lo, hi), lo, hi);
         // Atomic code spans can't carry partial styling.
         clip_wraps_to_codes(&mut wraps, &codes);
 
@@ -612,29 +632,13 @@ impl<'a> Emit<'a> {
                 buf.push_str(&markup);
                 return pos + 1;
             }
-            if let Some(&(cs, ce)) = codes.iter().find(|(s, _)| *s == pos) {
-                let content: String = self.chars[cs..ce].iter().collect();
-                buf.push_str("#raw(\"");
-                let rg0 = base + buf.len();
-                buf.push_str(&escape_string(&content));
-                let rg1 = base + buf.len();
-                buf.push_str("\")");
-                runs.push((cs..ce, rg0..rg1, EscapeCtx::StringLit));
-                return ce;
-            }
-            let re = next_boundary(pos, hi, &self.chars, &wraps, &codes);
-            let content: String = self.chars[pos..re].iter().collect();
-            // The neutralizing `\` sits *outside* the run's `generated` window,
-            // so `generated == escape_markup(content)` stays exact.
-            // `buf.is_empty()` gates to the segment's first content: a wrap
-            // already opened here would put the token mid-line.
-            if at_col0 && buf.is_empty() && opens_line_anchor(&content) {
-                buf.push('\\');
-            }
-            let rg0 = base + buf.len();
-            buf.push_str(&escape_markup(&content));
-            let rg1 = base + buf.len();
-            runs.push((pos..re, rg0..rg1, EscapeCtx::Markup));
+            // `buf.is_empty()` gates the line-anchor guard to the segment's
+            // first content: a wrap already opened here would put the token
+            // mid-line.
+            let anchored = at_col0 && buf.is_empty();
+            let (re, (content, g, ctx)) =
+                emit_run(buf, pos, hi, &self.chars, &wraps, &codes, anchored);
+            runs.push((content, (base + g.start)..(base + g.end), ctx));
             re
         });
         self.out.push_str(&buf);
@@ -802,6 +806,40 @@ fn wraps_and_codes(marks: &[Mark], lo: usize, hi: usize) -> (Vec<Wrap>, Vec<(usi
     (wraps, codes)
 }
 
+/// One run of a mark sweep: the atomic `#raw(..)` code span starting at `pos`,
+/// or the plain text up to the next boundary. Returns the position after it plus
+/// its `(content, generated, context)` pair, `generated` indexing `out` itself.
+/// `anchored` arms the line-anchor `\` guard, whose byte sits *outside* the
+/// run's window so `generated == escape_markup(content)` stays exact.
+fn emit_run(
+    out: &mut String,
+    pos: usize,
+    hi: usize,
+    chars: &[char],
+    wraps: &[Wrap],
+    codes: &[(usize, usize)],
+    anchored: bool,
+) -> (usize, (Range<usize>, Range<usize>, EscapeCtx)) {
+    if let Some(&(cs, ce)) = codes.iter().find(|(s, _)| *s == pos) {
+        let content: String = chars[cs..ce].iter().collect();
+        out.push_str("#raw(\"");
+        let g0 = out.len();
+        out.push_str(&escape_string(&content));
+        let g1 = out.len();
+        out.push_str("\")");
+        return (ce, (cs..ce, g0..g1, EscapeCtx::StringLit));
+    }
+    let re = next_boundary(pos, hi, chars, wraps, codes);
+    let content: String = chars[pos..re].iter().collect();
+    if anchored && opens_line_anchor(&content) {
+        out.push('\\');
+    }
+    let g0 = out.len();
+    out.push_str(&escape_markup(&content));
+    let g1 = out.len();
+    (re, (pos..re, g0..g1, EscapeCtx::Markup))
+}
+
 /// A cell is flat inline (no islands, no line breaks), so its markup carries no
 /// source-map runs.
 fn cell_markup(text: &str, marks: &[Mark]) -> String {
@@ -810,17 +848,7 @@ fn cell_markup(text: &str, marks: &[Mark]) -> String {
     clip_wraps_to_codes(&mut wraps, &codes);
     let mut out = String::new();
     sweep_marks(0, chars.len(), &wraps, &mut out, |out, pos| {
-        if let Some(&(cs, ce)) = codes.iter().find(|(s, _)| *s == pos) {
-            let content: String = chars[cs..ce].iter().collect();
-            out.push_str("#raw(\"");
-            out.push_str(&escape_string(&content));
-            out.push_str("\")");
-            return ce;
-        }
-        let re = next_boundary(pos, chars.len(), &chars, &wraps, &codes);
-        let content: String = chars[pos..re].iter().collect();
-        out.push_str(&escape_markup(&content));
-        re
+        emit_run(out, pos, chars.len(), &chars, &wraps, &codes, false).0
     });
     out
 }

--- a/crates/backends/typst/src/helper.rs
+++ b/crates/backends/typst/src/helper.rs
@@ -55,7 +55,6 @@ pub fn generate_lib_typ(
     if let Some(e) = cg.emit_error.take() {
         return Err(e);
     }
-    let meta_literal = meta_literal(meta);
     let display_literal = display_literal(&cg.display);
 
     // Placeholders are located in the *raw template* (trusted static text), never
@@ -68,7 +67,7 @@ pub fn generate_lib_typ(
     let mut blocks_at = 0usize;
     for (slot, value) in [
         ("{version}", HELPER_VERSION),
-        ("{meta_literal}", meta_literal.as_str()),
+        ("{meta_literal}", meta.meta_literal()),
         ("{content_blocks}", cg.blocks.as_str()),
         ("{data_literal}", data_literal.as_str()),
         ("{display_literal}", display_literal.as_str()),
@@ -398,12 +397,6 @@ enum DateKind {
     DateTime,
 }
 
-/// The schema address tables `_qm-known-path` validates `form-field` paths
-/// against.
-fn meta_literal(meta: &SchemaMeta) -> String {
-    lit(&meta.address_json())
-}
-
 /// Each present date's `_qm_dN` closure keyed by schema address, backing the
 /// `display(field, ..)` helper. Keys sort so a reorder-only `apply` still
 /// produces byte-identical source.
@@ -442,7 +435,7 @@ fn datetime_constructor(s: &str, kind: DateKind) -> Option<String> {
 /// exponent syntax, but the `float(str)` constructor parses every finite
 /// `f64`, and `json()` rejects non-finite numbers); strings via
 /// [`escape_string`]; arrays and objects via [`wrap_array`] / [`wrap_dict`].
-fn lit(v: &serde_json::Value) -> String {
+pub(crate) fn lit(v: &serde_json::Value) -> String {
     use serde_json::Value::*;
     match v {
         Null => "none".to_string(),

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -42,34 +42,80 @@ const SUPPORTED_FORMATS: &[OutputFormat] =
 /// recompiles.
 struct TypstSession {
     world: world::QuillWorld,
-    document: typst_layout::PagedDocument,
-    page_count: usize,
-    /// Extracted from each committed compile; converted to spine `FieldSpec`s
-    /// on every render.
-    field_placements: Vec<overlay::FieldPlacement>,
     /// Built once at `open`: the schema never changes for a session's lifetime,
     /// and codegen plus date validation read only these tables.
     schema_meta: SchemaMeta,
-    /// The span scan's classification table for the live compile: generated
-    /// content-block windows then the plate's scalar reference-site windows.
-    /// Swapped transactionally with the document.
-    windows: Vec<overlay::FieldWindow>,
     /// The plate is static for a session's lifetime, so these are computed once
-    /// at `open` and re-appended into `windows` per apply.
+    /// at `open` and re-appended into the compile's windows per apply.
     scalar_windows: Vec<overlay::FieldWindow>,
+    /// Swapped whole, and only once [`recompile`] has succeeded, so on `Err`
+    /// every read keeps serving the last-good compile.
+    live: Compiled,
+}
+
+/// One compile plus everything derived from it. Derived here rather than per
+/// query: a point hit or a region scan is a read of these tables.
+struct Compiled {
+    document: typst_layout::PagedDocument,
+    /// Extracted from each committed compile; converted to spine `FieldSpec`s
+    /// on every render.
+    field_placements: Vec<overlay::FieldPlacement>,
+    /// The placements as regions, the single derivation `regions` and
+    /// `field_at` both read. Empty if the placements fail to resolve; a render
+    /// surfaces the same error.
+    widget_regions: Vec<RenderedRegion>,
+    /// The span scan's classification table: generated content-block windows
+    /// then the plate's scalar reference-site windows.
+    windows: Vec<overlay::FieldWindow>,
     /// Span resolution goes through this snapshot, not the world: a failed
     /// `apply` leaves the *next* injection's text in the world while every read
     /// keeps serving this compile.
     helper_source: typst::syntax::Source,
     /// Diffed against the next compile's to produce `ChangeSet::dirty_pages`.
     page_hashes: Vec<u128>,
-    /// What [`session_warnings`] built for the live compile. The compile half
-    /// swaps on each committed `apply`; the load half rides along unchanged.
+    /// What [`session_warnings`] built for this compile. The compile half swaps
+    /// on each committed `apply`; the load half rides along unchanged.
     warnings: Vec<Diagnostic>,
-    /// [`overlay::unclosed_claims`] for the live document, suppressed by every
+    /// [`overlay::unclosed_claims`] for this document, suppressed by every
     /// region and point query. Computed with the compile rather than per query:
     /// `field_at` cannot derive it from the page prefix it walks.
     unclosed_claims: Vec<usize>,
+}
+
+/// Inject the data, compile, and derive every table a query reads. Nothing a
+/// session serves is touched on the way, so a caller commits the result in one
+/// move or keeps what it had.
+fn recompile(
+    world: &mut world::QuillWorld,
+    data: &serde_json::Value,
+    schema_meta: &SchemaMeta,
+    scalar_windows: &[overlay::FieldWindow],
+) -> Result<Compiled, RenderError> {
+    let mut windows = world
+        .inject_helper_package(data, schema_meta)
+        .map_err(|e| engine_err(e.code(), e.to_string()))?;
+    windows.extend(scalar_windows.iter().cloned());
+
+    let (document, compile_warnings) = compile::compile_document(world)?;
+    let helper_source = helper_source(world)?;
+    let field_placements = overlay::extract(&document)?;
+
+    let unclosed = overlay::unclosed_claims(&document);
+    let hashes = page_hashes(&document);
+    let warnings = session_warnings(world, compile_warnings, &unclosed);
+    let widget_regions = overlay::build_field_specs(&document, &field_placements)
+        .map(|specs| quillmark_pdf::regions_of(&specs))
+        .unwrap_or_default();
+    Ok(Compiled {
+        document,
+        field_placements,
+        widget_regions,
+        windows,
+        helper_source,
+        page_hashes: hashes,
+        warnings,
+        unclosed_claims: unclosed.into_iter().map(|(claim, _)| claim).collect(),
+    })
 }
 
 /// The quill's load warnings, then this compile's own, then one per runaway
@@ -205,59 +251,46 @@ impl SessionHandle for TypstSession {
         }
 
         compile::render_document_pages(
-            &self.document,
+            &self.live.document,
             opts.pages.as_deref(),
             format,
             opts.ppi,
-            &self.field_placements,
+            &self.live.field_placements,
             opts.producer.as_deref(),
         )
     }
 
     fn page_count(&self) -> usize {
-        self.page_count
+        self.live.document.pages().len()
     }
 
-    /// Transactional: the live document, placements, hashes, and compile
-    /// warnings swap together only after the compile *and* placement extraction
-    /// succeed, so on `Err` every read keeps serving the last-good compile.
+    /// Transactional: the live compile swaps in whole only after [`recompile`]
+    /// succeeds, so on `Err` every read keeps serving the last-good one.
     fn update(&mut self, json_data: &serde_json::Value) -> Result<ChangeSet, RenderError> {
         let data = transformed_data(json_data);
-        let mut windows = self
-            .world
-            .inject_helper_package(data.as_ref(), &self.schema_meta)
-            .map_err(|e| engine_err(e.code(), e.to_string()))?;
-        windows.extend(self.scalar_windows.iter().cloned());
+        let compiled = recompile(
+            &mut self.world,
+            data.as_ref(),
+            &self.schema_meta,
+            &self.scalar_windows,
+        )?;
 
-        let (document, compile_warnings) = compile::compile_document(&self.world)?;
-        let helper_source = helper_source(&self.world)?;
-        let field_placements = overlay::extract(&document)?;
-        let new_hashes = page_hashes(&document);
-        let unclosed = overlay::unclosed_claims(&document);
-
-        let dirty_pages = (0..new_hashes.len())
-            .filter(|&i| self.page_hashes.get(i) != Some(&new_hashes[i]))
+        let page_count = compiled.page_hashes.len();
+        let dirty_pages = (0..page_count)
+            .filter(|&i| self.live.page_hashes.get(i) != Some(&compiled.page_hashes[i]))
             .collect();
 
-        self.document = document;
-        self.field_placements = field_placements;
-        self.windows = windows;
-        self.helper_source = helper_source;
-        self.page_count = new_hashes.len();
-        self.page_hashes = new_hashes;
-        self.warnings = session_warnings(&self.world, compile_warnings, &unclosed);
-        self.unclosed_claims = unclosed.into_iter().map(|(claim, _)| claim).collect();
-
-        Ok(ChangeSet::new(self.page_count, dirty_pages))
+        self.live = compiled;
+        Ok(ChangeSet::new(page_count, dirty_pages))
     }
 
     fn warnings(&self) -> &[Diagnostic] {
-        &self.warnings
+        &self.live.warnings
     }
 
     /// Typst points: 1 pt = 1/72 inch.
     fn page_size_pt(&self, page: usize) -> Option<(f32, f32)> {
-        let frame = &self.document.pages().get(page)?.frame;
+        let frame = &self.live.document.pages().get(page)?.frame;
         let size = frame.size();
         Some((size.x.to_pt() as f32, size.y.to_pt() as f32))
     }
@@ -265,14 +298,8 @@ impl SessionHandle for TypstSession {
     /// Non-premultiplied RGBA8 at `scale`× the natural 72 ppi, returned as
     /// `(width_px, height_px, rgba)` with `w * h * 4` row-major bytes.
     fn render_rgba(&self, page: usize, scale: f32) -> Option<(u32, u32, Vec<u8>)> {
-        let p = self.document.pages().get(page)?;
-        let pixmap = typst_render::render(
-            p,
-            &typst_render::RenderOptions {
-                pixel_per_pt: typst::utils::Scalar::new(scale as f64),
-                ..Default::default()
-            },
-        );
+        let p = self.live.document.pages().get(page)?;
+        let pixmap = typst_render::render(p, &compile::render_options(scale));
         let width = pixmap.width();
         let height = pixmap.height();
         let mut rgba = Vec::with_capacity((width as usize) * (height as usize) * 4);
@@ -292,73 +319,46 @@ impl SessionHandle for TypstSession {
     /// repeat it, so consumers group by field. Widget regions are empty if the
     /// placements fail to resolve; a render surfaces the same error.
     fn regions(&self) -> Vec<quillmark_core::RenderedRegion> {
-        let mut regions = self.widget_regions();
-        regions.extend(overlay::scan_content_regions(
-            &self.document,
-            &self.world,
-            &self.helper_source,
-            &self.windows,
-            &self.unclosed_claims,
-        ));
+        let mut regions = self.live.widget_regions.clone();
+        regions.extend(self.scan().regions());
         regions
     }
 
     /// Widget boxes answer first: a widget is a deliberate click target drawing
     /// no spanned ink of its own, so content ink beneath it must not swallow the
     /// click. Among overlapping widgets the later-painted one wins, matching
-    /// `span_scan::field_at`.
+    /// `Scan::field_at`.
     fn field_at(&self, page: usize, x: f32, y: f32) -> Option<String> {
-        self.widget_regions()
-            .into_iter()
+        self.live
+            .widget_regions
+            .iter()
             .rev()
             .find(|r| r.contains(page, x, y))
-            .map(|r| r.field)
-            .or_else(|| {
-                overlay::field_at(
-                    &self.document,
-                    &self.world,
-                    &self.helper_source,
-                    &self.windows,
-                    &self.unclosed_claims,
-                    page,
-                    x,
-                    y,
-                )
-            })
+            .map(|r| r.field.clone())
+            .or_else(|| self.scan().field_at(page, x, y))
     }
 
     /// The fine-grained twin of [`field_at`](Self::field_at). Widgets draw no
     /// spanned content ink, so unlike `field_at` they are not consulted.
     fn position_at(&self, page: usize, x: f32, y: f32) -> Option<ContentHit> {
-        overlay::position_at(
-            &self.document,
-            &self.world,
-            &self.helper_source,
-            &self.windows,
-            page,
-            x,
-            y,
-        )
+        self.scan().position_at(page, x, y)
     }
 
     fn locate(&self, field: &str, pos: usize) -> Option<RenderedRegion> {
-        overlay::locate(
-            &self.document,
-            &self.world,
-            &self.helper_source,
-            &self.windows,
-            field,
-            pos,
-        )
+        self.scan().locate(field, pos)
     }
 }
 
 impl TypstSession {
-    /// The single derivation `regions` and `field_at` both read.
-    fn widget_regions(&self) -> Vec<quillmark_core::RenderedRegion> {
-        overlay::build_field_specs(&self.document, &self.field_placements)
-            .map(|specs| quillmark_pdf::regions_of(&specs))
-            .unwrap_or_default()
+    /// The live compile's tables, as the one context every content query takes.
+    fn scan(&self) -> overlay::Scan<'_> {
+        overlay::Scan {
+            doc: &self.live.document,
+            world: &self.world,
+            helper: &self.live.helper_source,
+            windows: &self.live.windows,
+            unclosed: &self.live.unclosed_claims,
+        }
     }
 }
 
@@ -410,9 +410,6 @@ impl Backend for TypstBackend {
                 .with_source(e.as_ref()),
             )
         })?;
-        let mut windows = world
-            .inject_helper_package(data.as_ref(), &schema_meta)
-            .map_err(|e| engine_err(e.code(), e.to_string()))?;
         // The plate is static for the session: window its scalar sites once.
         let scalar_windows: Vec<overlay::FieldWindow> = {
             use typst::World as _;
@@ -433,26 +430,12 @@ impl Backend for TypstBackend {
                 })
                 .unwrap_or_default()
         };
-        windows.extend(scalar_windows.iter().cloned());
-        let (document, compile_warnings) = compile::compile_document(&world)?;
-        let unclosed = overlay::unclosed_claims(&document);
-        let warnings = session_warnings(&world, compile_warnings, &unclosed);
-        let helper_src = helper_source(&world)?;
-        let page_count = document.pages().len();
-        let field_placements = overlay::extract(&document)?;
-        let hashes = page_hashes(&document);
+        let live = recompile(&mut world, data.as_ref(), &schema_meta, &scalar_windows)?;
         let session = TypstSession {
             world,
-            document,
-            page_count,
-            field_placements,
             schema_meta,
-            windows,
             scalar_windows,
-            helper_source: helper_src,
-            page_hashes: hashes,
-            warnings,
-            unclosed_claims: unclosed.into_iter().map(|(claim, _)| claim).collect(),
+            live,
         };
         Ok(LiveSession::new(
             Box::new(session),
@@ -497,7 +480,7 @@ fn read_plate(source: &Quill) -> Result<String, RenderError> {
 }
 
 /// A single-diagnostic [`RenderError`] carrying `code`.
-fn engine_err(code: &str, message: impl Into<String>) -> RenderError {
+pub(crate) fn engine_err(code: &str, message: impl Into<String>) -> RenderError {
     RenderError::from_diag(
         Diagnostic::new(Severity::Error, message.into()).with_code(code.to_string()),
     )
@@ -578,7 +561,6 @@ impl AddressNode {
 /// because they answer different questions. Lowering reads the schema node
 /// ([`helper::lowering`]); the tree answers which *addresses* a plate may
 /// write, which is the same walk with everything but the steps pruned away.
-#[derive(Default)]
 pub(crate) struct SchemaMeta {
     /// The walk's cursor source: the same recursive projection
     /// `build_transform_schema` produced, kept whole rather than flattened.
@@ -587,6 +569,15 @@ pub(crate) struct SchemaMeta {
     /// [`AddressNode::to_json`] serializes it for the helper either way.
     pub(crate) root: AddressNode,
     pub(crate) cards: BTreeMap<String, AddressNode>,
+    /// Serialized once: the schema is fixed for a session's lifetime, and every
+    /// apply splices this same literal into the generated `lib.typ`.
+    meta_literal: String,
+}
+
+impl Default for SchemaMeta {
+    fn default() -> Self {
+        Self::from_schema_json(&serde_json::Value::Null)
+    }
 }
 
 impl SchemaMeta {
@@ -604,15 +595,18 @@ impl SchemaMeta {
             }
         }
 
-        Self {
+        let mut meta = Self {
             root: AddressNode::from_schema(schema_json),
             cards,
             schema: schema_json.clone(),
-        }
+            meta_literal: String::new(),
+        };
+        meta.meta_literal = helper::lit(&meta.address_json());
+        meta
     }
 
     /// The address tables the helper's `_qm-known-path` validates against.
-    pub(crate) fn address_json(&self) -> serde_json::Value {
+    fn address_json(&self) -> serde_json::Value {
         serde_json::json!({
             "fields": self.root.to_json(),
             "cards": serde_json::Value::Object(
@@ -622,6 +616,12 @@ impl SchemaMeta {
                     .collect(),
             ),
         })
+    }
+
+    /// [`address_json`](Self::address_json) as the Typst literal codegen
+    /// splices into `_qm-meta`.
+    pub(crate) fn meta_literal(&self) -> &str {
+        &self.meta_literal
     }
 
     /// The schema node declaring a top-level field.

--- a/crates/backends/typst/src/overlay/extract.rs
+++ b/crates/backends/typst/src/overlay/extract.rs
@@ -14,7 +14,7 @@ use quillmark_core::{Diagnostic, RenderError, Severity};
 
 use quillmark_pdf::{FormFont, TextAlign};
 
-use super::{err, FieldKind, FieldPlacement};
+use super::{engine_err, FieldKind, FieldPlacement};
 
 const FIELD_LABEL: &str = "__qm_field__";
 const CODE_INTERNAL: &str = "typst::overlay_internal";
@@ -22,7 +22,7 @@ const CODE_INTERNAL: &str = "typst::overlay_internal";
 pub(crate) fn extract(doc: &PagedDocument) -> Result<Vec<FieldPlacement>, RenderError> {
     let intro = doc.introspector();
     let label = Label::new(PicoStr::intern(FIELD_LABEL)).ok_or_else(|| {
-        err(
+        engine_err(
             CODE_INTERNAL,
             "FIELD_LABEL must be a non-empty interned string",
         )
@@ -39,12 +39,12 @@ pub(crate) fn extract(doc: &PagedDocument) -> Result<Vec<FieldPlacement>, Render
         let dict = match c.get_by_name("value") {
             Ok(Value::Dict(d)) => d,
             Ok(other) => {
-                return Err(err(
+                return Err(engine_err(
                     CODE_INTERNAL,
                     format!("expected metadata value to be a dict, got {}", other.ty()),
                 ))
             }
-            Err(e) => return Err(err(CODE_INTERNAL, format!("metadata.value missing: {e:?}"))),
+            Err(e) => return Err(engine_err(CODE_INTERNAL, format!("metadata.value missing: {e:?}"))),
         };
         if read_str(&dict, "kind")? != FIELD_LABEL {
             // User attached <__qm_field__> to unrelated metadata; ignore it.
@@ -61,7 +61,7 @@ pub(crate) fn extract(doc: &PagedDocument) -> Result<Vec<FieldPlacement>, Render
         let align = read_align(&dict)?;
         let loc = c
             .location()
-            .ok_or_else(|| err(CODE_INTERNAL, "form-field metadata is not located"))?;
+            .ok_or_else(|| engine_err(CODE_INTERNAL, "form-field metadata is not located"))?;
 
         if let Some(&prior) = by_name.get(&name) {
             return Err(duplicate_field_error(&name, prior, loc));
@@ -70,7 +70,7 @@ pub(crate) fn extract(doc: &PagedDocument) -> Result<Vec<FieldPlacement>, Render
 
         let pos = intro
             .position(loc)
-            .ok_or_else(|| err(CODE_INTERNAL, "form-field metadata has no position"))?;
+            .ok_or_else(|| engine_err(CODE_INTERNAL, "form-field metadata has no position"))?;
         placements.push(FieldPlacement {
             name,
             schema_field,
@@ -111,7 +111,7 @@ fn read_field_kind(
             value: read_value_str(d, "value")?,
         }),
         "signature" => Ok(FieldKind::Signature),
-        other => Err(err(
+        other => Err(engine_err(
             CODE_INTERNAL,
             format!("unknown form-field type {other:?}"),
         )),
@@ -125,7 +125,7 @@ fn read_font(d: &typst::foundations::Dict) -> Result<FormFont, RenderError> {
         "helvetica" => Ok(FormFont::Helvetica),
         "times" => Ok(FormFont::Times),
         "courier" => Ok(FormFont::Courier),
-        other => Err(err(
+        other => Err(engine_err(
             CODE_INTERNAL,
             format!("unknown form-field font {other:?}"),
         )),
@@ -137,7 +137,7 @@ fn read_align(d: &typst::foundations::Dict) -> Result<TextAlign, RenderError> {
         "left" => Ok(TextAlign::Left),
         "center" => Ok(TextAlign::Center),
         "right" => Ok(TextAlign::Right),
-        other => Err(err(
+        other => Err(engine_err(
             CODE_INTERNAL,
             format!("unknown form-field align {other:?}"),
         )),
@@ -154,11 +154,11 @@ fn read_opt_f64(d: &typst::foundations::Dict, key: &str) -> Result<Option<f64>, 
 fn read_str(d: &typst::foundations::Dict, key: &str) -> Result<String, RenderError> {
     match d.get(key) {
         Ok(Value::Str(s)) => Ok(s.to_string()),
-        Ok(other) => Err(err(
+        Ok(other) => Err(engine_err(
             CODE_INTERNAL,
             format!("expected metadata.{key} to be str, got {}", other.ty()),
         )),
-        Err(_) => Err(err(CODE_INTERNAL, format!("metadata.{key} missing"))),
+        Err(_) => Err(engine_err(CODE_INTERNAL, format!("metadata.{key} missing"))),
     }
 }
 
@@ -166,11 +166,11 @@ fn read_f64(d: &typst::foundations::Dict, key: &str) -> Result<f64, RenderError>
     match d.get(key) {
         Ok(Value::Float(f)) => Ok(*f),
         Ok(Value::Int(i)) => Ok(*i as f64),
-        Ok(other) => Err(err(
+        Ok(other) => Err(engine_err(
             CODE_INTERNAL,
             format!("expected metadata.{key} to be float, got {}", other.ty()),
         )),
-        Err(_) => Err(err(CODE_INTERNAL, format!("metadata.{key} missing"))),
+        Err(_) => Err(engine_err(CODE_INTERNAL, format!("metadata.{key} missing"))),
     }
 }
 
@@ -178,7 +178,7 @@ fn read_opt_str(d: &typst::foundations::Dict, key: &str) -> Result<Option<String
     match d.get(key) {
         Ok(Value::Str(s)) => Ok(Some(s.to_string())),
         Ok(Value::None) => Ok(None),
-        Ok(other) => Err(err(
+        Ok(other) => Err(engine_err(
             CODE_INTERNAL,
             format!(
                 "expected metadata.{key} to be str or none, got {}",
@@ -195,7 +195,7 @@ fn read_str_array(d: &typst::foundations::Dict, key: &str) -> Result<Vec<String>
             .iter()
             .map(|v| match v {
                 Value::Str(s) => Ok(s.to_string()),
-                other => Err(err(
+                other => Err(engine_err(
                     CODE_INTERNAL,
                     format!(
                         "expected metadata.{key} elements to be str, got {}",
@@ -205,7 +205,7 @@ fn read_str_array(d: &typst::foundations::Dict, key: &str) -> Result<Vec<String>
             })
             .collect(),
         Ok(Value::None) => Ok(Vec::new()),
-        Ok(other) => Err(err(
+        Ok(other) => Err(engine_err(
             CODE_INTERNAL,
             format!("expected metadata.{key} to be an array, got {}", other.ty()),
         )),
@@ -223,7 +223,7 @@ fn read_value_str(d: &typst::foundations::Dict, key: &str) -> Result<Option<Stri
         Ok(Value::Bool(b)) => b.to_string(),
         Ok(Value::None) | Err(_) => return Ok(None),
         Ok(other) => {
-            return Err(err(
+            return Err(engine_err(
                 CODE_INTERNAL,
                 format!(
                     "expected metadata.{key} to be str/int/float/bool/none, got {}",
@@ -239,7 +239,7 @@ fn read_value_bool(d: &typst::foundations::Dict, key: &str) -> Result<Option<boo
     match d.get(key) {
         Ok(Value::Bool(b)) => Ok(Some(*b)),
         Ok(Value::None) | Err(_) => Ok(None),
-        Ok(other) => Err(err(
+        Ok(other) => Err(engine_err(
             CODE_INTERNAL,
             format!(
                 "expected metadata.{key} to be bool or none, got {}",

--- a/crates/backends/typst/src/overlay/mod.rs
+++ b/crates/backends/typst/src/overlay/mod.rs
@@ -2,18 +2,17 @@
 //! shared `quillmark-pdf` stamping spine. Typst→PDF coordinate ownership lives
 //! here so the spine never imports `typst_layout`.
 
-use quillmark_core::{Diagnostic, RenderError, Severity};
+use quillmark_core::RenderError;
 use quillmark_pdf::{FieldSpec, FieldType, FormFont, TextAlign, CHECKBOX_ON_STATE};
 use typst_layout::PagedDocument;
+
+use crate::engine_err;
 
 mod extract;
 mod span_scan;
 
 pub(crate) use extract::extract;
-pub(crate) use span_scan::{
-    field_at, locate, position_at, scalar_windows, scan_content_regions, unclosed_claims,
-    FieldWindow,
-};
+pub(crate) use span_scan::{scalar_windows, unclosed_claims, FieldWindow, Scan};
 
 /// Mirrors the spine's [`FieldType`] but carries the *resolved* Typst value.
 #[derive(Debug, Clone, PartialEq)]
@@ -46,10 +45,6 @@ pub(crate) struct FieldPlacement {
     pub align: TextAlign,
 }
 
-pub(crate) fn err(code: &'static str, msg: impl Into<String>) -> RenderError {
-    RenderError::from_diag(Diagnostic::new(Severity::Error, msg.into()).with_code(code.into()))
-}
-
 /// Owned by the backend, never defaulted from the leaf spine's version.
 pub(crate) fn default_producer() -> String {
     format!("Quillmark {}", env!("CARGO_PKG_VERSION"))
@@ -73,7 +68,7 @@ pub(crate) fn build_field_specs(
         .iter()
         .map(|p| {
             let page_h = *page_heights.get(p.page).ok_or_else(|| {
-                err(
+                engine_err(
                     "typst::form_field_page_out_of_range",
                     format!(
                         "form-field {:?} targets page {} but the document has {} page(s)",

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -231,7 +231,7 @@ impl Markers {
     ///
     /// `claims` grows on every open, suppressed or not, so an index addresses
     /// the same call in any walk of one document — including the page prefix
-    /// [`field_at`] walks.
+    /// [`Scan::field_at`] walks.
     fn edge(&mut self, path: &str, close: bool) {
         if !close {
             self.claims.push(path.to_string());
@@ -286,13 +286,14 @@ fn region_marker(elem: &Content) -> Option<(String, bool)> {
     ))
 }
 
-/// Memoizing span → two-tier classifier: the resolve + segment search runs once
-/// per distinct span, not once per glyph.
+/// Memoizing span → two-tier classifier: the tree descent that resolves a span
+/// to its byte range runs once per distinct span, not once per glyph, and both
+/// the classification and the caret path read that one cache.
 struct Classifier<'a> {
     world: &'a QuillWorld,
     helper: &'a Source,
     windows: &'a [FieldWindow],
-    memo: HashMap<Span, Option<(usize, Option<usize>)>>,
+    memo: HashMap<Span, Option<(FileId, Range<usize>)>>,
 }
 
 impl<'a> Classifier<'a> {
@@ -307,8 +308,11 @@ impl<'a> Classifier<'a> {
 
     /// The same unpack `WorldExt::range` performs, with the helper file routed
     /// to the served compile's snapshot instead of the world.
-    fn resolve_range(&self, span: Span) -> Option<(FileId, Range<usize>)> {
-        match DiagSpan::from(span).get() {
+    fn range_of(&mut self, span: Span) -> Option<(FileId, Range<usize>)> {
+        if let Some(cached) = self.memo.get(&span) {
+            return cached.clone();
+        }
+        let resolved = match DiagSpan::from(span).get() {
             DiagSpanKind::Detached => None,
             DiagSpanKind::Number { id, num, sub_range } => {
                 let range = if id == self.helper.id() {
@@ -322,25 +326,21 @@ impl<'a> Classifier<'a> {
                 range.map(|r| (id, r))
             }
             DiagSpanKind::Range { id, range } => Some((id, range)),
-        }
+        };
+        self.memo.insert(span, resolved.clone());
+        resolved
     }
 
     /// Resolves to the innermost segment whose `generated` range contains the
     /// span, or `None` for inter-segment / segment-less ink.
     fn classify_seg(&mut self, span: Span) -> Option<(usize, Option<usize>)> {
-        if let Some(&c) = self.memo.get(&span) {
-            return c;
-        }
-        let c = self.resolve_range(span).and_then(|(file, range)| {
-            self.windows
-                .iter()
-                .position(|win| {
-                    win.file == file && win.range.start <= range.start && range.end <= win.range.end
-                })
-                .map(|i| (i, self.seg_of(i, &range)))
-        });
-        self.memo.insert(span, c);
-        c
+        let (file, range) = self.range_of(span)?;
+        self.windows
+            .iter()
+            .position(|win| {
+                win.file == file && win.range.start <= range.start && range.end <= win.range.end
+            })
+            .map(|i| (i, self.seg_of(i, &range)))
     }
 
     /// Segments are `generated`-ordered and disjoint, so the sole candidate is
@@ -502,55 +502,170 @@ enum Run {
     Done,
 }
 
-/// Each span window's **first placement** and each `field-region` call's whole
-/// claim: one [`RenderedRegion`] per page a run touches, PDF bottom-left rects,
-/// sorted (page, field, key order). A claim in `unclosed` accrues nothing and so
-/// surfaces no region.
-pub(crate) fn scan_content_regions(
-    doc: &PagedDocument,
-    world: &QuillWorld,
-    helper: &Source,
-    windows: &[FieldWindow],
-    unclosed: &[usize],
-) -> Vec<RenderedRegion> {
-    let mut cls = Classifier::new(world, helper, windows);
-    let mut markers = Markers::suppressing(unclosed);
-    let mut hits = Vec::new();
-    for (page, p) in doc.pages().iter().enumerate() {
-        collect_page_hits(&p.frame, page, &mut cls, &mut markers, &mut hits);
+/// One committed compile plus the tables its spans resolve against: the context
+/// every region and point query shares. `unclosed` is supplied rather than
+/// derived per query because whether a claim open at some page ever closes is
+/// knowable only from the pages after it, which a single-page walk never
+/// reaches.
+pub(crate) struct Scan<'a> {
+    pub(crate) doc: &'a PagedDocument,
+    pub(crate) world: &'a QuillWorld,
+    pub(crate) helper: &'a Source,
+    pub(crate) windows: &'a [FieldWindow],
+    pub(crate) unclosed: &'a [usize],
+}
+
+impl<'a> Scan<'a> {
+    fn classifier(&self) -> Classifier<'a> {
+        Classifier::new(self.world, self.helper, self.windows)
     }
 
-    // Claims are only known after the walk, so keys extend the window keys.
-    let mut keys = flatten_keys(windows);
-    keys.extend((0..markers.claims.len()).map(Key::Marker));
-    let boxes = run_scan_machine(&keys, &hits);
-
-    let mut out: Vec<(RenderedRegion, usize)> = Vec::new();
-    for (ki, key) in keys.iter().enumerate() {
-        let (path, span) = match *key {
-            Key::Span(wi, seg) => {
-                let window = &windows[wi];
-                let span = seg.map(|s| {
-                    let c = &window.segments[s].content;
-                    [c.start, c.end]
-                });
-                (window.path.clone(), span)
+    /// `page`'s ink, or every page's when `page` is `None`, plus the marker
+    /// stack the walk ended on. Pages before `page` are walked for their markers
+    /// alone, since a claim opening there may still cover the page wanted;
+    /// skipping their glyphs keeps that lookbehind linear in frame items.
+    fn hits(&self, page: Option<usize>) -> (Vec<Hit>, Markers) {
+        let mut cls = self.classifier();
+        let mut markers = Markers::suppressing(self.unclosed);
+        let mut hits = Vec::new();
+        for (i, p) in self.doc.pages().iter().enumerate() {
+            match page {
+                Some(want) if i < want => scan_markers(&p.frame, &mut markers),
+                Some(want) if i > want => break,
+                _ => collect_page_hits(&p.frame, i, &mut cls, &mut markers, &mut hits),
             }
-            // Geometry with no content address, like a scalar site or a widget.
-            Key::Marker(ci) => (markers.claims[ci].clone(), None),
-        };
-        for (page, b) in &boxes[ki] {
-            let Some(page_h) = doc.pages().get(*page).map(|p| p.frame.size().y.to_pt()) else {
-                continue;
-            };
-            let mut region = RenderedRegion::new(path.clone(), *page, pdf_rect(b, page_h));
-            region.span = span;
-            out.push((region, ki));
         }
+        (hits, markers)
     }
-    // `ki` orders window-major then segment-ascending, a stable tiebreak.
-    out.sort_by(|(a, ai), (b, bi)| (a.page, &a.field, *ai).cmp(&(b.page, &b.field, *bi)));
-    out.into_iter().map(|(r, _)| r).collect()
+
+    /// Each span window's **first placement** and each `field-region` call's
+    /// whole claim: one [`RenderedRegion`] per page a run touches, PDF
+    /// bottom-left rects, sorted (page, field, key order). A claim in `unclosed`
+    /// accrues nothing and so surfaces no region.
+    pub(crate) fn regions(&self) -> Vec<RenderedRegion> {
+        let (hits, markers) = self.hits(None);
+
+        // Claims are only known after the walk, so keys extend the window keys.
+        let mut keys = flatten_keys(self.windows);
+        keys.extend((0..markers.claims.len()).map(Key::Marker));
+        let boxes = run_scan_machine(&keys, &hits);
+
+        let mut out: Vec<(RenderedRegion, usize)> = Vec::new();
+        for (ki, key) in keys.iter().enumerate() {
+            let (path, span) = match *key {
+                Key::Span(wi, seg) => {
+                    let window = &self.windows[wi];
+                    let span = seg.map(|s| {
+                        let c = &window.segments[s].content;
+                        [c.start, c.end]
+                    });
+                    (window.path.clone(), span)
+                }
+                // Geometry with no content address, like a scalar site or a widget.
+                Key::Marker(ci) => (markers.claims[ci].clone(), None),
+            };
+            for (page, b) in &boxes[ki] {
+                let Some(page_h) = self.doc.pages().get(*page).map(|p| p.frame.size().y.to_pt())
+                else {
+                    continue;
+                };
+                let mut region = RenderedRegion::new(path.clone(), *page, pdf_rect(b, page_h));
+                region.span = span;
+                out.push((region, ki));
+            }
+        }
+        // `ki` orders window-major then segment-ascending, a stable tiebreak.
+        out.sort_by(|(a, ai), (b, bi)| (a.page, &a.field, *ai).cmp(&(b.page, &b.field, *bi)));
+        out.into_iter().map(|(r, _)| r).collect()
+    }
+
+    /// The schema field under a point (`x`/`y` in PDF bottom-left points).
+    /// Unlike [`regions`](Self::regions) every placement answers, not just the
+    /// first. Among tracked ink the later-painted item wins; untracked ink never
+    /// occludes.
+    pub(crate) fn field_at(&self, page: usize, x: f32, y: f32) -> Option<String> {
+        let frame = &self.doc.pages().get(page)?.frame;
+        let page_h = frame.size().y.to_pt();
+        let (x, y) = (x as f64, page_h - y as f64);
+
+        let (hits, markers) = self.hits(Some(page));
+
+        hits.iter()
+            .rev()
+            .find(|h| h.rect.is_some_and(|r| r.contains(x, y)))
+            .and_then(|h| h.class.owner())
+            .map(|owner| match owner {
+                Owner::Window(w) => self.windows[w].path.clone(),
+                Owner::Claim(c) => markers.claims[c].clone(),
+            })
+    }
+
+    /// A point (PDF bottom-left points) → content position in a content field.
+    /// Degrades to the segment's content start when the resolved node nests
+    /// inside no single run (a multi-line `#raw` block, or structural ink).
+    pub(crate) fn position_at(&self, page: usize, x: f32, y: f32) -> Option<ContentHit> {
+        if self.windows.is_empty() {
+            return None;
+        }
+        let frame = &self.doc.pages().get(page)?.frame;
+        let page_h = frame.size().y.to_pt();
+        let (px, py) = (x as f64, page_h - y as f64);
+
+        let mut cls = self.classifier();
+        let mut hits = Vec::new();
+        walk_glyphs(frame, page, &mut cls, None, &mut hits);
+
+        // Later-painted wins; ink with no segment has no content position.
+        let hit = hits
+            .iter()
+            .rev()
+            .find(|g| g.seg.is_some() && g.rect.contains(px, py))?;
+        let window = &self.windows[hit.window];
+        let segmap = &window.segments[hit.seg?];
+        let (pos, granularity) = invert_hit(self.helper, segmap, &hit.node, hit.offset);
+        Some(ContentHit::new(window.path.clone(), pos).with_granularity(granularity))
+    }
+
+    /// A content position → caret rect: the box of the frame glyph whose
+    /// resolved node covers `pos`, with `span` collapsed to `[pos, pos]`.
+    pub(crate) fn locate(&self, field: &str, pos: usize) -> Option<RenderedRegion> {
+        if self.windows.is_empty() {
+            return None;
+        }
+        let (wi, window) = self
+            .windows
+            .iter()
+            .enumerate()
+            .find(|(_, w)| w.path == field && !w.segments.is_empty())?;
+        let seg_idx = window
+            .segments
+            .iter()
+            .position(|s| s.content.start <= pos && pos <= s.content.end)?;
+        let target_gen = forward_pos(self.helper, &window.segments[seg_idx], pos);
+
+        let mut cls = self.classifier();
+        let mut hits = Vec::new();
+        for (page, p) in self.doc.pages().iter().enumerate() {
+            walk_glyphs(&p.frame, page, &mut cls, Some((wi, Some(seg_idx))), &mut hits);
+        }
+
+        // A covering glyph always beats a non-covering one, so a caret near a
+        // run edge still resolves; `min_by_key` keeps the first on ties.
+        let g = hits.iter().min_by_key(|g| {
+            let covers = g.node.start <= target_gen && target_gen < g.node.end;
+            let caret = g.node.start + g.offset as usize;
+            (
+                !covers,
+                caret > target_gen,
+                (caret as isize - target_gen as isize).unsigned_abs(),
+            )
+        })?;
+        let page_h = self.doc.pages().get(g.page)?.frame.size().y.to_pt();
+        Some(
+            RenderedRegion::new(field.to_string(), g.page, pdf_rect(&g.rect, page_h))
+                .with_span([pos, pos]),
+        )
+    }
 }
 
 /// Window-major, segment-ascending: the order regions sort by.
@@ -589,21 +704,17 @@ fn run_scan_machine(keys: &[Key], hits: &[Hit]) -> Vec<Vec<(usize, Aabb)>> {
                     if let Some((c, last_page)) = current.take() {
                         state[c] = Run::Suspended { last_page };
                     }
-                    match state[ki] {
-                        _ if matches!(keys[ki], Key::Marker(_)) => {
-                            accrue(&mut boxes[ki], hit);
-                            current = Some((ki, hit.page));
-                        }
-                        Run::NotSeen => {
-                            accrue(&mut boxes[ki], hit);
-                            current = Some((ki, hit.page));
-                        }
-                        Run::Suspended { last_page } if hit.page == last_page + 1 => {
-                            accrue(&mut boxes[ki], hit);
-                            current = Some((ki, hit.page));
-                        }
-                        Run::Suspended { .. } => state[ki] = Run::Done,
-                        Run::Done => {}
+                    let resumes = match state[ki] {
+                        _ if matches!(keys[ki], Key::Marker(_)) => true,
+                        Run::NotSeen => true,
+                        Run::Suspended { last_page } => hit.page == last_page + 1,
+                        Run::Done => false,
+                    };
+                    if resumes {
+                        accrue(&mut boxes[ki], hit);
+                        current = Some((ki, hit.page));
+                    } else {
+                        state[ki] = Run::Done;
                     }
                 }
             }
@@ -635,47 +746,6 @@ fn accrue(boxes: &mut Vec<(usize, Aabb)>, hit: &Hit) {
         Some((page, b)) if *page == hit.page => b.union(rect),
         _ => boxes.push((hit.page, rect)),
     }
-}
-
-/// The schema field under a point (`x`/`y` in PDF bottom-left points). Unlike
-/// [`scan_content_regions`] every placement answers, not just the first. Among
-/// tracked ink the later-painted item wins; untracked ink never occludes.
-///
-/// Earlier pages are walked for their markers alone, so a `field-region` that
-/// opened on a previous page still claims this page's ink. `unclosed` is
-/// supplied rather than derived here because whether a claim open at `page` ever
-/// closes is knowable only from the pages after it, which this walk never
-/// reaches.
-pub(crate) fn field_at(
-    doc: &PagedDocument,
-    world: &QuillWorld,
-    helper: &Source,
-    windows: &[FieldWindow],
-    unclosed: &[usize],
-    page: usize,
-    x: f32,
-    y: f32,
-) -> Option<String> {
-    let frame = &doc.pages().get(page)?.frame;
-    let page_h = frame.size().y.to_pt();
-    let (x, y) = (x as f64, page_h - y as f64);
-
-    let mut cls = Classifier::new(world, helper, windows);
-    let mut markers = Markers::suppressing(unclosed);
-    let mut hits = Vec::new();
-    for earlier in doc.pages().iter().take(page) {
-        scan_markers(&earlier.frame, &mut markers);
-    }
-    collect_page_hits(frame, page, &mut cls, &mut markers, &mut hits);
-
-    hits.iter()
-        .rev()
-        .find(|h| h.rect.is_some_and(|r| r.contains(x, y)))
-        .and_then(|h| h.class.owner())
-        .map(|owner| match owner {
-            Owner::Window(w) => windows[w].path.clone(),
-            Owner::Claim(c) => markers.claims[c].clone(),
-        })
 }
 
 /// The finer counterpart to [`Hit`], carrying the node range and intra-node
@@ -716,7 +786,7 @@ fn walk_glyphs(
         if only.is_some_and(|t| t != (w, seg)) {
             return;
         }
-        if let Some((_, node)) = cls.resolve_range(span) {
+        if let Some((_, node)) = cls.range_of(span) {
             out.push(GlyphHit {
                 page,
                 rect: aabb(),
@@ -727,40 +797,6 @@ fn walk_glyphs(
             });
         }
     });
-}
-
-/// A point (PDF bottom-left points) → content position in a content field.
-/// Degrades to the segment's content start when the resolved node nests inside
-/// no single run (a multi-line `#raw` block, or structural ink).
-pub(crate) fn position_at(
-    doc: &PagedDocument,
-    world: &QuillWorld,
-    helper: &Source,
-    windows: &[FieldWindow],
-    page: usize,
-    x: f32,
-    y: f32,
-) -> Option<ContentHit> {
-    if windows.is_empty() {
-        return None;
-    }
-    let frame = &doc.pages().get(page)?.frame;
-    let page_h = frame.size().y.to_pt();
-    let (px, py) = (x as f64, page_h - y as f64);
-
-    let mut cls = Classifier::new(world, helper, windows);
-    let mut hits = Vec::new();
-    walk_glyphs(frame, page, &mut cls, None, &mut hits);
-
-    // Later-painted wins; ink with no segment has no content position.
-    let hit = hits
-        .iter()
-        .rev()
-        .find(|g| g.seg.is_some() && g.rect.contains(px, py))?;
-    let window = &windows[hit.window];
-    let segmap = &window.segments[hit.seg?];
-    let (pos, granularity) = invert_hit(helper, segmap, &hit.node, hit.offset);
-    Some(ContentHit::new(window.path.clone(), pos).with_granularity(granularity))
 }
 
 /// The content USV offset a glyph's generated position maps to. With no owning
@@ -788,55 +824,6 @@ fn invert_hit(
     let gen_text = &helper.text()[gen_r.clone()];
     let pos = content_r.start + crate::emit::invert_gen_offset(gen_text, *ctx, abs - gen_r.start);
     (pos, HitGranularity::Cluster)
-}
-
-/// A content position → caret rect: the box of the frame glyph whose resolved
-/// node covers `pos`, with `span` collapsed to `[pos, pos]`.
-pub(crate) fn locate(
-    doc: &PagedDocument,
-    world: &QuillWorld,
-    helper: &Source,
-    windows: &[FieldWindow],
-    field: &str,
-    pos: usize,
-) -> Option<RenderedRegion> {
-    if windows.is_empty() {
-        return None;
-    }
-    let (wi, window) = windows
-        .iter()
-        .enumerate()
-        .find(|(_, w)| w.path == field && !w.segments.is_empty())?;
-    let seg_idx = window
-        .segments
-        .iter()
-        .position(|s| s.content.start <= pos && pos <= s.content.end)?;
-    let target_gen = forward_pos(helper, &window.segments[seg_idx], pos);
-
-    let mut cls = Classifier::new(world, helper, windows);
-    let mut hits = Vec::new();
-    for (page, p) in doc.pages().iter().enumerate() {
-        walk_glyphs(&p.frame, page, &mut cls, Some((wi, Some(seg_idx))), &mut hits);
-    }
-
-    // A covering glyph always beats a non-covering one, so a caret near a run
-    // edge still resolves; `min_by_key` keeps the first on ties.
-    let g = hits
-        .iter()
-        .min_by_key(|g| {
-            let covers = g.node.start <= target_gen && target_gen < g.node.end;
-            let caret = g.node.start + g.offset as usize;
-            (
-                !covers,
-                caret > target_gen,
-                (caret as isize - target_gen as isize).unsigned_abs(),
-            )
-        })?;
-    let page_h = doc.pages().get(g.page)?.frame.size().y.to_pt();
-    Some(
-        RenderedRegion::new(field.to_string(), g.page, pdf_rect(&g.rect, page_h))
-            .with_span([pos, pos]),
-    )
 }
 
 /// A position in a structural gap (or at the segment edge) falls back to the
@@ -1423,7 +1410,14 @@ main:
             let helper = world
                 .source(QuillWorld::helper_fid("lib.typ"))
                 .expect("helper source");
-            let regions = scan_content_regions(&doc, &world, &helper, &windows, &[]);
+            let regions = Scan {
+                doc: &doc,
+                world: &world,
+                helper: &helper,
+                windows: &windows,
+                unclosed: &[],
+            }
+            .regions();
             regions
                 .iter()
                 .filter(|r| r.field == "body")
@@ -1946,27 +1940,20 @@ main:
             unclosed_claims(&self.doc).into_iter().map(|(c, _)| c).collect()
         }
 
-        fn regions(&self, unclosed: &[usize]) -> Vec<RenderedRegion> {
-            scan_content_regions(&self.doc, &self.world, &self.helper, &self.windows, unclosed)
-        }
-
-        fn field_at(&self, unclosed: &[usize], page: usize, x: f32, y: f32) -> Option<String> {
-            field_at(
-                &self.doc,
-                &self.world,
-                &self.helper,
-                &self.windows,
+        fn scan<'a>(&'a self, unclosed: &'a [usize]) -> Scan<'a> {
+            Scan {
+                doc: &self.doc,
+                world: &self.world,
+                helper: &self.helper,
+                windows: &self.windows,
                 unclosed,
-                page,
-                x,
-                y,
-            )
+            }
         }
     }
 
     fn probe_regions(plate: &str, data: serde_json::Value) -> Vec<RenderedRegion> {
         let p = probe(plate, data);
-        p.regions(&p.unclosed())
+        p.scan(&p.unclosed()).regions()
     }
 
     fn body(markdown: &str) -> serde_json::Value {
@@ -2133,7 +2120,8 @@ Interleaved plate chrome.
 
         let last = p.doc.pages().len() - 1;
         let runaway = p
-            .regions(&[])
+            .scan(&[])
+            .regions()
             .into_iter()
             .find(|r| r.field == "classification" && r.page == last)
             .expect("unsuppressed, the claim reaches the last page");
@@ -2142,12 +2130,12 @@ Interleaved plate chrome.
             (runaway.rect[1] + runaway.rect[3]) / 2.0,
         );
         assert_eq!(
-            p.field_at(&[], last, cx, cy),
+            p.scan(&[]).field_at(last, cx, cy),
             Some("classification".to_string()),
             "sanity: unsuppressed, that ink routes to the stranded claim"
         );
         assert_eq!(
-            p.field_at(&p.unclosed(), last, cx, cy),
+            p.scan(&p.unclosed()).field_at(last, cx, cy),
             None,
             "suppressed, page chrome under a runaway claim answers to no field"
         );

--- a/crates/content/Cargo.toml
+++ b/crates/content/Cargo.toml
@@ -8,9 +8,8 @@ homepage.workspace = true
 repository = "https://github.com/borb-sh/quillmark"
 description = "Content model (splice-shaped USV text with line attributes, marks, and islands), canonical serialization, edit deltas, and richtext/plaintext codecs for Quillmark"
 # The leaf content-model crate: `quillmark-core` depends on it for the storage
-# body type and the markdown-string normalizer, so it carries no dependency on
-# the document engine. Published because `quillmark-core` (published) depends on
-# it.
+# body type, so it carries no dependency on the document engine. Published
+# because `quillmark-core` (published) depends on it.
 publish = true
 
 [dependencies]

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -26,7 +26,7 @@
 //! adversarial delimiter/break placement.
 
 use crate::island::KnownIslandType;
-use crate::model::{Container, Island, LineKind, MarkKind, Content, ISLAND_SLOT};
+use crate::model::{Container, Island, LineKind, Mark, MarkKind, Content, ISLAND_SLOT};
 
 /// Render a content to markdown. An island projects by **type**: a type this
 /// build knows emits its markdown, any other a placeholder comment.
@@ -449,24 +449,7 @@ fn render_inline(ctx: &Ctx, i: usize, escape_leading_block: bool) -> String {
     let chars: Vec<char> = text.chars().collect();
     let n = chars.len();
 
-    let mut code_ranges: Vec<(usize, usize)> = Vec::new();
-    let mut fmt: Vec<(usize, usize, &MarkKind)> = Vec::new();
-    let mut links: Vec<(usize, usize, &str)> = Vec::new();
-    for m in &ctx.rt.marks {
-        let s = m.start.saturating_sub(line_start);
-        let e = m.end.saturating_sub(line_start);
-        if m.end <= line_start || m.start >= line_start + n {
-            continue; // outside this line
-        }
-        let s = s.min(n);
-        let e = e.min(n);
-        match &m.kind {
-            MarkKind::Anchor { .. } => {} // omitted from the projection
-            MarkKind::Code => code_ranges.push((s, e)),
-            MarkKind::Link { url } => links.push((s, e, url)),
-            _ => fmt.push((s, e, &m.kind)),
-        }
-    }
+    let (code_ranges, fmt, links) = bucket_marks(&ctx.rt.marks, line_start, n, false);
 
     // Leading ordered-list marker: a line whose text starts `<digits>.` or
     // `<digits>)` would re-import as an ordered list, so escape that punctuation.
@@ -503,6 +486,43 @@ fn render_inline(ctx: &Ctx, i: usize, escape_leading_block: bool) -> String {
             })
         },
     )
+}
+
+/// Route `marks` into the three lists [`render_marked_core`] takes, each range
+/// clipped to the `n` chars starting at `line_start` and rebased to local
+/// offsets. Anchors are dropped: the projection has no syntax for them.
+/// `drop_empty` also drops a range the clip left empty, which a cell wants and
+/// a prose line does not.
+fn bucket_marks(
+    marks: &[Mark],
+    line_start: usize,
+    n: usize,
+    drop_empty: bool,
+) -> (
+    Vec<(usize, usize)>,
+    Vec<(usize, usize, &MarkKind)>,
+    Vec<(usize, usize, &str)>,
+) {
+    let mut code_ranges: Vec<(usize, usize)> = Vec::new();
+    let mut fmt: Vec<(usize, usize, &MarkKind)> = Vec::new();
+    let mut links: Vec<(usize, usize, &str)> = Vec::new();
+    for m in marks {
+        if m.end <= line_start || m.start >= line_start + n {
+            continue;
+        }
+        let s = m.start.saturating_sub(line_start).min(n);
+        let e = m.end.saturating_sub(line_start).min(n);
+        if drop_empty && s >= e {
+            continue;
+        }
+        match &m.kind {
+            MarkKind::Anchor { .. } => {}
+            MarkKind::Code => code_ranges.push((s, e)),
+            MarkKind::Link { url } => links.push((s, e, url.as_str())),
+            _ => fmt.push((s, e, &m.kind)),
+        }
+    }
+    (code_ranges, fmt, links)
 }
 
 /// Render marks over a standalone char slice to markdown: the projection's mark
@@ -583,13 +603,13 @@ fn render_marked_core(
                 let mut reopen: Vec<usize> = Vec::new();
                 while stack.len() > idx {
                     let fi = stack.pop().unwrap();
-                    out.push_str(&delim_close(fmt[fi].2));
+                    out.push_str(delim_close(fmt[fi].2));
                     if fmt[fi].1 != pos {
                         reopen.push(fi);
                     }
                 }
                 for fi in reopen.into_iter().rev() {
-                    out.push_str(&delim_open(fmt[fi].2));
+                    out.push_str(delim_open(fmt[fi].2));
                     stack.push(fi);
                 }
             }
@@ -607,7 +627,7 @@ fn render_marked_core(
                 if !keep[fi] {
                     continue;
                 }
-                out.push_str(&delim_open(fmt[fi].2));
+                out.push_str(delim_open(fmt[fi].2));
                 stack.push(fi);
             }
             // A link is emitted atomically as [text](url). Nested marks in link
@@ -666,7 +686,7 @@ fn render_marked_core(
         // Clipping keeps every wrap `end` reachable, so this normally drains
         // nothing.
         while let Some(fi) = stack.pop() {
-            out.push_str(&delim_close(fmt[fi].2));
+            out.push_str(delim_close(fmt[fi].2));
         }
         out
     };
@@ -676,24 +696,26 @@ fn render_marked_core(
     // pulldown re-reads as literal text, leaking a delimiter into the content.
     // Re-parse the rendered line and, if its plain text drifted, search for a set
     // of flanking marks that keeps the text intact.
-    //
+    let is_flanking = |k: &MarkKind| {
+        matches!(k, MarkKind::Strong | MarkKind::Emph | MarkKind::Strike)
+    };
+    let out = sweep(&vec![true; fmt.len()]);
+    if !fmt.iter().any(|m| is_flanking(m.2)) {
+        return out;
+    }
     // The probe wraps the fragment in `,…,`: parsed standalone, a leading `0. ` /
     // `# ` / `> ` would read as a list/heading/quote marker and drop a good mark.
     // A punctuation sentinel blocks every leading-block construct, preserves edge
     // whitespace, and is flanking-equivalent to the line start/end it replaces,
     // so it never masks or invents a leak.
     let expected: String = chars.iter().collect();
-    let is_flanking = |k: &MarkKind| {
-        matches!(k, MarkKind::Strong | MarkKind::Emph | MarkKind::Strike)
-    };
     let want = format!(",{expected},");
     let text_safe = |md: &str| {
         crate::import::from_markdown(&format!(",{md},"))
             .map(|rt| rt.text == want)
             .unwrap_or(false)
     };
-    let out = sweep(&vec![true; fmt.len()]);
-    if !fmt.iter().any(|m| is_flanking(m.2)) || text_safe(&out) {
+    if text_safe(&out) {
         return out;
     }
     // The flanking marks in document order. That order is the re-add priority
@@ -857,26 +879,7 @@ fn clip_asterisk_overlap(fmt: &mut [(usize, usize, &MarkKind)]) {
 fn render_cell_md(v: &serde_json::Value) -> String {
     let (text, marks) = crate::serial::parse_cell(v);
     let chars: Vec<char> = text.chars().collect();
-    let n = chars.len();
-    let mut code_ranges: Vec<(usize, usize)> = Vec::new();
-    let mut fmt: Vec<(usize, usize, &MarkKind)> = Vec::new();
-    let mut links: Vec<(usize, usize, &str)> = Vec::new();
-    for m in &marks {
-        if m.start >= n {
-            continue;
-        }
-        let s = m.start;
-        let e = m.end.min(n);
-        if s >= e {
-            continue;
-        }
-        match &m.kind {
-            MarkKind::Anchor { .. } => {}
-            MarkKind::Code => code_ranges.push((s, e)),
-            MarkKind::Link { url } => links.push((s, e, url)),
-            _ => fmt.push((s, e, &m.kind)),
-        }
-    }
+    let (code_ranges, fmt, links) = bucket_marks(&marks, 0, chars.len(), true);
     render_marked_core(
         &chars,
         &code_ranges,
@@ -889,26 +892,26 @@ fn render_cell_md(v: &serde_json::Value) -> String {
     )
 }
 
-fn delim_open(kind: &MarkKind) -> String {
+fn delim_open(kind: &MarkKind) -> &'static str {
     match kind {
-        MarkKind::Strong => "**".into(),
+        MarkKind::Strong => "**",
         // `*`, not `_`: `_` cannot do intraword emphasis (CommonMark flanking),
         // so `_a_你` re-imports as literal text; `*a*你` emphasizes correctly.
-        MarkKind::Emph => "*".into(),
-        MarkKind::Underline => "<u>".into(),
-        MarkKind::Strike => "~~".into(),
+        MarkKind::Emph => "*",
+        MarkKind::Underline => "<u>",
+        MarkKind::Strike => "~~",
         // Code/Link/Anchor are handled elsewhere.
-        _ => String::new(),
+        _ => "",
     }
 }
 
-fn delim_close(kind: &MarkKind) -> String {
+fn delim_close(kind: &MarkKind) -> &'static str {
     match kind {
-        MarkKind::Strong => "**".into(),
-        MarkKind::Emph => "*".into(),
-        MarkKind::Underline => "</u>".into(),
-        MarkKind::Strike => "~~".into(),
-        _ => String::new(),
+        MarkKind::Strong => "**",
+        MarkKind::Emph => "*",
+        MarkKind::Underline => "</u>",
+        MarkKind::Strike => "~~",
+        _ => "",
     }
 }
 

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -103,11 +103,7 @@ pub fn from_plaintext(s: &str) -> Content {
         .map(|seg| {
             let continues = prev_nonempty && !seg.is_empty();
             prev_nonempty = !seg.is_empty();
-            Line {
-                kind: LineKind::Para,
-                containers: Vec::new(),
-                continues,
-            }
+            Line::new(LineKind::Para).with_continues(continues)
         })
         .collect();
     Content {
@@ -628,33 +624,23 @@ impl Builder {
 
     // ---- table ----
 
-    /// The open table cell's inline accumulator, if one is open.
-    fn cell_mut(&mut self) -> Option<&mut Inline> {
-        self.table.as_mut()?.cell.as_mut()
-    }
-
     /// Route one table event: structural events shape the accumulator, inline
     /// events build the open cell with the same [`Inline`] machinery prose uses.
     /// A cell is flat inline, so its marks are USV offsets into its own text.
     fn table_event(&mut self, event: &Event, underline: bool) {
+        let Some(acc) = self.table.as_mut() else {
+            return;
+        };
         // An image open inside the current cell intercepts everything until it
         // closes: the alt lands as plain text, the url is dropped, and the
         // island is flagged degraded, a cell having no slot to carry an image.
-        if self.table.as_ref().is_some_and(|a| a.img_depth > 0) {
+        if acc.img_depth > 0 {
             match event {
-                Event::Start(Tag::Image { .. }) => {
-                    if let Some(a) = self.table.as_mut() {
-                        a.img_depth += 1;
-                    }
-                }
-                Event::End(TagEnd::Image) => {
-                    if let Some(a) = self.table.as_mut() {
-                        a.img_depth -= 1;
-                    }
-                }
+                Event::Start(Tag::Image { .. }) => acc.img_depth += 1,
+                Event::End(TagEnd::Image) => acc.img_depth -= 1,
                 other => {
                     if let Some(s) = image_alt_text(other) {
-                        if let Some(c) = self.cell_mut() {
+                        if let Some(c) = acc.cell.as_mut() {
                             c.push_text(s);
                         }
                     }
@@ -664,96 +650,76 @@ impl Builder {
         }
         match event {
             Event::Start(Tag::Image { .. }) => {
-                if let Some(a) = self.table.as_mut() {
-                    a.img_depth += 1;
-                    a.degraded = true;
-                }
+                acc.img_depth += 1;
+                acc.degraded = true;
             }
-            Event::Start(Tag::TableHead) => {
-                if let Some(a) = self.table.as_mut() {
-                    a.in_head = true;
-                }
-            }
+            Event::Start(Tag::TableHead) => acc.in_head = true,
             Event::End(TagEnd::TableHead) => {
-                if let Some(a) = self.table.as_mut() {
-                    a.header = std::mem::take(&mut a.cur_row);
-                    a.in_head = false;
-                }
+                acc.header = std::mem::take(&mut acc.cur_row);
+                acc.in_head = false;
             }
-            Event::Start(Tag::TableRow) => {
-                if let Some(a) = self.table.as_mut() {
-                    a.cur_row.clear();
-                }
-            }
+            Event::Start(Tag::TableRow) => acc.cur_row.clear(),
             Event::End(TagEnd::TableRow) => {
-                if let Some(a) = self.table.as_mut() {
-                    if !a.in_head {
-                        let row = std::mem::take(&mut a.cur_row);
-                        a.rows.push(row);
-                    }
+                if !acc.in_head {
+                    let row = std::mem::take(&mut acc.cur_row);
+                    acc.rows.push(row);
                 }
             }
-            Event::Start(Tag::TableCell) => {
-                if let Some(a) = self.table.as_mut() {
-                    a.cell = Some(Inline::default());
-                }
-            }
+            Event::Start(Tag::TableCell) => acc.cell = Some(Inline::default()),
             Event::End(TagEnd::TableCell) => {
-                if let Some(a) = self.table.as_mut() {
-                    if let Some(mut cell) = a.cell.take() {
-                        // Close any marks pulldown left open (malformed input).
-                        while !cell.open.is_empty() {
-                            cell.close_mark();
-                        }
-                        a.cur_row
-                            .push(crate::serial::cell_to_value(&cell.text, &cell.marks));
+                if let Some(mut cell) = acc.cell.take() {
+                    // Close any marks pulldown left open (malformed input).
+                    while !cell.open.is_empty() {
+                        cell.close_mark();
                     }
+                    acc.cur_row
+                        .push(crate::serial::cell_to_value(&cell.text, &cell.marks));
                 }
             }
             // Inline content of the open cell. A soft/hard break in a
             // single-line cell is a space.
             Event::Text(t) => {
-                if let Some(c) = self.cell_mut() {
+                if let Some(c) = acc.cell.as_mut() {
                     c.push_text(t);
                 }
             }
             Event::Code(t) => {
-                if let Some(c) = self.cell_mut() {
+                if let Some(c) = acc.cell.as_mut() {
                     c.push_code(t);
                 }
             }
             Event::SoftBreak | Event::HardBreak => {
-                if let Some(c) = self.cell_mut() {
+                if let Some(c) = acc.cell.as_mut() {
                     c.push_text(" ");
                 }
             }
             Event::Start(Tag::Emphasis) => {
-                if let Some(c) = self.cell_mut() {
+                if let Some(c) = acc.cell.as_mut() {
                     c.open_mark(MarkKind::Emph);
                 }
             }
             Event::Start(Tag::Strong) => {
-                let kind = strong_kind(underline);
-                if let Some(c) = self.cell_mut() {
-                    c.open_mark(kind);
+                if let Some(c) = acc.cell.as_mut() {
+                    c.open_mark(strong_kind(underline));
                 }
             }
             Event::Start(Tag::Strikethrough) => {
-                if let Some(c) = self.cell_mut() {
+                if let Some(c) = acc.cell.as_mut() {
                     c.open_mark(MarkKind::Strike);
                 }
             }
             Event::Start(Tag::Link { dest_url, .. }) => {
-                let url = dest_url.to_string();
-                if let Some(c) = self.cell_mut() {
-                    c.open_mark(MarkKind::Link { url });
+                if let Some(c) = acc.cell.as_mut() {
+                    c.open_mark(MarkKind::Link {
+                        url: dest_url.to_string(),
+                    });
                 }
             }
             Event::End(TagEnd::Emphasis)
             | Event::End(TagEnd::Strong)
             | Event::End(TagEnd::Strikethrough)
             | Event::End(TagEnd::Link) => {
-                if let Some(c) = self.cell_mut() {
+                if let Some(c) = acc.cell.as_mut() {
                     c.close_mark();
                 }
             }
@@ -794,11 +760,7 @@ impl Builder {
             self.lines.push(last);
         }
         if self.lines.is_empty() {
-            self.lines.push(Line {
-                kind: LineKind::Para,
-                containers: Vec::new(),
-                continues: false,
-            });
+            self.lines.push(Line::new(LineKind::Para));
         }
         // Close any marks left open (unterminated `<u>`, malformed input).
         while !self.inline.open.is_empty() {
@@ -825,8 +787,9 @@ fn heading_level(level: pulldown_cmark::HeadingLevel) -> u8 {
     }
 }
 
-/// Sanitize a code-block info string to a language identifier, matching the
-/// typst backend's `sanitize_lang_tag`.
+/// A code-block info string reduced to a language identifier: its leading run of
+/// ASCII alphanumerics and `-`/`_`/`.`/`+`. Every stored `lang` has this shape,
+/// so an emitter writes it into its own syntax unquoted and unescaped.
 fn sanitize_lang(lang: &str) -> String {
     lang.chars()
         .take_while(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '+'))

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -408,6 +408,9 @@ impl MarkKind {
 /// A `serde_json::Value` rendered to a string with object keys recursively
 /// sorted: order-insensitive, so it is a stable comparison/grouping key.
 fn canonical_json_string(v: &JsonValue) -> String {
+    if is_value_key_sorted(v) {
+        return serde_json::to_string(v).unwrap_or_default();
+    }
     serde_json::to_string(&sort_keys_owned(v.clone())).unwrap_or_default()
 }
 
@@ -428,10 +431,13 @@ pub(crate) fn is_value_key_sorted(v: &JsonValue) -> bool {
 /// `true` when `v` nests deeper than `max` container levels: the guard that
 /// keeps the recursive walkers here and `Value`'s own `Drop` inside a bounded
 /// frame count. The walk is iterative, so the check itself cannot overflow on
-/// the adversarially deep input it exists to detect. The unit is **container
-/// levels**, not nodes, matching [`quillmark_core::json_depth_exceeds`], so the
-/// two boundaries reject the identical shape.
-pub(crate) fn json_depth_exceeds(v: &JsonValue, max: usize) -> bool {
+/// the adversarially deep input it exists to detect.
+///
+/// The unit is **container levels**, not nodes: only arrays/objects are charged
+/// a level and a scalar leaf is never checked, so an empty container at level
+/// `max + 1` is rejected exactly like a full one. `quillmark_core` re-exports
+/// this as its own depth guard, so every boundary rejects the identical shape.
+pub fn json_depth_exceeds(v: &JsonValue, max: usize) -> bool {
     // (value, depth) pairs; depth counts container levels entered.
     let mut stack: Vec<(&JsonValue, usize)> = vec![(v, 0)];
     while let Some((v, depth)) = stack.pop() {
@@ -774,6 +780,8 @@ impl Content {
     /// guarantees this; a hand-built content should be run through it in tests.
     pub fn validate(&self) -> Result<(), Invariant> {
         let mut slots = 0usize;
+        let mut newlines = 0usize;
+        let mut len: Usv = 0;
         for c in self.text.chars() {
             if c == '\r' {
                 return Err(Invariant::CarriageReturn);
@@ -784,6 +792,10 @@ impl Content {
             if c == ISLAND_SLOT {
                 slots += 1;
             }
+            if c == '\n' {
+                newlines += 1;
+            }
+            len += 1;
         }
         if slots != self.islands.len() {
             return Err(Invariant::IslandSlotMismatch {
@@ -791,7 +803,7 @@ impl Content {
                 islands: self.islands.len(),
             });
         }
-        let segments = self.segment_count();
+        let segments = newlines + 1;
         if self.lines.len() != segments {
             return Err(Invariant::LineCountMismatch {
                 lines: self.lines.len(),
@@ -801,8 +813,12 @@ impl Content {
         if self.lines.first().is_some_and(|l| l.continues) {
             return Err(Invariant::FirstLineContinues);
         }
-        let len = self.len_usv();
-        let chars: Vec<char> = self.text.chars().collect();
+        // Only the formatting-mark edge test below reads it.
+        let chars: Vec<char> = if self.marks.iter().any(|m| m.kind.is_formatting()) {
+            self.text.chars().collect()
+        } else {
+            Vec::new()
+        };
         // Anchor-id uniqueness is what `RemoveAnchor` presumes.
         let mut seen_anchor_ids = std::collections::HashSet::new();
         for m in &self.marks {

--- a/crates/content/src/normalize.rs
+++ b/crates/content/src/normalize.rs
@@ -22,7 +22,7 @@ pub(crate) fn is_bidi_char(c: char) -> bool {
 
 /// Removes the Unicode bidi formatting controls, which sit adjacent to `**`/`_`
 /// and defeat delimiter recognition.
-pub fn strip_bidi_formatting(s: &str) -> String {
+fn strip_bidi_formatting(s: &str) -> String {
     if !s.chars().any(is_bidi_char) {
         return s.to_string();
     }
@@ -35,7 +35,7 @@ pub fn strip_bidi_formatting(s: &str) -> String {
 /// CommonMark HTML block type 2 ends with the line containing `-->`, so text on
 /// that line after `-->` would be swallowed. Bare `-->` outside a comment is
 /// left untouched.
-pub fn fix_html_comment_fences(s: &str) -> String {
+fn fix_html_comment_fences(s: &str) -> String {
     if !s.contains("-->") {
         return s.to_string();
     }

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -163,8 +163,8 @@ impl ChangeBundle {
 // dialect.
 
 use crate::serial::{
-    container_from_authored_value, container_to_value, island_from_value, island_to_value,
-    line_kind_from_authored_value, line_kind_to_value, mark_from_authored_value, mark_to_value,
+    container_from_authored_value, container_to_value, island_fields, island_from_value,
+    line_kind_fields, line_kind_from_authored_value, mark_fields, mark_from_authored_value,
     usv_from, ParseError,
 };
 use serde_json::{Map, Value};
@@ -176,11 +176,11 @@ pub fn mark_op_to_value(op: &MarkOp) -> Value {
     match op {
         MarkOp::Add { start, end, kind } => {
             m.insert("op".into(), "add".into());
-            merge_mark(&mut m, *start, *end, kind);
+            m.extend(mark_fields(*start, *end, kind));
         }
         MarkOp::Remove { start, end, kind } => {
             m.insert("op".into(), "remove".into());
-            merge_mark(&mut m, *start, *end, kind);
+            m.extend(mark_fields(*start, *end, kind));
         }
         MarkOp::RemoveAnchor { id } => {
             m.insert("op".into(), "removeAnchor".into());
@@ -188,17 +188,6 @@ pub fn mark_op_to_value(op: &MarkOp) -> Value {
         }
     }
     Value::Object(m)
-}
-
-fn merge_mark(m: &mut Map<String, Value>, start: Usv, end: Usv, kind: &MarkKind) {
-    let mark = Mark {
-        start,
-        end,
-        kind: kind.clone(),
-    };
-    if let Value::Object(fields) = mark_to_value(&mark) {
-        m.extend(fields);
-    }
 }
 
 /// Decode a [`MarkOp`] from its wire object. `add`/`remove` read the mark
@@ -250,9 +239,7 @@ pub fn line_op_to_value(op: &LineOp) -> Value {
         LineOp::SetKind { line, kind } => {
             m.insert("op".into(), "setKind".into());
             m.insert("line".into(), Value::from(*line));
-            if let Value::Object(fields) = line_kind_to_value(kind) {
-                m.extend(fields);
-            }
+            m.extend(line_kind_fields(kind));
         }
         LineOp::SetContainers { line, containers } => {
             m.insert("op".into(), "setContainers".into());
@@ -317,9 +304,7 @@ pub fn island_op_to_value(op: &IslandOp) -> Value {
     if let Some(at) = at {
         m.insert("at".into(), Value::from(at));
     }
-    if let Value::Object(fields) = island_to_value(island) {
-        m.extend(fields);
-    }
+    m.extend(island_fields(island));
     Value::Object(m)
 }
 
@@ -489,7 +474,6 @@ impl Content {
         let delta = sanitized.as_ref();
 
         let old_chars: Vec<char> = self.text.chars().collect();
-        let old_lines = self.lines.clone();
         // `try_apply` retains the untouched remainder implicitly, so a splice
         // may name only the region it changes.
         let new_text = delta
@@ -498,6 +482,7 @@ impl Content {
                 expected: e.expected,
                 actual: e.actual,
             })?;
+        let old_lines = std::mem::take(&mut self.lines);
 
         self.rebase_marks(delta);
         let new_len = new_text.chars().count();
@@ -805,7 +790,7 @@ impl Content {
             .lines
             .get(line_idx)
             .cloned()
-            .unwrap_or_else(default_para_line);
+            .unwrap_or_else(|| Line::new(LineKind::Para));
         let mut new_line = template;
         new_line.continues = false;
         self.lines.insert(line_idx + 1, new_line);
@@ -843,14 +828,6 @@ impl Content {
             });
         }
         Ok(())
-    }
-}
-
-fn default_para_line() -> Line {
-    Line {
-        kind: LineKind::Para,
-        containers: Vec::new(),
-        continues: false,
     }
 }
 
@@ -933,7 +910,7 @@ fn sync_lines_for_delta(old_chars: &[char], old_lines: Vec<Line>, delta: &Delta)
                                 out.push(line);
                                 clone
                             }
-                            None => default_para_line(),
+                            None => Line::new(LineKind::Para),
                         };
                         new_line.continues = false;
                         cur = Some(new_line);

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -212,10 +212,16 @@ fn fold_legacy_attrs<'a>(
     Ok(Cow::Owned(folded))
 }
 
-/// Encode a [`LineKind`] into its canonical `kind` fields (`"para"`,
-/// `{"kind":"heading","level":n}`, …). Public so the op wire ([`crate::ops`])
-/// reuses the exact discriminant a `ContentLine` carries.
+/// Encode a [`LineKind`] into its canonical `kind` object (`{"kind":"para"}`,
+/// `{"kind":"heading","level":n}`, …).
 pub fn line_kind_to_value(kind: &LineKind) -> Value {
+    Value::Object(line_kind_fields(kind))
+}
+
+/// The same fields unwrapped, for the op wire ([`crate::ops`]), which flattens
+/// them beside its own keys and so carries the exact discriminant a
+/// `ContentLine` does.
+pub(crate) fn line_kind_fields(kind: &LineKind) -> Map<String, Value> {
     let mut m = Map::new();
     match kind {
         LineKind::Para => {
@@ -244,7 +250,7 @@ pub fn line_kind_to_value(kind: &LineKind) -> Value {
             m.insert("attrs".into(), attrs.clone());
         }
     }
-    Value::Object(m)
+    m
 }
 
 /// Decode a [`LineKind`] from an object carrying the canonical `kind` fields.
@@ -284,9 +290,7 @@ pub fn line_kind_from_value(v: &Value) -> Result<LineKind, ParseError> {
 }
 
 fn line_to_value(line: &Line) -> Value {
-    let Value::Object(mut m) = line_kind_to_value(&line.kind) else {
-        unreachable!("line_kind_to_value always returns an object")
-    };
+    let mut m = line_kind_fields(&line.kind);
     m.insert(
         "containers".into(),
         Value::Array(line.containers.iter().map(container_to_value).collect()),
@@ -368,13 +372,18 @@ pub fn container_from_value(v: &Value) -> Result<Container, ParseError> {
 }
 
 /// Encode a [`Mark`] (`{start, end, type, …}`) into its canonical wire object.
-/// Public so the op wire ([`crate::ops`]) reuses the exact `type` discriminant a
-/// `ContentMark` carries.
 pub fn mark_to_value(mark: &Mark) -> Value {
+    Value::Object(mark_fields(mark.start, mark.end, &mark.kind))
+}
+
+/// The same fields unwrapped and over a mark's parts, for the op wire
+/// ([`crate::ops`]), which flattens them beside its own keys, carries the exact
+/// `type` discriminant a `ContentMark` does, and holds no [`Mark`].
+pub(crate) fn mark_fields(start: Usv, end: Usv, kind: &MarkKind) -> Map<String, Value> {
     let mut m = Map::new();
-    m.insert("start".into(), Value::from(mark.start));
-    m.insert("end".into(), Value::from(mark.end));
-    match &mark.kind {
+    m.insert("start".into(), Value::from(start));
+    m.insert("end".into(), Value::from(end));
+    match kind {
         MarkKind::Strong => {
             m.insert("type".into(), "strong".into());
         }
@@ -403,7 +412,7 @@ pub fn mark_to_value(mark: &Mark) -> Value {
             m.insert("attrs".into(), attrs.clone());
         }
     }
-    Value::Object(m)
+    m
 }
 
 /// What every mark carries whatever its type.
@@ -803,7 +812,8 @@ pub(crate) fn table_shape_error(props: &Value) -> Option<Invariant> {
             }
         }
     }
-    for (i, (text, _)) in table_cells(props).iter().enumerate() {
+    for (i, cell) in table_cell_values(props).enumerate() {
+        let text = cell.get("text").and_then(Value::as_str).unwrap_or_default();
         if text.contains('\n') || text.contains('\r') {
             return Some(Invariant::TableCellNewline { cell: i });
         }
@@ -812,12 +822,18 @@ pub(crate) fn table_shape_error(props: &Value) -> Option<Invariant> {
 }
 
 pub(crate) fn island_to_value(island: &Island) -> Value {
+    Value::Object(island_fields(island))
+}
+
+/// The same fields unwrapped, for the op wire ([`crate::ops`]), which flattens
+/// them beside its own keys.
+pub(crate) fn island_fields(island: &Island) -> Map<String, Value> {
     let mut m = Map::new();
     m.insert("id".into(), Value::String(island.id.clone()));
     m.insert("type".into(), Value::String(island.island_type.clone()));
     m.insert("props".into(), island.props.clone());
     m.insert("loss".into(), island.loss.as_str().into());
-    Value::Object(m)
+    m
 }
 
 pub(crate) fn island_from_value(v: &Value) -> Result<Island, ParseError> {

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -5,8 +5,6 @@
 //! one source-ordered list, so a comment attaches to whichever item precedes it
 //! regardless of which side of the `$` boundary that is.
 
-use std::collections::HashMap;
-
 use crate::error::ParseError;
 use crate::value::QuillValue;
 use crate::Diagnostic;
@@ -57,6 +55,16 @@ fn strip_blank_separator(body: &str) -> &str {
         rest
     } else {
         body
+    }
+}
+
+/// The prose body following `blocks[idx]`: up to the next block's opener, or to
+/// EOF when it is the last one.
+fn body_after(markdown: &str, blocks: &[MetadataBlock], idx: usize) -> String {
+    let start = blocks[idx].end;
+    match blocks.get(idx + 1) {
+        Some(next) => strip_blank_separator(&markdown[start..next.start]).to_string(),
+        None => markdown[start..].to_string(),
     }
 }
 
@@ -197,7 +205,7 @@ pub(super) fn decompose_with_warnings(
     }
 
     // The first block is the document root; the rest are composable cards.
-    let (blocks, warnings) = find_metadata_blocks(markdown)?;
+    let (mut blocks, warnings) = find_metadata_blocks(markdown)?;
 
     if blocks.is_empty() {
         return Err(crate::error::ParseError::MissingQuill(
@@ -239,33 +247,23 @@ pub(super) fn decompose_with_warnings(
     // `set_kind` inserts at the canonical position, so canonical input
     // round-trips byte-equal and non-canonical input converges on first emit
     // (markdown-spec.md §9).
+    let root_block = &mut blocks[0];
     let mut main_payload = build_payload(
-        &root_block.meta_items,
-        &root_block.pre_items,
-        &root_block.pre_nested_comments,
-        &root_block.pre_nested_fills,
-        &root_block.yaml_value,
+        std::mem::take(&mut root_block.meta_items),
+        std::mem::take(&mut root_block.pre_items),
+        std::mem::take(&mut root_block.pre_nested_comments),
+        std::mem::take(&mut root_block.pre_nested_fills),
+        root_block.yaml_value.take(),
     )?;
     if main_payload.kind().is_none() {
         main_payload.set_kind("main");
     }
     let mut warnings = warnings;
-    for w in &root_block.pre_warnings {
+    for w in &blocks[0].pre_warnings {
         warnings.push(w.clone());
     }
 
-    // Global body: root block end to first card block start, or EOF.
-    let body_start = blocks[0].end;
-    let (body_end, body_is_followed_by_fence) = match blocks.get(1) {
-        Some(b) => (b.start, true),
-        None => (markdown.len(), false),
-    };
-    let global_body_raw = &markdown[body_start..body_end];
-    let global_body = if body_is_followed_by_fence {
-        strip_blank_separator(global_body_raw).to_string()
-    } else {
-        global_body_raw.to_string()
-    };
+    let global_body = body_after(markdown, &blocks, 0);
 
     let main = Card::from_parts(main_payload, import_body_or_parse_error(&global_body)?);
 
@@ -312,12 +310,13 @@ pub(super) fn decompose_with_warnings(
             ));
         }
 
+        let block = &mut blocks[idx];
         let card_payload = build_payload(
-            &block.meta_items,
-            &block.pre_items,
-            &block.pre_nested_comments,
-            &block.pre_nested_fills,
-            &block.yaml_value,
+            std::mem::take(&mut block.meta_items),
+            std::mem::take(&mut block.pre_items),
+            std::mem::take(&mut block.pre_nested_comments),
+            std::mem::take(&mut block.pre_nested_fills),
+            block.yaml_value.take(),
         )
         .map_err(|e| match e {
             ParseError::InvalidStructure(msg) => {
@@ -325,23 +324,11 @@ pub(super) fn decompose_with_warnings(
             }
             other => other,
         })?;
-        for w in &block.pre_warnings {
+        for w in &blocks[idx].pre_warnings {
             warnings.push(w.clone());
         }
 
-        let card_body_start = block.end;
-        let has_next_block = idx + 1 < blocks.len();
-        let card_body_end = if has_next_block {
-            blocks[idx + 1].start
-        } else {
-            markdown.len()
-        };
-        let card_body_raw = &markdown[card_body_start..card_body_end];
-        let card_body = if has_next_block {
-            strip_blank_separator(card_body_raw).to_string()
-        } else {
-            card_body_raw.to_string()
-        };
+        let card_body = body_after(markdown, &blocks, idx);
 
         cards.push(Card::from_parts(
             card_payload,
@@ -371,15 +358,23 @@ fn validate_parsed_field(key: &str, value: &serde_json::Value) -> Result<(), Par
     })
 }
 
+/// Take the typed `$` item for `key` out of `typed`, leaving its slot empty.
+fn take_meta_item(typed: &mut [Option<PayloadItem>], key: &str) -> Option<PayloadItem> {
+    typed
+        .iter_mut()
+        .find(|slot| slot.as_ref().and_then(meta_key) == Some(key))?
+        .take()
+}
+
 fn build_payload(
-    meta_items: &[PayloadItem],
-    pre_items: &[PreItem],
-    pre_nested_comments: &[NestedComment],
-    pre_nested_fills: &[Vec<CommentPathSegment>],
-    yaml_value: &Option<serde_json::Value>,
+    meta_items: Vec<PayloadItem>,
+    pre_items: Vec<PreItem>,
+    pre_nested_comments: Vec<NestedComment>,
+    pre_nested_fills: Vec<Vec<CommentPathSegment>>,
+    yaml_value: Option<serde_json::Value>,
 ) -> Result<Payload, ParseError> {
-    let mapping = match yaml_value {
-        Some(serde_json::Value::Object(map)) => map.clone(),
+    let mut mapping = match yaml_value {
+        Some(serde_json::Value::Object(map)) => map,
         Some(serde_json::Value::Null) | None => serde_json::Map::new(),
         Some(_) => {
             return Err(ParseError::InvalidStructure(
@@ -391,52 +386,45 @@ fn build_payload(
     // Typed `$` items, consumed at most once each; leftovers are appended in
     // source order. The assert pins `extract_meta_items` to the closed set, so a
     // regression upstream is loud rather than a silent drop.
-    let mut typed_by_key: HashMap<&'static str, PayloadItem> =
-        HashMap::with_capacity(meta_items.len());
+    let mut typed: Vec<Option<PayloadItem>> = Vec::with_capacity(meta_items.len());
     for m in meta_items {
-        let k = meta_key(m).expect(
+        meta_key(&m).expect(
             "build_payload: meta_items must contain only system variants \
              ($quill/$kind/$ext/$seed); got a Field or Comment",
         );
-        typed_by_key.insert(k, m.clone());
+        typed.push(Some(m));
     }
 
     let mut items: Vec<PayloadItem> = Vec::new();
-    let mut consumed_user_keys: std::collections::HashSet<String> =
-        std::collections::HashSet::new();
 
     for item in pre_items {
         match item {
             PreItem::Comment { text, inline } => {
-                items.push(PayloadItem::Comment {
-                    text: text.clone(),
-                    inline: *inline,
-                });
+                items.push(PayloadItem::Comment { text, inline });
             }
             PreItem::Field { key, fill } => {
                 if key.starts_with('$') {
-                    if let Some(meta) = typed_by_key.remove(key.as_str()) {
+                    if let Some(meta) = take_meta_item(&mut typed, &key) {
                         items.push(meta);
                     }
                     continue;
                 }
-                if let Some(value) = mapping.get(key).cloned() {
-                    if *fill && value.is_object() {
+                if let Some(value) = mapping.shift_remove(&key) {
+                    if fill && value.is_object() {
                         return Err(ParseError::InvalidStructure(format!(
                             "`!must_fill` on key `{}` targets a mapping; `!must_fill` is supported on scalars and sequences only",
                             key
                         )));
                     }
-                    validate_parsed_field(key, &value)?;
+                    validate_parsed_field(&key, &value)?;
                     let mut qv = QuillValue::from_json(value);
-                    apply_nested_fills(key, &mut qv, pre_nested_fills)?;
+                    apply_nested_fills(&key, &mut qv, &pre_nested_fills)?;
                     items.push(PayloadItem::Field {
-                        key: key.clone(),
+                        key,
                         value: qv,
-                        fill: *fill,
+                        fill,
                         nested_comments: Vec::new(),
                     });
-                    consumed_user_keys.insert(key.clone());
                 }
             }
         }
@@ -444,22 +432,14 @@ fn build_payload(
 
     // Drain `$` entries the prescan didn't reach, in source order, so the
     // conversion stays total.
-    for meta in meta_items {
-        let k = meta_key(meta).expect("see invariant above");
-        if typed_by_key.remove(k).is_some() {
-            items.push(meta.clone());
-        }
-    }
+    items.extend(typed.into_iter().flatten());
 
-    for (key, value) in &mapping {
-        if consumed_user_keys.contains(key) {
-            continue;
-        }
-        validate_parsed_field(key, value)?;
-        let mut qv = QuillValue::from_json(value.clone());
-        apply_nested_fills(key, &mut qv, pre_nested_fills)?;
+    for (key, value) in mapping {
+        validate_parsed_field(&key, &value)?;
+        let mut qv = QuillValue::from_json(value);
+        apply_nested_fills(&key, &mut qv, &pre_nested_fills)?;
         items.push(PayloadItem::Field {
-            key: key.clone(),
+            key,
             value: qv,
             fill: false,
             nested_comments: Vec::new(),
@@ -468,7 +448,7 @@ fn build_payload(
 
     Ok(Payload::from_items_with_flat_nested(
         items,
-        pre_nested_comments.to_vec(),
+        pre_nested_comments,
     ))
 }
 
@@ -509,19 +489,7 @@ fn apply_nested_fills(
 /// Render a structural path as a dotted/bracketed string for diagnostics,
 /// e.g. `addr.street` or `recipients[0].name`.
 fn render_path(path: &[CommentPathSegment]) -> String {
-    let mut out = String::new();
-    for seg in path {
-        match seg {
-            CommentPathSegment::Key(k) => {
-                if !out.is_empty() {
-                    out.push('.');
-                }
-                out.push_str(k);
-            }
-            CommentPathSegment::Index(i) => {
-                out.push_str(&format!("[{}]", i));
-            }
-        }
-    }
-    out
+    path.iter()
+        .fold(crate::path::DocPath::new(), |p, seg| p.segment(seg))
+        .to_string()
 }

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -18,20 +18,20 @@ use quillmark_content::{ApplyError, ChangeBundle, Content, Delta};
 use crate::document::meta::{validate_composable_kind, CardKindError};
 use crate::error::diag_args;
 use crate::document::payload::MetaKey;
-use crate::document::{Card, Document, Payload};
+use crate::document::{Card, Document, Payload, RichtextDecodeError};
 use crate::quill::{CoercionError, FieldSchema, FieldType, Leniency, QuillConfig};
 use crate::value::{PathSegment, QuillValue};
 use crate::version::QuillReference;
 
-/// An in-field path rendered as the tail of a [`DocPath`](crate::path::DocPath)
-/// field segment (`[0].name`), so a message names the address its anchor does.
-fn render_at(at: &[PathSegment]) -> String {
+/// A field plus its in-field path, rendered through
+/// [`DocPath`](crate::path::DocPath) (`recipients[0].name`), so a message names
+/// the address its anchor does.
+fn render_at(field: &str, at: &[PathSegment]) -> String {
     at.iter()
-        .map(|seg| match seg {
-            PathSegment::Key(k) => format!(".{k}"),
-            PathSegment::Index(i) => format!("[{i}]"),
+        .fold(crate::path::DocPath::new().field(field), |p, seg| {
+            p.segment(seg)
         })
-        .collect()
+        .to_string()
 }
 
 /// `true` if `name` matches `[A-Za-z_][A-Za-z0-9_]*` after NFC normalisation.
@@ -39,21 +39,14 @@ fn render_at(at: &[PathSegment]) -> String {
 /// Case is preserved verbatim; only `$`-prefixed keys are reserved, so a user
 /// field can never shadow system metadata.
 pub fn is_valid_field_name(name: &str) -> bool {
-    let normalized: String = name.nfc().collect();
-    if normalized.is_empty() {
+    let mut chars = name.nfc();
+    let Some(first) = chars.next() else {
         return false;
-    }
-    let mut chars = normalized.chars();
-    let first = chars.next().unwrap();
+    };
     if !first.is_ascii_alphabetic() && first != '_' {
         return false;
     }
-    for ch in chars {
-        if !ch.is_ascii_alphanumeric() && ch != '_' {
-            return false;
-        }
-    }
-    true
+    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
 }
 
 /// The `richtext` codec name carried by [`EditError::FieldDecode`] and
@@ -77,7 +70,7 @@ pub enum EditError {
     /// whose `$kind` carries no schema). A property an `object` field does not
     /// declare is the same error one level down, `at` naming it. Use
     /// [`Card::store_field`](Card::store_field) for opaque storage.
-    #[error("field '{field}{}' is not declared in the schema", render_at(.at))]
+    #[error("field '{}' is not declared in the schema", render_at(.field, .at))]
     UnknownField {
         field: String,
         /// The steps from the field to the undeclared name, its last segment
@@ -114,7 +107,7 @@ pub enum EditError {
     ///
     /// `codec` is the declared type's, not the stored shape's. Absence is not
     /// this error: a missing field is `None`, and reads as the empty content.
-    #[error("{codec} field '{field}{}': {message}", render_at(.at))]
+    #[error("{codec} field '{}': {message}", render_at(.field, .at))]
     FieldDecode {
         field: String,
         /// The steps from the field to the value that failed, empty when the
@@ -134,7 +127,7 @@ pub enum EditError {
     /// `Content`, so it lands here. Address one of its elements with
     /// [`get_content_at`](crate::TypedReader::get_content_at), which raises this
     /// in turn for a path that resolves to no content leaf.
-    #[error("field '{field}{}' is declared '{declared}', which is not a content field", render_at(.at))]
+    #[error("field '{}' is declared '{declared}', which is not a content field", render_at(.field, .at))]
     FieldNotContent {
         field: String,
         /// The steps from the field to the addressed value, empty when the field
@@ -312,8 +305,36 @@ fn check_field(name: &str, value: &serde_json::Value) -> Result<(), EditError> {
     validate_field(name, value).map_err(|v| edit_error_from_violation(name, v))
 }
 
-fn check_meta_depth(map: &serde_json::Map<String, serde_json::Value>) -> Result<(), EditError> {
-    crate::value::depth_check_meta_map(map.clone(), |max| EditError::ValueTooDeep { max })?;
+/// The composable-kind rule mapped onto the mutator error surface.
+fn check_kind(kind: &str) -> Result<(), EditError> {
+    validate_composable_kind(kind).map_err(|e| match e {
+        CardKindError::InvalidName => EditError::InvalidKindName(kind.to_string()),
+        CardKindError::Reserved => EditError::ReservedKind,
+    })
+}
+
+/// A decode failure on the field itself, under the codec that ran.
+fn field_decode(name: &str, codec: &str, e: RichtextDecodeError) -> EditError {
+    EditError::FieldDecode {
+        field: name.to_string(),
+        at: Vec::new(),
+        codec: codec.to_string(),
+        message: e.into_message(),
+    }
+}
+
+/// Depth-bound the values of an `$ext` / `$seed` map: the map itself is level
+/// 1, so its values carry the rest of the budget.
+fn check_meta_depth<'v>(
+    values: impl IntoIterator<Item = &'v serde_json::Value>,
+) -> Result<(), EditError> {
+    let max = crate::document::limits::MAX_YAML_DEPTH;
+    if values
+        .into_iter()
+        .any(|v| crate::value::json_depth_exceeds(v, max - 1))
+    {
+        return Err(EditError::ValueTooDeep { max });
+    }
     Ok(())
 }
 
@@ -413,11 +434,7 @@ impl Document {
 
     /// A card with no `$kind` is rejected as an invalid (empty) name.
     fn check_composable_kind(card: &Card) -> Result<(), EditError> {
-        let kind = card.kind().unwrap_or("");
-        validate_composable_kind(kind).map_err(|e| match e {
-            CardKindError::InvalidName => EditError::InvalidKindName(kind.to_string()),
-            CardKindError::Reserved => EditError::ReservedKind,
-        })
+        check_kind(card.kind().unwrap_or(""))
     }
 
     pub fn remove_card(&mut self, index: usize) -> Option<Card> {
@@ -440,10 +457,7 @@ impl Document {
         new_kind: impl Into<String>,
     ) -> Result<(), EditError> {
         let new_kind = new_kind.into();
-        validate_composable_kind(&new_kind).map_err(|e| match e {
-            CardKindError::InvalidName => EditError::InvalidKindName(new_kind.clone()),
-            CardKindError::Reserved => EditError::ReservedKind,
-        })?;
+        check_kind(&new_kind)?;
         let len = self.cards().len();
         let card = self
             .card_mut(index)
@@ -475,10 +489,7 @@ impl Card {
     /// Create a composable card with the given kind, no fields, and an empty body.
     pub fn new(kind: impl Into<String>) -> Result<Self, EditError> {
         let kind = kind.into();
-        validate_composable_kind(&kind).map_err(|e| match e {
-            CardKindError::InvalidName => EditError::InvalidKindName(kind.clone()),
-            CardKindError::Reserved => EditError::ReservedKind,
-        })?;
+        check_kind(&kind)?;
         let mut payload = Payload::new();
         payload.set_kind(kind);
         Ok(Card::from_parts(
@@ -569,7 +580,7 @@ impl Card {
         &mut self,
         value: serde_json::Map<String, serde_json::Value>,
     ) -> Result<(), EditError> {
-        check_meta_depth(&value)?;
+        check_meta_depth(value.values())?;
         self.payload_mut().set_ext(value);
         Ok(())
     }
@@ -614,10 +625,16 @@ impl Card {
         namespace: String,
         value: serde_json::Value,
     ) -> Result<(), EditError> {
-        let mut map = self.payload_mut().meta(key).cloned().unwrap_or_default();
+        let surviving = self
+            .payload()
+            .meta(key)
+            .into_iter()
+            .flatten()
+            .filter(|(k, _)| **k != namespace)
+            .map(|(_, v)| v);
+        check_meta_depth(surviving.chain(std::iter::once(&value)))?;
+        let mut map = self.payload_mut().take_meta(key).unwrap_or_default();
         map.insert(namespace, value);
-        check_meta_depth(&map)?;
-        self.payload_mut().take_meta(key);
         self.payload_mut().set_meta(key, map);
         Ok(())
     }
@@ -657,10 +674,7 @@ impl Card {
         value: serde_json::Value,
     ) -> Result<(), EditError> {
         let card_kind = card_kind.into();
-        validate_composable_kind(&card_kind).map_err(|e| match e {
-            CardKindError::InvalidName => EditError::InvalidKindName(card_kind.clone()),
-            CardKindError::Reserved => EditError::ReservedKind,
-        })?;
+        check_kind(&card_kind)?;
         self.merge_meta_namespace(MetaKey::Seed, card_kind, value)
     }
 
@@ -774,14 +788,7 @@ impl Card {
         }
         let base = match self.field_richtext(name) {
             Some(Ok(rt)) => rt,
-            Some(Err(e)) => {
-                return Err(EditError::FieldDecode {
-                    field: name.to_string(),
-                    at: Vec::new(),
-                    codec: CODEC_RICHTEXT.to_string(),
-                    message: e.into_message(),
-                })
-            }
+            Some(Err(e)) => return Err(field_decode(name, CODEC_RICHTEXT, e)),
             None => Content::empty(),
         };
         diff_import(&base, &body.into()).map_err(EditError::Import)
@@ -866,14 +873,7 @@ impl Card {
         }
         let base = match self.field_plaintext_content(name) {
             Some(Ok(rt)) => quillmark_content::export::to_plaintext(&rt),
-            Some(Err(e)) => {
-                return Err(EditError::FieldDecode {
-                    field: name.to_string(),
-                    at: Vec::new(),
-                    codec: CODEC_PLAINTEXT.to_string(),
-                    message: e.into_message(),
-                })
-            }
+            Some(Err(e)) => return Err(field_decode(name, CODEC_PLAINTEXT, e)),
             None => String::new(),
         };
         // The strict write is the codec: it runs the `from_plaintext` boundary
@@ -925,14 +925,7 @@ impl Card {
     ) -> Result<(), EditError> {
         let mut content = match self.field_richtext(name) {
             Some(Ok(rt)) => rt,
-            Some(Err(e)) => {
-                return Err(EditError::FieldDecode {
-                    field: name.to_string(),
-                    at: Vec::new(),
-                    codec: CODEC_RICHTEXT.to_string(),
-                    message: e.into_message(),
-                })
-            }
+            Some(Err(e)) => return Err(field_decode(name, CODEC_RICHTEXT, e)),
             // Only this arm creates; the `Some` arms resolved an existing field.
             None => {
                 if !is_valid_field_name(name) {

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -139,13 +139,75 @@ fn emit_meta_block(
     out.push(':');
     push_trailer(out, trailer);
     out.push('\n');
-    let path: Vec<CommentPathSegment> = Vec::new();
-    emit_mapping_children(out, value, 2, &path, nested, &[]);
+    emit_mapping_children(
+        out,
+        value,
+        2,
+        EmitCtx {
+            nested,
+            ..EmitCtx::EMPTY
+        },
+    );
 }
 
-/// Fill sets are small, so a linear scan beats building a hash set per field.
-fn path_is_fill(fills: &[Vec<CommentPathSegment>], path: &[CommentPathSegment]) -> bool {
-    fills.iter().any(|p| p.as_slice() == path)
+/// The sidecar tables threaded through the recursive emit: `path` is the
+/// container path the current node sits at, `nested` and `fills` the whole
+/// block's comment and `!must_fill` tables.
+#[derive(Clone, Copy)]
+struct EmitCtx<'a> {
+    path: &'a [CommentPathSegment],
+    nested: &'a [NestedComment],
+    fills: &'a [Vec<CommentPathSegment>],
+}
+
+impl<'a> EmitCtx<'a> {
+    const EMPTY: Self = Self {
+        path: &[],
+        nested: &[],
+        fills: &[],
+    };
+
+    fn at(self, path: &'a [CommentPathSegment]) -> Self {
+        Self { path, ..self }
+    }
+
+    /// Fill sets are small, so a linear scan beats building a hash set per field.
+    fn is_fill(self, path: &[CommentPathSegment]) -> bool {
+        self.fills.iter().any(|p| p.as_slice() == path)
+    }
+}
+
+/// Where a field's key goes: on its own line at an indent, or right after the
+/// `- ` the caller already wrote.
+#[derive(Clone, Copy)]
+enum KeyPos {
+    Line(usize),
+    SeqHead(usize),
+}
+
+impl KeyPos {
+    fn write_key(self, out: &mut String, key: &str) {
+        match self {
+            KeyPos::Line(indent) => {
+                push_indent(out, indent);
+                emit_key_at(out, key, indent);
+            }
+            KeyPos::SeqHead(_) => emit_key(out, key),
+        }
+    }
+
+    fn map_indent(self) -> usize {
+        match self {
+            KeyPos::Line(i) | KeyPos::SeqHead(i) => i + 2,
+        }
+    }
+
+    fn seq_indent(self) -> usize {
+        match self {
+            KeyPos::Line(i) => i + 2,
+            KeyPos::SeqHead(i) => i + 4,
+        }
+    }
 }
 
 fn emit_block(out: &mut String, card: &Card) {
@@ -192,39 +254,36 @@ fn emit_payload_items(out: &mut String, items: &[PayloadItem]) {
                 // spelling. Once projected the cell is a scalar, which is the
                 // shape `!must_fill` emits against.
                 if let Some(markdown) = project_content_field(value.as_json()) {
-                    emit_field(
+                    emit_field_at(
                         out,
                         key,
                         &JsonValue::String(markdown),
-                        0,
+                        KeyPos::Line(0),
                         *fill,
-                        &[],
-                        &[],
-                        &[],
+                        EmitCtx::EMPTY,
                         trailer,
                     );
                     i += if consumed_trailer { 2 } else { 1 };
                     continue;
                 }
-                let path: Vec<CommentPathSegment> = Vec::new();
                 // Nested fill markers; the top-level one rides on `*fill`.
                 let fills = value.fill_paths();
-                emit_field(
+                emit_field_at(
                     out,
                     key,
                     value.as_json(),
-                    0,
+                    KeyPos::Line(0),
                     *fill,
-                    &path,
-                    nested_comments,
-                    &fills,
+                    EmitCtx {
+                        nested: nested_comments,
+                        fills: &fills,
+                        ..EmitCtx::EMPTY
+                    },
                     trailer,
                 );
             }
             PayloadItem::Comment { text, .. } => {
-                out.push_str("# ");
-                out.push_str(text);
-                out.push('\n');
+                push_comment_line(out, 0, text);
                 consumed_trailer = false;
             }
         }
@@ -270,44 +329,32 @@ fn ensure_blank_before_fence(out: &mut String) {
     out.push('\n');
 }
 
-/// Emit own-line nested comments at `position` in `path` (inline comments are
-/// handled by `find_inline_trailer`).
-fn emit_own_line_pending(
-    out: &mut String,
-    path: &[CommentPathSegment],
-    position: usize,
-    indent: usize,
-    nested: &[NestedComment],
-) {
-    for c in nested {
-        if c.position == position && !c.inline && c.container_path.as_slice() == path {
-            push_indent(out, indent);
-            out.push_str("# ");
-            out.push_str(&c.text);
-            out.push('\n');
+/// Emit own-line nested comments at `position` in the context path (inline
+/// comments are handled by `find_inline_trailer`).
+fn emit_own_line_pending(out: &mut String, ctx: EmitCtx<'_>, position: usize, indent: usize) {
+    for c in ctx.nested {
+        if c.position == position && !c.inline && c.container_path.as_slice() == ctx.path {
+            push_comment_line(out, indent, &c.text);
         }
     }
 }
 
-/// Return the inline trailer for `position` in `path`. If multiple inline
-/// comments share the slot, returns the first and emits the rest as own-line.
+/// Return the inline trailer for `position` in the context path. If multiple
+/// inline comments share the slot, returns the first and emits the rest as
+/// own-line.
 fn find_inline_trailer<'a>(
     out: &mut String,
-    path: &[CommentPathSegment],
+    ctx: EmitCtx<'a>,
     position: usize,
     indent: usize,
-    nested: &'a [NestedComment],
 ) -> Option<&'a str> {
     let mut chosen: Option<&str> = None;
-    for c in nested {
-        if c.position == position && c.inline && c.container_path.as_slice() == path {
+    for c in ctx.nested {
+        if c.position == position && c.inline && c.container_path.as_slice() == ctx.path {
             if chosen.is_none() {
                 chosen = Some(c.text.as_str());
             } else {
-                push_indent(out, indent);
-                out.push_str("# ");
-                out.push_str(&c.text);
-                out.push('\n');
+                push_comment_line(out, indent, &c.text);
             }
         }
     }
@@ -315,21 +362,19 @@ fn find_inline_trailer<'a>(
 }
 
 /// Emit orphan inline comments (`position >= container_len`) as own-line.
-fn emit_orphan_inlines(
-    out: &mut String,
-    path: &[CommentPathSegment],
-    container_len: usize,
-    indent: usize,
-    nested: &[NestedComment],
-) {
-    for c in nested {
-        if c.inline && c.position >= container_len && c.container_path.as_slice() == path {
-            push_indent(out, indent);
-            out.push_str("# ");
-            out.push_str(&c.text);
-            out.push('\n');
+fn emit_orphan_inlines(out: &mut String, ctx: EmitCtx<'_>, container_len: usize, indent: usize) {
+    for c in ctx.nested {
+        if c.inline && c.position >= container_len && c.container_path.as_slice() == ctx.path {
+            push_comment_line(out, indent, &c.text);
         }
     }
+}
+
+fn push_comment_line(out: &mut String, indent: usize, text: &str) {
+    push_indent(out, indent);
+    out.push_str("# ");
+    out.push_str(text);
+    out.push('\n');
 }
 
 fn push_trailer(out: &mut String, trailer: Option<&str>) {
@@ -339,28 +384,23 @@ fn push_trailer(out: &mut String, trailer: Option<&str>) {
     }
 }
 
-/// Emit a `key: <value>\n` pair at `indent` spaces.
+/// Emit a `key: <value>\n` pair with the key placed per `pos`.
 ///
-/// `path` is the container path for nested-comment interleaving. Empty objects
-/// emit `key: {}\n`, empty arrays `key: []\n`. When `fill` is `true`:
-/// scalars → `key: !must_fill <value>`, empty seqs → `key: !must_fill []`, null →
-/// `key: !must_fill`, non-empty seqs → `key: !must_fill\n  - …`. Mappings with `fill`
-/// are rejected at parse and never reach this path.
-#[allow(clippy::too_many_arguments)]
-fn emit_field(
+/// Empty objects emit `key: {}\n`, empty arrays `key: []\n`. When `fill` is
+/// `true`: scalars → `key: !must_fill <value>`, empty seqs → `key: !must_fill []`,
+/// null → `key: !must_fill`, non-empty seqs → `key: !must_fill\n  - …`. Mappings
+/// with `fill` are rejected at parse and never reach this path.
+fn emit_field_at(
     out: &mut String,
     key: &str,
     value: &JsonValue,
-    indent: usize,
+    pos: KeyPos,
     fill: bool,
-    path: &[CommentPathSegment],
-    nested: &[NestedComment],
-    fills: &[Vec<CommentPathSegment>],
+    ctx: EmitCtx<'_>,
     inline_trailer: Option<&str>,
 ) {
+    pos.write_key(out, key);
     if fill {
-        push_indent(out, indent);
-        emit_key_at(out, key, indent);
         match value {
             JsonValue::Null => {
                 out.push_str(": !must_fill");
@@ -382,51 +422,49 @@ fn emit_field(
                 out.push_str(": !must_fill");
                 push_trailer(out, inline_trailer);
                 out.push('\n');
-                emit_sequence_children(out, items, indent + 2, path, nested, fills);
+                emit_sequence_children(out, items, pos.seq_indent(), ctx);
             }
-            JsonValue::Object(_) => {
-                out.push_str(": ");
-                emit_scalar(out, value);
-                push_trailer(out, inline_trailer);
-                out.push('\n');
-            }
+            JsonValue::Object(map) => match pos {
+                KeyPos::Line(_) => {
+                    out.push_str(": ");
+                    emit_scalar(out, value);
+                    push_trailer(out, inline_trailer);
+                    out.push('\n');
+                }
+                KeyPos::SeqHead(_) => {
+                    out.push(':');
+                    push_trailer(out, inline_trailer);
+                    out.push('\n');
+                    emit_mapping_children(out, map, pos.map_indent(), ctx);
+                }
+            },
         }
         return;
     }
     match value {
         JsonValue::Object(map) if map.is_empty() => {
-            push_indent(out, indent);
-            emit_key_at(out, key, indent);
             out.push_str(": {}");
             push_trailer(out, inline_trailer);
             out.push('\n');
         }
         JsonValue::Object(map) => {
-            push_indent(out, indent);
-            emit_key_at(out, key, indent);
             out.push(':');
             push_trailer(out, inline_trailer);
             out.push('\n');
-            emit_mapping_children(out, map, indent + 2, path, nested, fills);
+            emit_mapping_children(out, map, pos.map_indent(), ctx);
         }
         JsonValue::Array(items) if items.is_empty() => {
-            push_indent(out, indent);
-            emit_key_at(out, key, indent);
             out.push_str(": []");
             push_trailer(out, inline_trailer);
             out.push('\n');
         }
         JsonValue::Array(items) => {
-            push_indent(out, indent);
-            emit_key_at(out, key, indent);
             out.push(':');
             push_trailer(out, inline_trailer);
             out.push('\n');
-            emit_sequence_children(out, items, indent + 2, path, nested, fills);
+            emit_sequence_children(out, items, pos.seq_indent(), ctx);
         }
         _ => {
-            push_indent(out, indent);
-            emit_key_at(out, key, indent);
             out.push_str(": ");
             emit_scalar(out, value);
             push_trailer(out, inline_trailer);
@@ -439,62 +477,53 @@ fn emit_mapping_children(
     out: &mut String,
     map: &serde_json::Map<String, JsonValue>,
     child_indent: usize,
-    path: &[CommentPathSegment],
-    nested: &[NestedComment],
-    fills: &[Vec<CommentPathSegment>],
+    ctx: EmitCtx<'_>,
 ) {
     for (i, (k, v)) in map.iter().enumerate() {
-        emit_own_line_pending(out, path, i, child_indent, nested);
-        let trailer = find_inline_trailer(out, path, i, child_indent, nested);
-        let mut child_path = path.to_vec();
+        emit_own_line_pending(out, ctx, i, child_indent);
+        let trailer = find_inline_trailer(out, ctx, i, child_indent);
+        let mut child_path = ctx.path.to_vec();
         child_path.push(CommentPathSegment::Key(k.clone()));
-        let child_fill = path_is_fill(fills, &child_path);
-        emit_field(
+        let child_fill = ctx.is_fill(&child_path);
+        emit_field_at(
             out,
             k,
             v,
-            child_indent,
+            KeyPos::Line(child_indent),
             child_fill,
-            &child_path,
-            nested,
-            fills,
+            ctx.at(&child_path),
             trailer,
         );
     }
-    emit_own_line_pending(out, path, map.len(), child_indent, nested);
-    emit_orphan_inlines(out, path, map.len(), child_indent, nested);
+    emit_own_line_pending(out, ctx, map.len(), child_indent);
+    emit_orphan_inlines(out, ctx, map.len(), child_indent);
 }
 
 fn emit_sequence_children(
     out: &mut String,
     items: &[JsonValue],
     base_indent: usize,
-    path: &[CommentPathSegment],
-    nested: &[NestedComment],
-    fills: &[Vec<CommentPathSegment>],
+    ctx: EmitCtx<'_>,
 ) {
     for (i, item) in items.iter().enumerate() {
-        emit_own_line_pending(out, path, i, base_indent, nested);
-        let trailer = find_inline_trailer(out, path, i, base_indent, nested);
-        let mut child_path = path.to_vec();
+        emit_own_line_pending(out, ctx, i, base_indent);
+        let trailer = find_inline_trailer(out, ctx, i, base_indent);
+        let mut child_path = ctx.path.to_vec();
         child_path.push(CommentPathSegment::Index(i));
-        emit_sequence_item(out, item, base_indent, &child_path, nested, fills, trailer);
+        emit_sequence_item(out, item, base_indent, ctx.at(&child_path), trailer);
     }
-    emit_own_line_pending(out, path, items.len(), base_indent, nested);
-    emit_orphan_inlines(out, path, items.len(), base_indent, nested);
+    emit_own_line_pending(out, ctx, items.len(), base_indent);
+    emit_orphan_inlines(out, ctx, items.len(), base_indent);
 }
 
 /// Emit a single `- <value>\n` sequence item. When the item is a mapping,
 /// if both the seq-item trailer and the first key's trailer are present,
 /// the inner one degrades to an own-line comment.
-#[allow(clippy::too_many_arguments)]
 fn emit_sequence_item(
     out: &mut String,
     value: &JsonValue,
     base_indent: usize,
-    path: &[CommentPathSegment],
-    nested: &[NestedComment],
-    fills: &[Vec<CommentPathSegment>],
+    ctx: EmitCtx<'_>,
     inline_trailer: Option<&str>,
 ) {
     match value {
@@ -505,54 +534,48 @@ fn emit_sequence_item(
             out.push('\n');
         }
         JsonValue::Object(map) => {
-            emit_own_line_pending(out, path, 0, base_indent, nested);
+            emit_own_line_pending(out, ctx, 0, base_indent);
 
             let mut first = true;
             for (i, (k, v)) in map.iter().enumerate() {
                 if !first {
-                    emit_own_line_pending(out, path, i, base_indent + 2, nested);
+                    emit_own_line_pending(out, ctx, i, base_indent + 2);
                 }
-                let inner_trailer = find_inline_trailer(out, path, i, base_indent + 2, nested);
-                let mut child_path = path.to_vec();
+                let inner_trailer = find_inline_trailer(out, ctx, i, base_indent + 2);
+                let mut child_path = ctx.path.to_vec();
                 child_path.push(CommentPathSegment::Key(k.clone()));
+                let child_fill = ctx.is_fill(&child_path);
                 if first {
                     let line_trailer = inline_trailer.or(inner_trailer);
                     push_indent(out, base_indent);
                     out.push_str("- ");
-                    emit_field_inline(
+                    emit_field_at(
                         out,
                         k,
                         v,
-                        base_indent + 2,
-                        path_is_fill(fills, &child_path),
-                        &child_path,
-                        nested,
-                        fills,
+                        KeyPos::SeqHead(base_indent),
+                        child_fill,
+                        ctx.at(&child_path),
                         line_trailer,
                     );
                     if let (Some(_), Some(loser)) = (inline_trailer, inner_trailer) {
-                        push_indent(out, base_indent + 2);
-                        out.push_str("# ");
-                        out.push_str(loser);
-                        out.push('\n');
+                        push_comment_line(out, base_indent + 2, loser);
                     }
                     first = false;
                 } else {
-                    emit_field(
+                    emit_field_at(
                         out,
                         k,
                         v,
-                        base_indent + 2,
-                        path_is_fill(fills, &child_path),
-                        &child_path,
-                        nested,
-                        fills,
+                        KeyPos::Line(base_indent + 2),
+                        child_fill,
+                        ctx.at(&child_path),
                         inner_trailer,
                     );
                 }
             }
-            emit_own_line_pending(out, path, map.len(), base_indent + 2, nested);
-            emit_orphan_inlines(out, path, map.len(), base_indent + 2, nested);
+            emit_own_line_pending(out, ctx, map.len(), base_indent + 2);
+            emit_orphan_inlines(out, ctx, map.len(), base_indent + 2);
         }
         JsonValue::Array(inner) if inner.is_empty() => {
             push_indent(out, base_indent);
@@ -565,92 +588,11 @@ fn emit_sequence_item(
             out.push('-');
             push_trailer(out, inline_trailer);
             out.push('\n');
-            emit_sequence_children(out, inner, base_indent + 2, path, nested, fills);
+            emit_sequence_children(out, inner, base_indent + 2, ctx);
         }
         _ => {
             push_indent(out, base_indent);
             out.push_str("- ");
-            emit_scalar(out, value);
-            push_trailer(out, inline_trailer);
-            out.push('\n');
-        }
-    }
-}
-
-/// Emit `key: <value>\n` where the caller already wrote `- ` on the current line.
-#[allow(clippy::too_many_arguments)]
-fn emit_field_inline(
-    out: &mut String,
-    key: &str,
-    value: &JsonValue,
-    child_indent: usize,
-    fill: bool,
-    path: &[CommentPathSegment],
-    nested: &[NestedComment],
-    fills: &[Vec<CommentPathSegment>],
-    inline_trailer: Option<&str>,
-) {
-    if fill {
-        emit_key(out, key);
-        match value {
-            JsonValue::Null => out.push_str(": !must_fill"),
-            JsonValue::Array(items) if items.is_empty() => out.push_str(": !must_fill []"),
-            JsonValue::Array(items) => {
-                out.push_str(": !must_fill");
-                push_trailer(out, inline_trailer);
-                out.push('\n');
-                emit_sequence_children(out, items, child_indent + 2, path, nested, fills);
-                return;
-            }
-            JsonValue::Object(_) => {
-                // `!must_fill` on a mapping is rejected at parse; emit plainly.
-                out.push(':');
-                push_trailer(out, inline_trailer);
-                out.push('\n');
-                if let JsonValue::Object(map) = value {
-                    emit_mapping_children(out, map, child_indent, path, nested, fills);
-                }
-                return;
-            }
-            _ => {
-                out.push_str(": !must_fill ");
-                emit_scalar(out, value);
-            }
-        }
-        push_trailer(out, inline_trailer);
-        out.push('\n');
-        return;
-    }
-    match value {
-        JsonValue::Object(map) if map.is_empty() => {
-            emit_key(out, key);
-            out.push_str(": {}");
-            push_trailer(out, inline_trailer);
-            out.push('\n');
-        }
-        JsonValue::Object(map) => {
-            emit_key(out, key);
-            out.push(':');
-            push_trailer(out, inline_trailer);
-            out.push('\n');
-            emit_mapping_children(out, map, child_indent, path, nested, fills);
-        }
-        JsonValue::Array(items) if items.is_empty() => {
-            emit_key(out, key);
-            out.push_str(": []");
-            push_trailer(out, inline_trailer);
-            out.push('\n');
-        }
-        JsonValue::Array(items) => {
-            emit_key(out, key);
-            out.push(':');
-            push_trailer(out, inline_trailer);
-            out.push('\n');
-            emit_sequence_children(out, items, child_indent + 2, path, nested, fills);
-        }
-        _ => {
-            emit_key(out, key);
-            out.push_str(": ");
             emit_scalar(out, value);
             push_trailer(out, inline_trailer);
             out.push('\n');
@@ -900,19 +842,24 @@ mod tests {
         vec![CommentPathSegment::Key(key.to_string())]
     }
 
+    fn ctx(path: &[CommentPathSegment]) -> EmitCtx<'_> {
+        EmitCtx {
+            path,
+            ..EmitCtx::EMPTY
+        }
+    }
+
     #[test]
     fn empty_object_emitted() {
         let value = QuillValue::from_json(serde_json::json!({}));
         let mut out = String::new();
-        emit_field(
+        emit_field_at(
             &mut out,
             "empty_map",
             value.as_json(),
-            0,
+            KeyPos::Line(0),
             false,
-            &p("empty_map"),
-            &[],
-            &[],
+            ctx(&p("empty_map")),
             None,
         );
         assert_eq!(out, "empty_map: {}\n");
@@ -922,15 +869,13 @@ mod tests {
     fn empty_object_keeps_inline_trailer() {
         let value = QuillValue::from_json(serde_json::json!({}));
         let mut out = String::new();
-        emit_field(
+        emit_field_at(
             &mut out,
             "empty_map",
             value.as_json(),
-            0,
+            KeyPos::Line(0),
             false,
-            &p("empty_map"),
-            &[],
-            &[],
+            ctx(&p("empty_map")),
             Some("orphan"),
         );
         assert_eq!(out, "empty_map: {} # orphan\n");
@@ -940,15 +885,13 @@ mod tests {
     fn empty_array_emitted() {
         let value = QuillValue::from_json(serde_json::json!([]));
         let mut out = String::new();
-        emit_field(
+        emit_field_at(
             &mut out,
             "empty_seq",
             value.as_json(),
-            0,
+            KeyPos::Line(0),
             false,
-            &p("empty_seq"),
-            &[],
-            &[],
+            ctx(&p("empty_seq")),
             None,
         );
         assert_eq!(out, "empty_seq: []\n");
@@ -958,15 +901,13 @@ mod tests {
     fn scalar_field_with_inline_trailer() {
         let value = QuillValue::from_json(serde_json::json!("Hello"));
         let mut out = String::new();
-        emit_field(
+        emit_field_at(
             &mut out,
             "title",
             value.as_json(),
-            0,
+            KeyPos::Line(0),
             false,
-            &p("title"),
-            &[],
-            &[],
+            ctx(&p("title")),
             Some("greeting"),
         );
         assert_eq!(out, "title: Hello # greeting\n");
@@ -976,15 +917,13 @@ mod tests {
     fn container_field_with_inline_trailer_lands_on_key_line() {
         let value = QuillValue::from_json(serde_json::json!({"inner": 1}));
         let mut out = String::new();
-        emit_field(
+        emit_field_at(
             &mut out,
             "outer",
             value.as_json(),
-            0,
+            KeyPos::Line(0),
             false,
-            &p("outer"),
-            &[],
-            &[],
+            ctx(&p("outer")),
             Some("note"),
         );
         assert_eq!(out, "outer: # note\n  inner: 1\n");
@@ -994,15 +933,13 @@ mod tests {
     fn fill_null_emits_bare_tag() {
         let value = QuillValue::from_json(serde_json::Value::Null);
         let mut out = String::new();
-        emit_field(
+        emit_field_at(
             &mut out,
             "recipient",
             value.as_json(),
-            0,
+            KeyPos::Line(0),
             true,
-            &p("recipient"),
-            &[],
-            &[],
+            ctx(&p("recipient")),
             None,
         );
         assert_eq!(out, "recipient: !must_fill\n");
@@ -1012,15 +949,13 @@ mod tests {
     fn fill_string_emits_tag_with_value() {
         let value = QuillValue::from_json(serde_json::json!("placeholder"));
         let mut out = String::new();
-        emit_field(
+        emit_field_at(
             &mut out,
             "dept",
             value.as_json(),
-            0,
+            KeyPos::Line(0),
             true,
-            &p("dept"),
-            &[],
-            &[],
+            ctx(&p("dept")),
             None,
         );
         assert_eq!(out, "dept: !must_fill placeholder\n");
@@ -1030,15 +965,13 @@ mod tests {
     fn fill_with_inline_trailer() {
         let value = QuillValue::from_json(serde_json::json!("placeholder"));
         let mut out = String::new();
-        emit_field(
+        emit_field_at(
             &mut out,
             "dept",
             value.as_json(),
-            0,
+            KeyPos::Line(0),
             true,
-            &p("dept"),
-            &[],
-            &[],
+            ctx(&p("dept")),
             Some("note"),
         );
         assert_eq!(out, "dept: !must_fill placeholder # note\n");

--- a/crates/core/src/document/fences.rs
+++ b/crates/core/src/document/fences.rs
@@ -150,22 +150,7 @@ fn looks_like_yaml_key_line(line: &str) -> bool {
     if trimmed.is_empty() || trimmed.starts_with('#') {
         return false;
     }
-    let bytes = trimmed.as_bytes();
-    let mut i;
-    if bytes[0] == b'$' {
-        if bytes.len() < 2 || !(bytes[1].is_ascii_alphabetic() || bytes[1] == b'_') {
-            return false;
-        }
-        i = 2;
-    } else if bytes[0].is_ascii_alphabetic() || bytes[0] == b'_' {
-        i = 1;
-    } else {
-        return false;
-    }
-    while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
-        i += 1;
-    }
-    i < bytes.len() && bytes[i] == b':'
+    super::prescan::key_end(trimmed).is_some()
 }
 
 /// A paired `---` block with YAML-key content between the markers, seen after

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -118,7 +118,7 @@ pub use dto::{peek_storage_version, StorageError, StoredDocument, STORAGE_V0_93_
 pub use edit::EditError;
 pub use meta::{is_valid_kind_name, validate_composable_kind, CardKindError};
 pub use payload::{MetaKey, Payload, PayloadItem};
-// Reachable through `PayloadItem::nested_comments`, so nameable from here.
+// Reachable through `PayloadItem`'s `nested_comments` fields, so nameable from here.
 pub use prescan::{CommentPathSegment, NestedComment};
 pub use wire::{CardWire, PayloadItemWire, WireError};
 

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -424,6 +424,12 @@ impl Document {
         &mut self.cards
     }
 
+    /// The ordered card kinds, `None` per kindless card: the shape
+    /// [`regions_to_doc_path`](crate::regions_to_doc_path) takes.
+    pub fn card_kinds(&self) -> Vec<Option<&str>> {
+        self.cards.iter().map(|c| c.kind()).collect()
+    }
+
     /// A single composable card by index: the immutable twin of
     /// [`card_mut`](Document::card_mut), so reading one card's payload does not
     /// require materializing every card via [`cards`](Document::cards). `None`

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -122,19 +122,6 @@ impl PayloadItem {
         }
     }
 
-    /// `&[]` for variants that carry no nested comments.
-    pub fn nested_comments(&self) -> &[NestedComment] {
-        match self {
-            PayloadItem::Field {
-                nested_comments, ..
-            }
-            | PayloadItem::Meta {
-                nested_comments, ..
-            } => nested_comments,
-            _ => &[],
-        }
-    }
-
     pub(crate) fn comment(text: impl Into<String>) -> Self {
         PayloadItem::Comment {
             text: text.into(),
@@ -457,11 +444,6 @@ impl Payload {
             PayloadItem::Field { key: k, value, .. } if k == key => Some(value),
             _ => None,
         })
-    }
-
-    /// `true` if a user field with this key is present.
-    pub fn contains_key(&self, key: &str) -> bool {
-        self.get(key).is_some()
     }
 
     /// `true` if a user field with this key is marked `!must_fill`.

--- a/crates/core/src/document/prescan.rs
+++ b/crates/core/src/document/prescan.rs
@@ -175,23 +175,8 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
                     child_count: 0,
                 });
             } else if let Some((key, after_colon)) = split_key(after_dash_trimmed) {
-                let (fill, value_without_tag, had_non_fill_tag, fill_target_err) =
-                    inspect_fill_and_tags(&after_colon, &key);
-                if had_non_fill_tag {
-                    out.warnings.push(
-                        Diagnostic::new(
-                            Severity::Warning,
-                            format!(
-                                "YAML tag on key `{}` is not supported; the tag has been dropped and the value kept",
-                                key
-                            ),
-                        )
-                        .with_code("parse::unsupported_yaml_tag".to_string()),
-                    );
-                }
-                if let Some(err) = fill_target_err {
-                    out.fill_target_errors.push(err);
-                }
+                let (fill, value_without_tag, had_non_fill_tag) =
+                    record_fill_and_tags(&mut out, &after_colon, &key);
                 if fill {
                     let mut key_path = item_path.clone();
                     key_path.push(CommentPathSegment::Key(key.clone()));
@@ -242,24 +227,8 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
             if let Some((key, after_colon)) = split_key(line) {
                 let (value_part, trailing_comment) = split_trailing_comment(&after_colon);
 
-                let (fill, value_without_tag, had_non_fill_tag, fill_target_err) =
-                    inspect_fill_and_tags(&value_part, &key);
-
-                if had_non_fill_tag {
-                    out.warnings.push(
-                        Diagnostic::new(
-                            Severity::Warning,
-                            format!(
-                                "YAML tag on key `{}` is not supported; the tag has been dropped and the value kept",
-                                key
-                            ),
-                        )
-                        .with_code("parse::unsupported_yaml_tag".to_string()),
-                    );
-                }
-                if let Some(err) = fill_target_err {
-                    out.fill_target_errors.push(err);
-                }
+                let (fill, value_without_tag, _) =
+                    record_fill_and_tags(&mut out, &value_part, &key);
 
                 out.items.push(PreItem::Field {
                     key: key.clone(),
@@ -319,23 +288,7 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
 
             let (value_part, trailing_comment) = split_trailing_comment(&after_colon);
 
-            let (fill, value_without_tag, had_non_fill_tag, fill_target_err) =
-                inspect_fill_and_tags(&value_part, &key);
-            if had_non_fill_tag {
-                out.warnings.push(
-                    Diagnostic::new(
-                        Severity::Warning,
-                        format!(
-                            "YAML tag on key `{}` is not supported; the tag has been dropped and the value kept",
-                            key
-                        ),
-                    )
-                    .with_code("parse::unsupported_yaml_tag".to_string()),
-                );
-            }
-            if let Some(err) = fill_target_err {
-                out.fill_target_errors.push(err);
-            }
+            let (fill, value_without_tag, _) = record_fill_and_tags(&mut out, &value_part, &key);
             if fill {
                 out.nested_fills.push(key_path.clone());
             }
@@ -480,9 +433,10 @@ fn has_empty_inline_value(after_colon: &str) -> bool {
     v.trim().is_empty()
 }
 
-/// Split a line into `(key, rest_after_colon)`, or `None` for non-key lines.
-/// Handles `[a-zA-Z_][a-zA-Z0-9_]*` and `$`-prefixed system keys.
-fn split_key(line: &str) -> Option<(String, String)> {
+/// Byte index of the `:` closing `line`'s leading key, or `None` when `line`
+/// does not open with one. A key is `[a-zA-Z_][a-zA-Z0-9_]*`, optionally
+/// `$`-prefixed for system keys.
+pub(super) fn key_end(line: &str) -> Option<usize> {
     let bytes = line.as_bytes();
     if bytes.is_empty() {
         return None;
@@ -501,12 +455,13 @@ fn split_key(line: &str) -> Option<(String, String)> {
     while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
         i += 1;
     }
-    if i >= bytes.len() || bytes[i] != b':' {
-        return None;
-    }
-    let key = line[..i].to_string();
-    let rest = line[i + 1..].to_string();
-    Some((key, rest))
+    (i < bytes.len() && bytes[i] == b':').then_some(i)
+}
+
+/// Split a line into `(key, rest_after_colon)`, or `None` for non-key lines.
+fn split_key(line: &str) -> Option<(String, String)> {
+    let i = key_end(line)?;
+    Some((line[..i].to_string(), line[i + 1..].to_string()))
 }
 
 /// Split `value` into `(value_without_comment, trailing_comment)` following
@@ -675,6 +630,29 @@ fn inspect_fill_and_tags(value: &str, key: &str) -> (bool, String, bool, Option<
     }
 
     (false, value.to_string(), false, None)
+}
+
+/// [`inspect_fill_and_tags`] with its diagnostics recorded onto `out`,
+/// returning `(fill, value_without_tag, had_other_tag)`.
+fn record_fill_and_tags(out: &mut PreScan, value: &str, key: &str) -> (bool, String, bool) {
+    let (fill, value_without_tag, had_non_fill_tag, fill_target_err) =
+        inspect_fill_and_tags(value, key);
+    if had_non_fill_tag {
+        out.warnings.push(
+            Diagnostic::new(
+                Severity::Warning,
+                format!(
+                    "YAML tag on key `{}` is not supported; the tag has been dropped and the value kept",
+                    key
+                ),
+            )
+            .with_code("parse::unsupported_yaml_tag".to_string()),
+        );
+    }
+    if let Some(err) = fill_target_err {
+        out.fill_target_errors.push(err);
+    }
+    (fill, value_without_tag, had_non_fill_tag)
 }
 
 #[cfg(test)]

--- a/crates/core/src/document/tests/ext_tests.rs
+++ b/crates/core/src/document/tests/ext_tests.rs
@@ -1,10 +1,7 @@
 use serde_json::json;
 
+use crate::document::tests::parse;
 use crate::document::{Document, MetaKey, PayloadItem};
-
-fn parse(src: &str) -> Document {
-    Document::parse(src).expect("source should parse").document
-}
 
 #[test]
 fn ext_with_mapping_value_is_accepted() {

--- a/crates/core/src/document/tests/mod.rs
+++ b/crates/core/src/document/tests/mod.rs
@@ -12,6 +12,13 @@ mod multibyte_tests;
 mod number_edge_tests;
 mod seed_tests;
 
+/// Parse `src`, failing the test on a parse error and dropping the warnings.
+pub(super) fn parse(src: &str) -> super::Document {
+    super::Document::parse(src)
+        .expect("source should parse")
+        .document
+}
+
 /// Every `.md` reachable from `root`, recursively. Includes bundled quill
 /// `README.md`s, which carry no root card-yaml block and are skipped at parse.
 pub(super) fn collect_md_files(root: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {

--- a/crates/core/src/document/tests/seed_tests.rs
+++ b/crates/core/src/document/tests/seed_tests.rs
@@ -1,10 +1,7 @@
 use serde_json::json;
 
+use crate::document::tests::parse;
 use crate::document::{Document, MetaKey, PayloadItem};
-
-fn parse(src: &str) -> Document {
-    Document::parse(src).expect("source should parse").document
-}
 
 #[test]
 fn seed_with_mapping_value_is_accepted() {

--- a/crates/core/src/document/yaml_hints.rs
+++ b/crates/core/src/document/yaml_hints.rs
@@ -65,19 +65,11 @@ fn derive_hint(message: &str, content: &str) -> Option<String> {
     if m.contains("alias references unknown anchor")
         || m.contains("anchor") && m.contains("not found")
     {
-        if let Some(field) = first_field_with_unquoted_prefix(content, &['*', '&']) {
-            return Some(format!(
-                "Plain-scalar values cannot start with `*` or `&` (reserved as YAML \
-                 alias/anchor indicators). For markdown emphasis or a literal `*`/`&`, \
-                 wrap the value in single quotes: `{field}: '**bold text**'`"
-            ));
-        }
-        return Some(
-            "Plain-scalar values cannot start with `*` or `&` (reserved as YAML \
-             alias/anchor indicators). For markdown emphasis or a literal `*`/`&`, \
-             wrap the value in single quotes; e.g. `field: '**bold text**'`."
-                .to_string(),
-        );
+        return Some(anchor_alias_hint(
+            content,
+            "For markdown emphasis or a literal `*`/`&`, wrap the value in single quotes",
+            "**bold text**",
+        ));
     }
 
     // An unquoted value containing `:` reads as a nested mapping key.
@@ -150,19 +142,11 @@ fn derive_hint(message: &str, content: &str) -> Option<String> {
     // Anchor-scan failure: the alias case above under different wording
     // ("scanning an anchor or alias" rather than "anchor" + "not found").
     if m.contains("scanning an anchor") || m.contains("scanning an alias") {
-        if let Some(field) = first_field_with_unquoted_prefix(content, &['*', '&']) {
-            return Some(format!(
-                "Plain-scalar values cannot start with `*` or `&` (reserved as YAML \
-                 alias/anchor indicators). Wrap the value in single quotes: \
-                 `{field}: '&literal value'`"
-            ));
-        }
-        return Some(
-            "Plain-scalar values cannot start with `*` or `&` (reserved as YAML \
-             alias/anchor indicators). Wrap the value in single quotes; e.g. \
-             `field: '&literal value'`."
-                .to_string(),
-        );
+        return Some(anchor_alias_hint(
+            content,
+            "Wrap the value in single quotes",
+            "&literal value",
+        ));
     }
 
     // A multi-line double-quoted scalar; block scalars are friendlier.
@@ -185,23 +169,39 @@ fn derive_hint(message: &str, content: &str) -> Option<String> {
     None
 }
 
+/// The alias/anchor hint, naming the offending field when one is recognizable.
+/// `advice` is the sentence before the example; `example` the quoted value shown.
+fn anchor_alias_hint(content: &str, advice: &str, example: &str) -> String {
+    match first_field_with_unquoted_prefix(content, &['*', '&']) {
+        Some(field) => format!(
+            "Plain-scalar values cannot start with `*` or `&` (reserved as YAML \
+             alias/anchor indicators). {advice}: `{field}: '{example}'`"
+        ),
+        None => format!(
+            "Plain-scalar values cannot start with `*` or `&` (reserved as YAML \
+             alias/anchor indicators). {advice}; e.g. `field: '{example}'`."
+        ),
+    }
+}
+
+/// The `key: value` lines of `content` whose key could be a YAML mapping key,
+/// values leading-trimmed. A comment or sequence line surfaces as a key
+/// starting with `#` / `-`, which callers filter as their scan requires.
+fn key_value_lines(content: &str) -> impl Iterator<Item = (&str, &str)> {
+    content.lines().filter_map(|line| {
+        let (key, rest) = line.trim_start().split_once(':')?;
+        (!key.is_empty() && !key.contains(' ')).then(|| (key, rest.trim_start()))
+    })
+}
+
 /// The first `key: <scalar>` line whose scalar starts with one of `prefixes`.
 /// Only the first line of each plain mapping entry is scanned: multi-line values
 /// cannot raise an alias/anchor error.
 fn first_field_with_unquoted_prefix(content: &str, prefixes: &[char]) -> Option<String> {
-    for line in content.lines() {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with('#') {
+    for (key, value) in key_value_lines(content) {
+        if key.starts_with('#') {
             continue;
         }
-        let (key, value) = match trimmed.split_once(':') {
-            Some(parts) => parts,
-            None => continue,
-        };
-        if key.is_empty() || key.contains(' ') {
-            continue;
-        }
-        let value = value.trim_start();
         let Some(first) = value.chars().next() else {
             continue;
         };
@@ -219,19 +219,10 @@ fn first_field_with_unquoted_prefix(content: &str, prefixes: &[char]) -> Option<
 /// The first `key: <value>` line whose unquoted value contains a second `:`,
 /// which is what raises "mapping values are not allowed in this context".
 fn first_field_with_unquoted_colon(content: &str) -> Option<(String, String)> {
-    for line in content.lines() {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with('#') || trimmed.starts_with('-') {
+    for (key, value) in key_value_lines(content) {
+        if key.starts_with('#') || key.starts_with('-') {
             continue;
         }
-        let (key, rest) = match trimmed.split_once(':') {
-            Some(parts) => parts,
-            None => continue,
-        };
-        if key.is_empty() || key.contains(' ') {
-            continue;
-        }
-        let value = rest.trim_start();
         let first = value.chars().next();
         if matches!(first, Some('\'') | Some('"') | Some('|') | Some('>')) {
             continue;
@@ -251,16 +242,7 @@ fn first_field_with_unquoted_colon(content: &str) -> Option<(String, String)> {
 /// The first `key: "...` line whose double-quoted scalar does not close on the
 /// same line: a proxy for a multi-line double-quoted scalar.
 fn first_field_with_unterminated_dquote(content: &str) -> Option<String> {
-    for line in content.lines() {
-        let trimmed = line.trim_start();
-        let (key, rest) = match trimmed.split_once(':') {
-            Some(parts) => parts,
-            None => continue,
-        };
-        if key.is_empty() || key.contains(' ') {
-            continue;
-        }
-        let value = rest.trim_start();
+    for (key, value) in key_value_lines(content) {
         if !value.starts_with('"') {
             continue;
         }

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -654,13 +654,7 @@ fn resolve_variant_sourced(
     // Coercion normalizes to the container, so the authored discriminant is the
     // `value` key. A bare scalar that bypassed coercion (a serde-built payload)
     // still reads, keeping this total.
-    let authored_member = authored.and_then(|json| match json {
-        serde_json::Value::Object(o) => o.get(VARIANT_DISCRIMINANT_KEY),
-        other => Some(other),
-    });
-    let authored_member = authored_member
-        .filter(|v| !v.is_null())
-        .and_then(|v| v.as_str());
+    let authored_member = FieldSchema::authored_member(authored).and_then(|v| v.as_str());
 
     let (member, source) = match authored_member {
         Some(member) => (member.to_string(), FieldSource::Authored),
@@ -726,15 +720,29 @@ fn rebuild_payload_with_meta(source: &Card, fields: IndexMap<String, QuillValue>
 /// consumer treats any outstanding marker as "not done".
 fn validate_fills(config: &QuillConfig, doc: &Document) -> Vec<Diagnostic> {
     let mut diags = Vec::new();
-    collect_fill_diags(doc.main(), &DocPath::main(), &mut diags);
-    for (index, card) in doc.cards().iter().enumerate() {
-        // A card whose declared `$kind` has no schema drops the kind segment and
-        // stays `cards[<i>]`, matching `validate_typed_document`; a
-        // schema-declared kind qualifies as `cards.<kind>[<i>]`.
-        let kind = card.kind().filter(|k| config.card_kind(k).is_some());
-        collect_fill_diags(card, &DocPath::card(kind, index), &mut diags);
+    for (_, card, path) in schema_cards(config, doc) {
+        collect_fill_diags(card, &path, &mut diags);
     }
     diags
+}
+
+/// Every card of `doc`, the main card first, with the schema its kind resolves
+/// to (`None` for an undeclared kind) and the [`DocPath`] it is reported under.
+///
+/// A card whose declared `$kind` has no schema drops the kind segment and stays
+/// `cards[<i>]`, matching `validate_typed_document`; a schema-declared kind
+/// qualifies as `cards.<kind>[<i>]`.
+fn schema_cards<'a>(
+    config: &'a QuillConfig,
+    doc: &'a Document,
+) -> impl Iterator<Item = (Option<&'a CardSchema>, &'a Card, DocPath)> {
+    std::iter::once((Some(&config.main), doc.main(), DocPath::main())).chain(
+        doc.cards().iter().enumerate().map(move |(index, card)| {
+            let schema = card.kind().and_then(|k| config.card_kind(k));
+            let kind = card.kind().filter(|_| schema.is_some());
+            (schema, card, DocPath::card(kind, index))
+        }),
+    )
 }
 
 /// Append a `validation::must_fill` warning for each marker in `card`'s fields.
@@ -781,17 +789,9 @@ pub(crate) fn fill_warning(path: &DocPath) -> Diagnostic {
 /// must-fill property inside it.
 fn validate_unauthored(config: &QuillConfig, doc: &Document) -> Vec<Diagnostic> {
     let mut diags = Vec::new();
-    collect_unauthored_diags(&config.main, doc.main(), &DocPath::main(), &mut diags);
-    for (index, card) in doc.cards().iter().enumerate() {
-        let Some(schema) = card.kind().and_then(|k| config.card_kind(k)) else {
-            continue;
-        };
-        collect_unauthored_diags(
-            schema,
-            card,
-            &DocPath::card(card.kind(), index),
-            &mut diags,
-        );
+    for (schema, card, path) in schema_cards(config, doc) {
+        let Some(schema) = schema else { continue };
+        collect_unauthored_diags(schema, card, &path, &mut diags);
     }
     diags
 }
@@ -836,27 +836,13 @@ fn collect_unauthored_field(
         let json = value.map(|v| v.as_json());
         let object = json.and_then(|j| j.as_object());
         // Pre-coercion the cell may still be the bare scalar; read either.
-        let authored = match json {
-            Some(serde_json::Value::Object(o)) => o.get(VARIANT_DISCRIMINANT_KEY),
-            other => other,
-        }
-        .filter(|v| !v.is_null());
+        let authored = FieldSchema::authored_member(json);
 
         let discriminant = path.field(VARIANT_DISCRIMINANT_KEY);
         if authored.is_none() && field.must_fill() {
             out.push(unauthored_warning(&discriminant));
         }
-        let member = authored
-            .and_then(|v| v.as_str())
-            .map(str::to_string)
-            .or_else(|| {
-                field
-                    .default
-                    .as_ref()
-                    .and_then(|d| d.as_str())
-                    .map(str::to_string)
-            })
-            .unwrap_or_default();
+        let member = field.selected_member(json);
 
         if let Some(fields) = field.variant_fields(&member) {
             for (name, schema) in fields {
@@ -907,12 +893,9 @@ fn collect_unauthored_field(
 /// human typed until a human clears it.
 fn validate_variants(config: &QuillConfig, doc: &Document) -> Vec<Diagnostic> {
     let mut diags = Vec::new();
-    collect_variant_diags(&config.main, doc.main(), &DocPath::main(), &mut diags);
-    for (index, card) in doc.cards().iter().enumerate() {
-        let Some(schema) = card.kind().and_then(|k| config.card_kind(k)) else {
-            continue;
-        };
-        collect_variant_diags(schema, card, &DocPath::card(card.kind(), index), &mut diags);
+    for (schema, card, path) in schema_cards(config, doc) {
+        let Some(schema) = schema else { continue };
+        collect_variant_diags(schema, card, &path, &mut diags);
     }
     diags
 }
@@ -928,22 +911,13 @@ fn collect_variant_diags(
         if !field.is_variant_bearing() {
             continue;
         }
-        let Some(object) = payload.get(name).and_then(|v| v.as_json().as_object().cloned()) else {
+        let Some(json) = payload.get(name).map(|v| v.as_json()) else {
             continue;
         };
-        let member = object
-            .get(VARIANT_DISCRIMINANT_KEY)
-            .filter(|v| !v.is_null())
-            .and_then(|v| v.as_str())
-            .map(str::to_string)
-            .or_else(|| {
-                field
-                    .default
-                    .as_ref()
-                    .and_then(|d| d.as_str())
-                    .map(str::to_string)
-            })
-            .unwrap_or_default();
+        let Some(object) = json.as_object() else {
+            continue;
+        };
+        let member = field.selected_member(Some(json));
         let live = field.variant_fields(&member);
         for key in object.keys() {
             if key == VARIANT_DISCRIMINANT_KEY || live.is_some_and(|f| f.contains_key(key)) {

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -123,6 +123,20 @@ pub enum CoercionError {
 }
 
 impl CoercionError {
+    fn uncoercible(
+        path: &str,
+        value: impl std::fmt::Display,
+        target: &str,
+        reason: impl Into<String>,
+    ) -> Self {
+        CoercionError::Uncoercible {
+            path: path.to_string(),
+            value: value.to_string(),
+            target: target.to_string(),
+            reason: reason.into(),
+        }
+    }
+
     /// The facts this error's message interpolates. See
     /// [`Diagnostic::args`](crate::error::Diagnostic::args).
     ///
@@ -230,19 +244,7 @@ impl QuillConfig {
         &self,
         payload: &IndexMap<String, QuillValue>,
     ) -> Result<IndexMap<String, QuillValue>, CoercionError> {
-        let mut coerced: IndexMap<String, QuillValue> = IndexMap::new();
-        for (field_name, field_value) in payload {
-            if let Some(field_schema) = self.main.fields.get(field_name) {
-                let path = field_name.as_str();
-                coerced.insert(
-                    field_name.clone(),
-                    Self::conform_value(field_value, field_schema, path, Leniency::Render)?,
-                );
-            } else {
-                coerced.insert(field_name.clone(), field_value.clone());
-            }
-        }
-        Ok(coerced)
+        Self::coerce_fields(&self.main, None, payload)
     }
 
     /// Coerce typed fields for a single card (IndexMap of user fields only).
@@ -256,10 +258,24 @@ impl QuillConfig {
         let Some(card_schema) = self.card_kind(card_kind) else {
             return Ok(fields.clone());
         };
+        Self::coerce_fields(card_schema, Some(card_kind), fields)
+    }
+
+    /// Coerce every field the schema declares and copy the rest through. A
+    /// `card_kind` anchors the error path under `card_kinds.<kind>.`; `None` is
+    /// the main card, whose fields are named bare.
+    fn coerce_fields(
+        schema: &CardSchema,
+        card_kind: Option<&str>,
+        fields: &IndexMap<String, QuillValue>,
+    ) -> Result<IndexMap<String, QuillValue>, CoercionError> {
         let mut coerced: IndexMap<String, QuillValue> = IndexMap::new();
         for (field_name, field_value) in fields {
-            if let Some(field_schema) = card_schema.fields.get(field_name) {
-                let path = format!("card_kinds.{card_kind}.{field_name}");
+            if let Some(field_schema) = schema.fields.get(field_name) {
+                let path: std::borrow::Cow<'_, str> = match card_kind {
+                    Some(kind) => format!("card_kinds.{kind}.{field_name}").into(),
+                    None => field_name.as_str().into(),
+                };
                 coerced.insert(
                     field_name.clone(),
                     Self::conform_value(field_value, field_schema, &path, Leniency::Render)?,
@@ -376,12 +392,12 @@ impl QuillConfig {
                     }
                 }
 
-                Err(CoercionError::Uncoercible {
-                    path: path.to_string(),
-                    value: json_value.to_string(),
-                    target: "boolean".to_string(),
-                    reason: "value is not coercible to boolean".to_string(),
-                })
+                Err(CoercionError::uncoercible(
+                    path,
+                    json_value,
+                    "boolean",
+                    "value is not coercible to boolean",
+                ))
             }
             FieldType::Number => {
                 if json_value.is_number() {
@@ -396,12 +412,12 @@ impl QuillConfig {
                             return Ok(QuillValue::from_json(num.into()));
                         }
                     }
-                    return Err(CoercionError::Uncoercible {
-                        path: path.to_string(),
-                        value: s.to_string(),
-                        target: "number".to_string(),
-                        reason: "string is not a valid number".to_string(),
-                    });
+                    return Err(CoercionError::uncoercible(
+                        path,
+                        s,
+                        "number",
+                        "string is not a valid number",
+                    ));
                 }
                 // Cross-type boolean→number is a render-floor leniency only.
                 if mode == Leniency::Render {
@@ -413,12 +429,12 @@ impl QuillConfig {
                     }
                 }
 
-                Err(CoercionError::Uncoercible {
-                    path: path.to_string(),
-                    value: json_value.to_string(),
-                    target: "number".to_string(),
-                    reason: "value is not coercible to number".to_string(),
-                })
+                Err(CoercionError::uncoercible(
+                    path,
+                    json_value,
+                    "number",
+                    "value is not coercible to number",
+                ))
             }
             FieldType::Integer => {
                 if let Some(i) = json_value.as_i64() {
@@ -428,23 +444,23 @@ impl QuillConfig {
                     if let Ok(i) = i64::try_from(u) {
                         return Ok(QuillValue::from_json(serde_json::Number::from(i).into()));
                     }
-                    return Err(CoercionError::Uncoercible {
-                        path: path.to_string(),
-                        value: json_value.to_string(),
-                        target: "integer".to_string(),
-                        reason: "integer value exceeds i64 range".to_string(),
-                    });
+                    return Err(CoercionError::uncoercible(
+                        path,
+                        json_value,
+                        "integer",
+                        "integer value exceeds i64 range",
+                    ));
                 }
                 if let Some(s) = json_value.as_str() {
                     if let Ok(i) = s.parse::<i64>() {
                         return Ok(QuillValue::from_json(serde_json::Number::from(i).into()));
                     }
-                    return Err(CoercionError::Uncoercible {
-                        path: path.to_string(),
-                        value: s.to_string(),
-                        target: "integer".to_string(),
-                        reason: "string is not a valid integer".to_string(),
-                    });
+                    return Err(CoercionError::uncoercible(
+                        path,
+                        s,
+                        "integer",
+                        "string is not a valid integer",
+                    ));
                 }
                 // Cross-type boolean→integer is a render-floor leniency only.
                 if mode == Leniency::Render {
@@ -456,12 +472,12 @@ impl QuillConfig {
                     }
                 }
 
-                Err(CoercionError::Uncoercible {
-                    path: path.to_string(),
-                    value: json_value.to_string(),
-                    target: "integer".to_string(),
-                    reason: "value is not coercible to integer".to_string(),
-                })
+                Err(CoercionError::uncoercible(
+                    path,
+                    json_value,
+                    "integer",
+                    "value is not coercible to integer",
+                ))
             }
             // Enum is open scalar data drawn from a closed domain: coerced as a
             // string here; domain membership is checked at the validation layer
@@ -482,12 +498,12 @@ impl QuillConfig {
                 // render floor defers to validation, a strict write fails now.
                 match mode {
                     Leniency::Render => Ok(value.clone()),
-                    Leniency::Write => Err(CoercionError::Uncoercible {
-                        path: path.to_string(),
-                        value: json_value.to_string(),
-                        target: field_schema.r#type.as_str().to_string(),
-                        reason: "value is not a string".to_string(),
-                    }),
+                    Leniency::Write => Err(CoercionError::uncoercible(
+                        path,
+                        json_value,
+                        field_schema.r#type.as_str(),
+                        "value is not a string",
+                    )),
                 }
             }
             FieldType::PlainText { inline } => {
@@ -506,22 +522,21 @@ impl QuillConfig {
                 let plain_check =
                     |rt: &quillmark_content::Content| -> Result<(), CoercionError> {
                         if !rt.is_plain() {
-                            return Err(CoercionError::Uncoercible {
-                                path: path.to_string(),
-                                value: "<plaintext>".to_string(),
-                                target: "plaintext".to_string(),
-                                reason: "plaintext carries no marks, islands, or block \
-                                     formatting (lists, quotes, headings)"
-                                    .to_string(),
-                            });
+                            return Err(CoercionError::uncoercible(
+                                path,
+                                "<plaintext>",
+                                "plaintext",
+                                "plaintext carries no marks, islands, or block \
+                                     formatting (lists, quotes, headings)",
+                            ));
                         }
                         if inline && !rt.is_inline() {
-                            return Err(CoercionError::Uncoercible {
-                                path: path.to_string(),
-                                value: "<plaintext>".to_string(),
-                                target: "plaintext(inline)".to_string(),
-                                reason: "plaintext(inline) requires a single line".to_string(),
-                            });
+                            return Err(CoercionError::uncoercible(
+                                path,
+                                "<plaintext>",
+                                "plaintext(inline)",
+                                "plaintext(inline) requires a single line",
+                            ));
                         }
                         Ok(())
                     };
@@ -537,11 +552,13 @@ impl QuillConfig {
                 };
                 if json_value.is_object() {
                     let rt = quillmark_content::serial::from_canonical_value(json_value).map_err(
-                        |e| CoercionError::Uncoercible {
-                            path: path.to_string(),
-                            value: "<object>".to_string(),
-                            target: "plaintext".to_string(),
-                            reason: format!("not a valid content object: {e}"),
+                        |e| {
+                            CoercionError::uncoercible(
+                                path,
+                                "<object>",
+                                "plaintext",
+                                format!("not a valid content object: {e}"),
+                            )
                         },
                     )?;
                     plain_check(&rt)?;
@@ -552,12 +569,12 @@ impl QuillConfig {
                 let Some(text) = lenient_string(json_value) else {
                     return match mode {
                         Leniency::Render => Ok(value.clone()),
-                        Leniency::Write => Err(CoercionError::Uncoercible {
-                            path: path.to_string(),
-                            value: json_value.to_string(),
-                            target: "plaintext".to_string(),
-                            reason: "value is not a plaintext string or content".to_string(),
-                        }),
+                        Leniency::Write => Err(CoercionError::uncoercible(
+                            path,
+                            json_value,
+                            "plaintext",
+                            "value is not a plaintext string or content",
+                        )),
                     };
                 };
                 let rt = quillmark_content::from_plaintext(&text);
@@ -582,14 +599,13 @@ impl QuillConfig {
                 let inline_check =
                     |rt: &quillmark_content::Content| -> Result<(), CoercionError> {
                         if inline && !rt.is_inline() {
-                            return Err(CoercionError::Uncoercible {
-                                path: path.to_string(),
-                                value: "<richtext>".to_string(),
-                                target: "richtext(inline)".to_string(),
-                                reason: "richtext(inline) requires a single paragraph line \
-                                     with no list/quote container and no islands"
-                                    .to_string(),
-                            });
+                            return Err(CoercionError::uncoercible(
+                                path,
+                                "<richtext>",
+                                "richtext(inline)",
+                                "richtext(inline) requires a single paragraph line \
+                                     with no list/quote container and no islands",
+                            ));
                         }
                         Ok(())
                     };
@@ -601,18 +617,20 @@ impl QuillConfig {
                 // which the bindings key on.
                 if mode == Leniency::Write {
                     let content = match crate::document::decode_richtext_value(json_value) {
-                        Some(result) => result.map_err(|e| CoercionError::Uncoercible {
-                            path: path.to_string(),
-                            value: "<richtext>".to_string(),
-                            target: "richtext".to_string(),
-                            reason: e.into_message(),
+                        Some(result) => result.map_err(|e| {
+                            CoercionError::uncoercible(
+                                path,
+                                "<richtext>",
+                                "richtext",
+                                e.into_message(),
+                            )
                         })?,
                         None => {
-                            return Err(CoercionError::Uncoercible {
-                                path: path.to_string(),
-                                value: json_value.to_string(),
-                                target: "richtext".to_string(),
-                                reason: format!(
+                            return Err(CoercionError::uncoercible(
+                                path,
+                                json_value,
+                                "richtext",
+                                format!(
                                     "expected a richtext content object or a markdown string, got {}",
                                     match json_value {
                                         serde_json::Value::Bool(_) => "a boolean",
@@ -621,7 +639,7 @@ impl QuillConfig {
                                         _ => "an unsupported value",
                                     }
                                 ),
-                            })
+                            ));
                         }
                     };
                     inline_check(&content)?;
@@ -631,11 +649,13 @@ impl QuillConfig {
                 }
                 if json_value.is_object() {
                     let rt = quillmark_content::serial::from_canonical_value(json_value).map_err(
-                        |e| CoercionError::Uncoercible {
-                            path: path.to_string(),
-                            value: "<object>".to_string(),
-                            target: "richtext".to_string(),
-                            reason: format!("not a valid richtext content: {e}"),
+                        |e| {
+                            CoercionError::uncoercible(
+                                path,
+                                "<object>",
+                                "richtext",
+                                format!("not a valid richtext content: {e}"),
+                            )
                         },
                     )?;
                     inline_check(&rt)?;
@@ -653,12 +673,12 @@ impl QuillConfig {
                     return Ok(value.clone());
                 };
                 let rt = quillmark_content::import::from_markdown(&markdown).map_err(|e| {
-                    CoercionError::Uncoercible {
-                        path: path.to_string(),
-                        value: markdown.clone(),
-                        target: "richtext".to_string(),
-                        reason: format!("markdown import failed: {e}"),
-                    }
+                    CoercionError::uncoercible(
+                        path,
+                        &markdown,
+                        "richtext",
+                        format!("markdown import failed: {e}"),
+                    )
                 })?;
                 inline_check(&rt)?;
                 Ok(QuillValue::from_json(
@@ -684,28 +704,28 @@ impl QuillConfig {
                         if let Some(s) = arr[0].as_str() {
                             s.to_string()
                         } else {
-                            return Err(CoercionError::Uncoercible {
-                                path: path.to_string(),
-                                value: json_value.to_string(),
-                                target: field_schema.r#type.as_str().to_string(),
-                                reason: "value must be a string".to_string(),
-                            });
+                            return Err(CoercionError::uncoercible(
+                                path,
+                                json_value,
+                                field_schema.r#type.as_str(),
+                                "value must be a string",
+                            ));
                         }
                     } else {
-                        return Err(CoercionError::Uncoercible {
-                            path: path.to_string(),
-                            value: json_value.to_string(),
-                            target: field_schema.r#type.as_str().to_string(),
-                            reason: "value must be a single string".to_string(),
-                        });
+                        return Err(CoercionError::uncoercible(
+                            path,
+                            json_value,
+                            field_schema.r#type.as_str(),
+                            "value must be a single string",
+                        ));
                     }
                 } else {
-                    return Err(CoercionError::Uncoercible {
-                        path: path.to_string(),
-                        value: json_value.to_string(),
-                        target: field_schema.r#type.as_str().to_string(),
-                        reason: "value must be a string".to_string(),
-                    });
+                    return Err(CoercionError::uncoercible(
+                        path,
+                        json_value,
+                        field_schema.r#type.as_str(),
+                        "value must be a string",
+                    ));
                 };
 
                 // The two date types share extraction and verbatim storage;
@@ -724,12 +744,12 @@ impl QuillConfig {
                 if valid {
                     Ok(QuillValue::from_json(serde_json::Value::String(text)))
                 } else {
-                    Err(CoercionError::Uncoercible {
-                        path: path.to_string(),
-                        value: text,
-                        target: field_schema.r#type.as_str().to_string(),
-                        reason: reason.to_string(),
-                    })
+                    Err(CoercionError::uncoercible(
+                        path,
+                        text,
+                        field_schema.r#type.as_str(),
+                        reason,
+                    ))
                 }
             }
             FieldType::Object => {
@@ -747,12 +767,12 @@ impl QuillConfig {
                     // a strict write fails now.
                     match mode {
                         Leniency::Render => Ok(value.clone()),
-                        Leniency::Write => Err(CoercionError::Uncoercible {
-                            path: path.to_string(),
-                            value: json_value.to_string(),
-                            target: "object".to_string(),
-                            reason: "value is not an object".to_string(),
-                        }),
+                        Leniency::Write => Err(CoercionError::uncoercible(
+                            path,
+                            json_value,
+                            "object",
+                            "value is not an object",
+                        )),
                     }
                 }
             }
@@ -835,12 +855,12 @@ impl QuillConfig {
                 // floor defers to validation, a strict write fails now.
                 None => match mode {
                     Leniency::Render => Ok(QuillValue::from_json(json_value.clone())),
-                    Leniency::Write => Err(CoercionError::Uncoercible {
-                        path: path.to_string(),
-                        value: json_value.to_string(),
-                        target: "enum".to_string(),
-                        reason: "value is neither a member nor a variant container".to_string(),
-                    }),
+                    Leniency::Write => Err(CoercionError::uncoercible(
+                        path,
+                        json_value,
+                        "enum",
+                        "value is neither a member nor a variant container",
+                    )),
                 },
             };
         };
@@ -861,12 +881,12 @@ impl QuillConfig {
                             out.insert(key.clone(), value.clone());
                         }
                         Leniency::Write => {
-                            return Err(CoercionError::Uncoercible {
-                                path: format!("{path}.{key}"),
-                                value: value.to_string(),
-                                target: "enum".to_string(),
-                                reason: "value is not a string".to_string(),
-                            });
+                            return Err(CoercionError::uncoercible(
+                                &format!("{path}.{key}"),
+                                value,
+                                "enum",
+                                "value is not a string",
+                            ));
                         }
                     },
                 }
@@ -1493,6 +1513,29 @@ impl QuillConfig {
         }
     }
 
+    /// Parse an optional typed sub-section (`quill.ui`, `main.ui`, `main.body`).
+    /// Absent is `None`; present-but-malformed is `None` plus a diagnostic, so a
+    /// typo in the block is reported rather than silently dropping it.
+    fn parse_section<T: serde::de::DeserializeOwned>(
+        value: Option<&serde_json::Value>,
+        label: &str,
+        code: &str,
+        hint: &str,
+        errors: &mut Vec<Diagnostic>,
+    ) -> Option<T> {
+        match serde_json::from_value::<T>(value?.clone()) {
+            Ok(parsed) => Some(parsed),
+            Err(e) => {
+                errors.push(
+                    Diagnostic::new(Severity::Error, format!("Invalid '{label}' block: {e}"))
+                        .with_code(code.to_string())
+                        .with_hint(hint.to_string()),
+                );
+                None
+            }
+        }
+    }
+
     /// Parse fields from a JSON map into `FieldSchema`s (both `main.fields` and
     /// a card kind's `fields`). Declaration order rides the map itself: the
     /// source map preserves key order (serde_json's `preserve_order`) and the
@@ -1798,23 +1841,13 @@ impl QuillConfig {
             .map(|s| s.to_string())
             .unwrap_or_else(|| "Unknown".to_string());
 
-        let ui_section: Option<UiCardSchema> = match quill_section.get("ui").cloned() {
-            None => None,
-            Some(v) => match serde_json::from_value::<UiCardSchema>(v) {
-                Ok(parsed) => Some(parsed),
-                Err(e) => {
-                    errors.push(
-                        Diagnostic::new(
-                            Severity::Error,
-                            format!("Invalid 'quill.ui' block: {}", e),
-                        )
-                        .with_code("quill::invalid_ui".to_string())
-                        .with_hint("Valid keys under 'ui' are: title, groups.".to_string()),
-                    );
-                    None
-                }
-            },
-        };
+        let ui_section: Option<UiCardSchema> = Self::parse_section(
+            quill_section.get("ui"),
+            "quill.ui",
+            "quill::invalid_ui",
+            "Valid keys under 'ui' are: title, groups.",
+            &mut errors,
+        );
 
         // Extract optional backend-specific section (keyed by `quill.backend`).
         let mut backend_config = HashMap::new();
@@ -1881,45 +1914,22 @@ impl QuillConfig {
 
         // Extract main.ui (optional). Fail loudly on malformed UI metadata rather
         // than silently dropping it; see `quill.ui` handling above.
-        let main_ui: Option<UiCardSchema> = match main_obj_opt
-            .and_then(|main_obj| main_obj.get("ui"))
-            .cloned()
-        {
-            None => None,
-            Some(v) => match serde_json::from_value::<UiCardSchema>(v) {
-                Ok(parsed) => Some(parsed),
-                Err(e) => {
-                    errors.push(
-                        Diagnostic::new(Severity::Error, format!("Invalid 'main.ui' block: {}", e))
-                            .with_code("quill::invalid_ui".to_string())
-                            .with_hint("Valid keys under 'ui' are: title, groups.".to_string()),
-                    );
-                    None
-                }
-            },
-        };
+        let main_ui: Option<UiCardSchema> = Self::parse_section(
+            main_obj_opt.and_then(|main_obj| main_obj.get("ui")),
+            "main.ui",
+            "quill::invalid_ui",
+            "Valid keys under 'ui' are: title, groups.",
+            &mut errors,
+        );
 
         // Extract main.body (optional). Fail loudly on malformed body metadata.
-        let main_body: Option<BodyCardSchema> = match main_obj_opt
-            .and_then(|main_obj| main_obj.get("body"))
-            .cloned()
-        {
-            None => None,
-            Some(v) => match serde_json::from_value::<BodyCardSchema>(v) {
-                Ok(parsed) => Some(parsed),
-                Err(e) => {
-                    errors.push(
-                        Diagnostic::new(
-                            Severity::Error,
-                            format!("Invalid 'main.body' block: {}", e),
-                        )
-                        .with_code("quill::invalid_body".to_string())
-                        .with_hint("Valid keys under 'body' are: enabled, example.".to_string()),
-                    );
-                    None
-                }
-            },
-        };
+        let main_body: Option<BodyCardSchema> = Self::parse_section(
+            main_obj_opt.and_then(|main_obj| main_obj.get("body")),
+            "main.body",
+            "quill::invalid_body",
+            "Valid keys under 'body' are: enabled, example.",
+            &mut errors,
+        );
 
         // Extract main.description (optional, authored under `main:` like any
         // other card kind). This is independent of `quill.description`.
@@ -2041,24 +2051,26 @@ impl QuillConfig {
                 None
             }
         };
-        if let Some(d) = warn_example_unused("main", &main.body) {
-            warnings.push(d);
-        }
-        for card in &card_kinds {
-            if let Some(d) = warn_example_unused(&format!("card_kinds.{}", card.name), &card.body) {
+        // Every card the read-only checks below walk, under the label each names
+        // it by. The checks stay one loop apiece: a diagnostic's position in the
+        // vector is check-major, not card-major.
+        let labeled: Vec<(String, &CardSchema)> = std::iter::once(("main".to_string(), &main))
+            .chain(
+                card_kinds
+                    .iter()
+                    .map(|card| (format!("card_kinds.{}", card.name), card)),
+            )
+            .collect();
+
+        for (label, card) in &labeled {
+            if let Some(d) = warn_example_unused(label, &card.body) {
                 warnings.push(d);
             }
         }
 
         // Validate each card's group registry and its fields' group references.
-        Self::validate_card_groups("main", &main, &mut errors, &mut warnings);
-        for card in &card_kinds {
-            Self::validate_card_groups(
-                &format!("card_kinds.{}", card.name),
-                card,
-                &mut errors,
-                &mut warnings,
-            );
+        for (label, card) in &labeled {
+            Self::validate_card_groups(label, card, &mut errors, &mut warnings);
         }
 
         // Error when `body.example` contains a line that the document parser
@@ -2085,13 +2097,8 @@ impl QuillConfig {
                 None
             }
         };
-        if let Some(d) = err_example_contains_fence("main", &main.body) {
-            errors.push(d);
-        }
-        for card in &card_kinds {
-            if let Some(d) =
-                err_example_contains_fence(&format!("card_kinds.{}", card.name), &card.body)
-            {
+        for (label, card) in &labeled {
+            if let Some(d) = err_example_contains_fence(label, &card.body) {
                 errors.push(d);
             }
         }

--- a/crates/core/src/quill/load.rs
+++ b/crates/core/src/quill/load.rs
@@ -50,45 +50,35 @@ impl Quill {
         // so every Quill.yaml error reaches the caller.
         let (config, warnings) = QuillConfig::from_yaml_with_warnings(&quill_yaml_content)?;
 
-        Self::from_config(config, root).map(|quill| (quill, warnings))
+        Ok((Self::from_config(config, root), warnings))
     }
 
     /// Create a Quill from a QuillConfig and file tree.
-    fn from_config(config: QuillConfig, root: FileTreeNode) -> Result<Self, Vec<Diagnostic>> {
+    fn from_config(config: QuillConfig, root: FileTreeNode) -> Self {
         let mut metadata: std::collections::HashMap<String, QuillValue> =
             std::collections::HashMap::new();
 
-        metadata.insert(
-            "backend".to_string(),
-            QuillValue::from_json(serde_json::Value::String(config.backend.clone())),
-        );
-
-        metadata.insert(
-            "description".to_string(),
-            QuillValue::from_json(serde_json::Value::String(config.description.clone())),
-        );
-
-        metadata.insert(
-            "author".to_string(),
-            QuillValue::from_json(serde_json::Value::String(config.author.clone())),
-        );
-
-        metadata.insert(
-            "version".to_string(),
-            QuillValue::from_json(serde_json::Value::String(config.version.clone())),
-        );
+        for (key, value) in [
+            ("backend", &config.backend),
+            ("description", &config.description),
+            ("author", &config.author),
+            ("version", &config.version),
+        ] {
+            metadata.insert(
+                key.to_string(),
+                QuillValue::from_json(serde_json::Value::String(value.clone())),
+            );
+        }
 
         // Expose backend-specific config to metadata under `<backend>_<key>`.
         for (key, value) in &config.backend_config {
             metadata.insert(format!("{}_{}", config.backend, key), value.clone());
         }
 
-        let source = Quill {
+        Quill {
             metadata,
             config,
             files: root,
-        };
-
-        Ok(source)
+        }
     }
 }

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -27,15 +27,18 @@ pub const QUILLMARK_PLAIN_KEY: &str = "quillmark:plain";
 /// conventional label.
 pub const QUILLMARK_BLANK_TITLE_KEY: &str = "quillmark:blank_title";
 
-/// The discriminant cell of a variant-bearing enum: the same
-/// `{type: string, enum: ["", …]}` a plain enum projects to. The container is a
-/// mapping and therefore not a cell, so this is where the choice lands.
+/// The `{type: string, enum: ["", …]}` an enum projects to: a plain enum's own
+/// cell, and the discriminant cell of a variant-bearing one. That container is a
+/// mapping and therefore not a cell, so this is where its choice lands.
 fn discriminant_schema(field: &FieldSchema) -> serde_json::Value {
     let mut schema = serde_json::Map::new();
     schema.insert(
         "type".to_string(),
         serde_json::Value::String("string".to_string()),
     );
+    // The model layer keeps `""` out of `values:` (it is not a choice), but this
+    // projection describes what is *wire-valid*, and the blank is: without it a
+    // standard JSON-Schema validator rejects a value the engine accepts.
     schema.insert(
         "enum".to_string(),
         serde_json::Value::Array(
@@ -103,31 +106,8 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
             schema.insert("properties".to_string(), properties.into());
             return serde_json::Value::Object(schema);
         }
-        if let Some(values) = &field.enum_values {
-            schema.insert(
-                "type".to_string(),
-                serde_json::Value::String("string".to_string()),
-            );
-            // The model layer keeps `""` out of `values:` (it is not a choice),
-            // but this projection describes what is *wire-valid*, and the blank
-            // is: without it a standard JSON-Schema validator rejects a value
-            // the engine accepts.
-            schema.insert(
-                "enum".to_string(),
-                serde_json::Value::Array(
-                    std::iter::once(String::new())
-                        .chain(values.iter().cloned())
-                        .map(serde_json::Value::String)
-                        .collect(),
-                ),
-            );
-            if let Some(blank_title) = field.ui.as_ref().and_then(|u| u.blank_title.as_ref()) {
-                schema.insert(
-                    QUILLMARK_BLANK_TITLE_KEY.to_string(),
-                    serde_json::Value::String(blank_title.clone()),
-                );
-            }
-            return serde_json::Value::Object(schema);
+        if field.enum_values.is_some() {
+            return discriminant_schema(field);
         }
         match field.r#type {
             FieldType::String => {

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -169,12 +169,8 @@ fn seed_variant(
 ) -> Option<PayloadItem> {
     let overlay_json = overlaid.map(|v| v.as_json());
     let overlay_object = overlay_json.and_then(|j| j.as_object());
-    let overlay_member = match overlay_json {
-        Some(serde_json::Value::Object(o)) => o.get(VARIANT_DISCRIMINANT_KEY),
-        other => other,
-    }
-    .filter(|v| !v.is_null())
-    .and_then(|v| v.as_str());
+    let overlay_member =
+        crate::quill::FieldSchema::authored_member(overlay_json).and_then(|v| v.as_str());
 
     let member = overlay_member
         .map(str::to_string)

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -136,9 +136,9 @@ fn test_quillignore_integration() {
 
     let quill = load_from_path(quill_dir).unwrap();
 
-    assert!(quill.files().file_exists("plate.typ"));
-    assert!(!quill.files().file_exists("should_ignore.tmp"));
-    assert!(!quill.files().file_exists("target/debug.txt"));
+    assert!(quill.files().get_file("plate.typ").is_some());
+    assert!(quill.files().get_file("should_ignore.tmp").is_none());
+    assert!(quill.files().get_file("target/debug.txt").is_none());
 }
 
 #[test]
@@ -275,7 +275,7 @@ fn test_to_tree_round_trips_from_tree() {
 }
 
 #[test]
-fn test_dir_exists_and_list_apis() {
+fn test_list_directories() {
     let mut root_files = HashMap::new();
 
     root_files.insert(
@@ -334,43 +334,23 @@ fn test_dir_exists_and_list_apis() {
     );
 
     let root = FileTreeNode::Directory { files: root_files };
-    let tree = root.clone();
     let quill = Quill::from_tree(root).unwrap();
 
-    assert!(quill.files().dir_exists("assets"));
-    assert!(quill.files().dir_exists("assets/fonts"));
-    assert!(quill.files().dir_exists("empty"));
-    assert!(!quill.files().dir_exists("nonexistent"));
-    assert!(!quill.files().dir_exists("plate.typ")); // file, not directory
+    let mut root_dirs = quill.files().list_directories("");
+    root_dirs.sort();
+    assert_eq!(
+        root_dirs,
+        vec![PathBuf::from("assets"), PathBuf::from("empty")]
+    );
 
-    assert!(quill.files().file_exists("plate.typ"));
-    assert!(quill.files().file_exists("assets/logo.png"));
-    assert!(quill.files().file_exists("assets/fonts/font.ttf"));
-    assert!(!quill.files().file_exists("assets")); // directory, not file
+    assert_eq!(
+        quill.files().list_directories("assets"),
+        vec![PathBuf::from("assets/fonts")]
+    );
 
-    let root_files_list = tree.list_files("");
-    assert_eq!(root_files_list.len(), 2); // Quill.yaml and plate.typ
-    assert!(root_files_list.contains(&"Quill.yaml".to_string()));
-    assert!(root_files_list.contains(&"plate.typ".to_string()));
-
-    let assets_files_list = tree.list_files("assets");
-    assert_eq!(assets_files_list.len(), 2); // logo.png and icon.svg
-    assert!(assets_files_list.contains(&"logo.png".to_string()));
-    assert!(assets_files_list.contains(&"icon.svg".to_string()));
-
-    let root_subdirs = tree.list_subdirectories("");
-    assert_eq!(root_subdirs.len(), 2); // assets and empty
-    assert!(root_subdirs.contains(&"assets".to_string()));
-    assert!(root_subdirs.contains(&"empty".to_string()));
-
-    let assets_subdirs = tree.list_subdirectories("assets");
-    assert_eq!(assets_subdirs.len(), 1); // fonts
-    assert!(assets_subdirs.contains(&"fonts".to_string()));
-
-    let empty_subdirs = tree.list_subdirectories("empty");
-    assert_eq!(empty_subdirs.len(), 0);
-
-    assert_eq!(quill.files().list_directories("").len(), 2);
+    assert!(quill.files().list_directories("empty").is_empty());
+    assert!(quill.files().list_directories("plate.typ").is_empty()); // file, not directory
+    assert!(quill.files().list_directories("nonexistent").is_empty());
 }
 
 #[test]

--- a/crates/core/src/quill/tree.rs
+++ b/crates/core/src/quill/tree.rs
@@ -78,65 +78,24 @@ impl FileTreeNode {
         }
     }
 
-    /// Check if a file exists at the given path
-    pub fn file_exists<P: AsRef<Path>>(&self, path: P) -> bool {
-        matches!(self.get_node(path), Some(FileTreeNode::File { .. }))
-    }
-
-    /// Check if a directory exists at the given path
-    pub fn dir_exists<P: AsRef<Path>>(&self, path: P) -> bool {
-        matches!(self.get_node(path), Some(FileTreeNode::Directory { .. }))
-    }
-
-    /// List all files in a directory (non-recursive)
-    pub fn list_files<P: AsRef<Path>>(&self, dir_path: P) -> Vec<String> {
-        match self.get_node(dir_path) {
-            Some(FileTreeNode::Directory { files }) => files
-                .iter()
-                .filter_map(|(name, node)| {
-                    if matches!(node, FileTreeNode::File { .. }) {
-                        Some(name.clone())
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
-            _ => Vec::new(),
-        }
-    }
-
-    /// List all subdirectories in a directory (non-recursive)
-    pub fn list_subdirectories<P: AsRef<Path>>(&self, dir_path: P) -> Vec<String> {
-        match self.get_node(dir_path) {
-            Some(FileTreeNode::Directory { files }) => files
-                .iter()
-                .filter_map(|(name, node)| {
-                    if matches!(node, FileTreeNode::Directory { .. }) {
-                        Some(name.clone())
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
-            _ => Vec::new(),
-        }
-    }
-
-    /// List all directories in a directory, as paths joined onto `dir_path`.
-    /// The name twin is [`list_subdirectories`](Self::list_subdirectories);
-    /// results stay relative to the receiver either way.
+    /// List the subdirectories of a directory (non-recursive), as paths joined
+    /// onto `dir_path` and so relative to the receiver.
     pub fn list_directories<P: AsRef<Path>>(&self, dir_path: P) -> Vec<PathBuf> {
         let dir_path = dir_path.as_ref();
-        self.list_subdirectories(dir_path)
-            .iter()
-            .map(|name| {
-                if dir_path == Path::new("") {
-                    PathBuf::from(name)
-                } else {
-                    dir_path.join(name)
-                }
-            })
-            .collect()
+        match self.get_node(dir_path) {
+            Some(FileTreeNode::Directory { files }) => files
+                .iter()
+                .filter(|(_, node)| matches!(node, FileTreeNode::Directory { .. }))
+                .map(|(name, _)| {
+                    if dir_path == Path::new("") {
+                        PathBuf::from(name)
+                    } else {
+                        dir_path.join(name)
+                    }
+                })
+                .collect(),
+            _ => Vec::new(),
+        }
     }
 
     /// Get all files matching a pattern (supports glob-style wildcards).

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -614,6 +614,28 @@ impl FieldSchema {
         self.variants.is_some()
     }
 
+    /// The discriminant a document authored for a variant-bearing field, read
+    /// off either shape: the container's [`VARIANT_DISCRIMINANT_KEY`] or a bare
+    /// scalar that bypassed coercion. `None` where the cell is absent or null,
+    /// which is what makes it the *authored* rung of the ladder.
+    pub fn authored_member(value: Option<&serde_json::Value>) -> Option<&serde_json::Value> {
+        match value {
+            Some(serde_json::Value::Object(o)) => o.get(VARIANT_DISCRIMINANT_KEY),
+            other => other,
+        }
+        .filter(|v| !v.is_null())
+    }
+
+    /// The member the ladder selects: the authored discriminant, else
+    /// `default:`, else the blank.
+    pub fn selected_member(&self, value: Option<&serde_json::Value>) -> String {
+        Self::authored_member(value)
+            .and_then(|v| v.as_str())
+            .or_else(|| self.default.as_ref()?.as_str())
+            .unwrap_or_default()
+            .to_string()
+    }
+
     /// Whether a human must author this cell. Keyed on `default`'s *presence*,
     /// so a `default: ""` stays a skippable cell rather than becoming a marker.
     ///

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -1,8 +1,6 @@
 use std::collections::BTreeMap;
 
-use indexmap::IndexMap;
-
-use crate::document::Document;
+use crate::document::{Document, Payload};
 use crate::error::{Diagnostic, Severity, diag_args};
 use crate::path::DocPath;
 use crate::quill::formats::{is_valid_date, is_valid_datetime};
@@ -334,15 +332,14 @@ fn yaml_scalar_type(value: &serde_json::Value) -> &'static str {
     }
 }
 
-/// Validate a typed [`Document`] (with `IndexMap` payload + typed `Card` list).
+/// Validate a typed [`Document`] (typed [`Payload`] + typed `Card` list).
 ///
 /// This is the typed entry point used by `QuillConfig::validate_document`.
 pub fn validate_typed_document(
     config: &QuillConfig,
     doc: &Document,
 ) -> Result<(), Vec<ValidationError>> {
-    let main_fields = doc.main().payload().to_index_map();
-    let mut errors = validate_fields_for_card_indexmap(&config.main, &main_fields, &DocPath::main());
+    let mut errors = validate_fields_for_card(&config.main, doc.main().payload(), &DocPath::main());
 
     // Enforce body.enabled on the main card. Whitespace-only bodies are
     // treated as empty: only meaningful prose triggers the diagnostic.
@@ -368,10 +365,9 @@ pub fn validate_typed_document(
         };
 
         let card_path = DocPath::card(Some(&card_name), index);
-        let card_fields = card.payload().to_index_map();
-        errors.extend(validate_fields_for_card_indexmap(
+        errors.extend(validate_fields_for_card(
             card_schema,
-            &card_fields,
+            card.payload(),
             &card_path,
         ));
 
@@ -390,9 +386,9 @@ pub fn validate_typed_document(
     }
 }
 
-fn validate_fields_for_card_indexmap(
+fn validate_fields_for_card(
     card: &CardSchema,
-    fields: &IndexMap<String, QuillValue>,
+    fields: &Payload,
     base: &DocPath,
 ) -> Vec<ValidationError> {
     let mut errors = Vec::new();
@@ -807,6 +803,7 @@ fn expected_type_name(field_type: &FieldType) -> &'static str {
 mod tests {
     use super::*;
     use crate::document::{Card, Document};
+    use indexmap::IndexMap;
     use serde_json::json;
 
     fn config_with(main_fields: &str, cards: &str) -> QuillConfig {

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -4,6 +4,7 @@ use crate::{
     Severity,
 };
 pub use quillmark_content::{ApplyError, Assoc, ChangeBundle, Delta, IslandOp, LineOp, MarkOp, Op};
+use std::sync::OnceLock;
 
 /// What a committed [`LiveSession::update`] changed.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -154,6 +155,9 @@ pub struct LiveSession {
     /// because the compile is a pure config read; the font and package bytes
     /// stay with the backend that needed them.
     config: QuillConfig,
+    /// The current compile's geometry, rebuilt by the backend at most once per
+    /// compile: invariant between commits, so the commit points clear it.
+    regions: OnceLock<Vec<RenderedRegion>>,
 }
 
 impl LiveSession {
@@ -165,7 +169,11 @@ impl LiveSession {
     /// structural, not an obligation on the caller.
     #[doc(hidden)]
     pub fn new(inner: Box<dyn SessionHandle>, config: QuillConfig) -> Self {
-        Self { inner, config }
+        Self {
+            inner,
+            config,
+            regions: OnceLock::new(),
+        }
     }
 
     pub fn page_count(&self) -> usize {
@@ -208,7 +216,11 @@ impl LiveSession {
     /// Reflects the current compile; re-read after each committed
     /// [`update`](Self::update).
     pub fn regions(&self) -> Vec<RenderedRegion> {
-        self.inner.regions()
+        self.cached_regions().to_vec()
+    }
+
+    fn cached_regions(&self) -> &[RenderedRegion] {
+        self.regions.get_or_init(|| self.inner.regions())
     }
 
     /// The whole-field highlight boxes for `field`: one union rect per page,
@@ -216,7 +228,7 @@ impl LiveSession {
     /// placed solely as a scalar reference or a bound widget yields nothing
     /// here, its box being a single [`regions`](Self::regions) rect.
     pub fn field_boxes(&self, field: &str) -> Vec<RenderedRegion> {
-        crate::field_boxes(&self.regions(), field)
+        crate::field_boxes(self.cached_regions(), field)
     }
 
     /// The schema field whose content is under a point on `page`. `x`/`y` are
@@ -264,7 +276,7 @@ impl LiveSession {
         // Attached at the wrapper, so a backend needs nothing beyond the
         // `regions` accessor it already has.
         if opts.regions {
-            result.regions = self.inner.regions();
+            result.regions = self.regions();
         }
         Ok(result)
     }
@@ -278,6 +290,7 @@ impl LiveSession {
     /// under a schema the session was not opened against.
     pub fn update(&mut self, doc: &Document) -> Result<ChangeSet, RenderError> {
         let json_data = self.config.compile_checked(doc)?;
+        self.regions.take();
         self.inner.update(&json_data)
     }
 
@@ -293,6 +306,7 @@ impl LiveSession {
     #[cfg(feature = "internal-test-seam")]
     #[doc(hidden)]
     pub fn update_data(&mut self, json_data: &serde_json::Value) -> Result<ChangeSet, RenderError> {
+        self.regions.take();
         self.inner.update(json_data)
     }
 }

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -130,40 +130,16 @@ impl Node {
     }
 }
 
-/// `true` when `value` nests deeper than `max_depth` container levels.
+/// `true` when a value nests deeper than `max_depth` container levels: the
+/// content crate's guard, re-exported so this crate's boundaries and the content
+/// model reject the identical shape.
 ///
 /// Every path that stores a value into a `Document` bounds nesting at
 /// [`crate::document::limits::MAX_YAML_DEPTH`], so the recursive consumers
 /// (emit, plate-JSON serialization, DTO conversion) are bounded by
-/// construction. The walk is iterative, so the check itself cannot overflow on
-/// the very input it exists to detect.
-///
-/// The unit is **container levels**, not nodes: only arrays/objects are charged
-/// a level and the scalar leaf is never checked, so an empty container at level
-/// `max_depth + 1` is rejected exactly like a full one. The Python binding's
-/// `py_to_json_at` charges levels the same way.
-pub fn json_depth_exceeds(value: &serde_json::Value, max_depth: usize) -> bool {
-    use serde_json::Value;
-    let mut stack: Vec<(&Value, usize)> = vec![(value, 0)];
-    while let Some((v, depth)) = stack.pop() {
-        match v {
-            Value::Array(items) => {
-                if depth + 1 > max_depth {
-                    return true;
-                }
-                stack.extend(items.iter().map(|c| (c, depth + 1)));
-            }
-            Value::Object(map) => {
-                if depth + 1 > max_depth {
-                    return true;
-                }
-                stack.extend(map.values().map(|c| (c, depth + 1)));
-            }
-            _ => {}
-        }
-    }
-    false
-}
+/// construction. The Python binding's `py_to_json_at` charges levels the same
+/// way.
+pub use quillmark_content::model::json_depth_exceeds;
 
 /// Depth-bound an owned `$ext` / `$seed` map against
 /// [`MAX_YAML_DEPTH`](crate::document::limits::MAX_YAML_DEPTH), returning it

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -205,22 +205,6 @@ impl QuillValue {
         QuillValue { node, json }
     }
 
-    pub fn string(s: impl Into<String>) -> Self {
-        Self::from_json(serde_json::Value::String(s.into()))
-    }
-
-    pub fn integer(n: i64) -> Self {
-        Self::from_json(serde_json::Value::Number(n.into()))
-    }
-
-    pub fn bool(b: bool) -> Self {
-        Self::from_json(serde_json::Value::Bool(b))
-    }
-
-    pub fn null() -> Self {
-        Self::from_json(serde_json::Value::Null)
-    }
-
     /// Whether this value's root node carries the `!must_fill` marker.
     pub fn fill(&self) -> bool {
         self.node.fill
@@ -480,14 +464,14 @@ mod tests {
     #[test]
     fn fill_marker_rides_on_the_node_not_the_json() {
         let filled = || {
-            let mut qv = QuillValue::string("draft");
+            let mut qv = QuillValue::from("draft");
             assert!(qv.set_fill_at(&[]));
             qv
         };
         let qv = filled();
         assert!(qv.fill());
         assert_eq!(qv.as_json(), &serde_json::json!("draft"));
-        assert_ne!(qv, QuillValue::string("draft"), "equality is fill-sensitive");
+        assert_ne!(qv, QuillValue::from("draft"), "equality is fill-sensitive");
         assert_eq!(qv, filled());
     }
 }

--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -125,18 +125,13 @@ impl FromStr for VersionSelector {
         let parts: Vec<&str> = version_str.split('.').collect();
 
         match parts.len() {
-            3 => {
+            2 | 3 => {
                 let version = Version::from_str(version_str)?;
-                Ok(VersionSelector::Exact(version))
-            }
-            2 => {
-                let major = parts[0].parse::<u32>().map_err(|_| {
-                    format!("Invalid major version '{}': must be a number", parts[0])
-                })?;
-                let minor = parts[1].parse::<u32>().map_err(|_| {
-                    format!("Invalid minor version '{}': must be a number", parts[1])
-                })?;
-                Ok(VersionSelector::Minor(major, minor))
+                Ok(if parts.len() == 3 {
+                    VersionSelector::Exact(version)
+                } else {
+                    VersionSelector::Minor(version.major, version.minor)
+                })
             }
             1 => {
                 let major = version_str.parse::<u32>().map_err(|_| {

--- a/crates/core/src/writer.rs
+++ b/crates/core/src/writer.rs
@@ -52,11 +52,8 @@ impl<'a> TypedWriter<'a> {
     /// [`Card::store_field`](crate::Card::store_field). Other errors are those
     /// of `Card::commit_field`.
     pub fn set(&mut self, name: &str, value: impl Into<QuillValue>) -> Result<(), EditError> {
-        let config = self.config;
-        match config.main.fields.get(name) {
-            Some(schema) => self.doc.main_mut().commit_field(name, value, schema),
-            None => Err(EditError::unknown_field(name)),
-        }
+        let schema = Some(&self.config.main.fields);
+        commit_impl(self.doc.main_mut(), schema, name, value)
     }
 
     /// Write several main-card fields atomically, the typed twin of
@@ -92,10 +89,8 @@ impl<'a> TypedWriter<'a> {
     /// markdown, so a byte-identical revise of a value carrying escapes is a
     /// byte no-op.
     pub fn revise_field(&mut self, name: &str, text: &str) -> Result<Delta, EditError> {
-        match self.config.main.fields.get(name) {
-            Some(schema) => self.doc.main_mut().revise_field_checked(name, text, schema),
-            None => Err(EditError::unknown_field(name)),
-        }
+        let schema = Some(&self.config.main.fields);
+        revise_impl(self.doc.main_mut(), schema, name, text)
     }
 
     /// Build a composable card of `kind`, typed-commit `fields` onto it,
@@ -175,10 +170,7 @@ impl CardWriter<'_> {
     /// unknown) fails with [`EditError::UnknownField`] rather than storing
     /// opaquely.
     pub fn set(&mut self, name: &str, value: impl Into<QuillValue>) -> Result<(), EditError> {
-        match self.schema.and_then(|s| s.fields.get(name)) {
-            Some(schema) => self.card.commit_field(name, value, schema),
-            None => Err(EditError::unknown_field(name)),
-        }
+        commit_impl(self.card, self.schema.map(|s| &s.fields), name, value)
     }
 
     /// Revise this card's body from markdown (edit semantics), returning the
@@ -190,10 +182,7 @@ impl CardWriter<'_> {
     /// The card twin of [`TypedWriter::revise_field`], resolved against the
     /// card's [`CardSchema`].
     pub fn revise_field(&mut self, name: &str, text: &str) -> Result<Delta, EditError> {
-        match self.schema.and_then(|s| s.fields.get(name)) {
-            Some(schema) => self.card.revise_field_checked(name, text, schema),
-            None => Err(EditError::unknown_field(name)),
-        }
+        revise_impl(self.card, self.schema.map(|s| &s.fields), name, text)
     }
 
     /// Write several fields on this card atomically; see
@@ -206,6 +195,35 @@ impl CardWriter<'_> {
         I: IntoIterator<Item = (K, V)>,
     {
         set_all_impl(self.card, self.schema.map(|s| &s.fields), fields)
+    }
+}
+
+/// Typed single-field commit shared by [`TypedWriter::set`] and
+/// [`CardWriter::set`]. A `None` schema is an unknown card kind: every name on
+/// it is undeclared.
+fn commit_impl(
+    card: &mut Card,
+    fields_schema: Option<&IndexMap<String, FieldSchema>>,
+    name: &str,
+    value: impl Into<QuillValue>,
+) -> Result<(), EditError> {
+    match fields_schema.and_then(|m| m.get(name)) {
+        Some(schema) => card.commit_field(name, value, schema),
+        None => Err(EditError::unknown_field(name)),
+    }
+}
+
+/// The anchor-preserving twin of [`commit_impl`], shared by
+/// [`TypedWriter::revise_field`] and [`CardWriter::revise_field`].
+fn revise_impl(
+    card: &mut Card,
+    fields_schema: Option<&IndexMap<String, FieldSchema>>,
+    name: &str,
+    text: &str,
+) -> Result<Delta, EditError> {
+    match fields_schema.and_then(|m| m.get(name)) {
+        Some(schema) => card.revise_field_checked(name, text, schema),
+        None => Err(EditError::unknown_field(name)),
     }
 }
 

--- a/crates/quillmark-pdf/src/lib.rs
+++ b/crates/quillmark-pdf/src/lib.rs
@@ -87,24 +87,6 @@ impl FieldSpec {
             align: TextAlign::default(),
         }
     }
-
-    /// Set [`schema_field`](Self::schema_field); without it, no region is emitted.
-    pub fn with_schema_field(mut self, schema_field: String) -> Self {
-        self.schema_field = Some(schema_field);
-        self
-    }
-
-    /// Set [`value`](Self::value).
-    pub fn with_value(mut self, value: String) -> Self {
-        self.value = Some(value);
-        self
-    }
-
-    /// Set [`tooltip`](Self::tooltip).
-    pub fn with_tooltip(mut self, tooltip: String) -> Self {
-        self.tooltip = Some(tooltip);
-        self
-    }
 }
 
 /// A field's definition, never a runtime value (that rides in

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -175,8 +175,8 @@ pub fn find_object_bytes(pdf: &[u8], id: u32) -> Option<(usize, usize)> {
     let mut last_start = None;
     let mut i = 0;
     while i + p.len() <= pdf.len() {
-        if pdf[i..].starts_with(p)
-            && (i == 0 || matches!(pdf[i - 1], b'\n' | b'\r' | b' '))
+        if (i == 0 || matches!(pdf[i - 1], b'\n' | b'\r' | b' '))
+            && pdf[i..].starts_with(p)
             && is_obj_header_tail(&pdf[i + p.len()..])
         {
             last_start = Some(i);
@@ -195,15 +195,14 @@ fn find_endobj_end(pdf: &[u8], from: usize) -> Option<usize> {
     let needle = b"endobj";
     let mut i = from;
     while i < pdf.len() {
-        if pdf[i] == b'(' {
-            i = skip_pdf_string(pdf, i);
-        } else if pdf[i] == b'%' {
-            i = skip_ws_and_comments(pdf, i);
-        } else if pdf[i..].starts_with(needle) {
-            return Some(i + needle.len());
-        } else {
-            i += 1;
+        if let Some(ni) = skip_string_or_comment(pdf, i) {
+            i = ni;
+            continue;
         }
+        if pdf[i..].starts_with(needle) {
+            return Some(i + needle.len());
+        }
+        i += 1;
     }
     None
 }
@@ -318,9 +317,7 @@ pub fn splice_dict_value(dict: &[u8], key: &[u8], value: &[u8], new_value: &[u8]
 fn skip_ws_and_comments(b: &[u8], start: usize) -> usize {
     let mut i = start;
     loop {
-        while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r' | b'\x0c') {
-            i += 1;
-        }
+        i = ws_end(b, i);
         if b.get(i) == Some(&b'%') {
             while i < b.len() && b[i] != b'\n' && b[i] != b'\r' {
                 i += 1;
@@ -352,10 +349,7 @@ fn skip_string_or_comment(b: &[u8], i: usize) -> Option<usize> {
 /// The index after the last byte of the value beginning at `start`, whose
 /// leading whitespace is skipped before the value type is classified.
 fn read_value_end(b: &[u8], start: usize) -> Option<usize> {
-    let mut i = start;
-    while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r' | b'\x0c') {
-        i += 1;
-    }
+    let mut i = ws_end(b, start);
     if i >= b.len() {
         return Some(i);
     }
@@ -381,26 +375,10 @@ fn read_value_end(b: &[u8], start: usize) -> Option<usize> {
             Some(i)
         }
         b'(' => Some(skip_pdf_string(b, i)),
-        b'<' if b[i..].starts_with(b"<<") => {
-            let mut depth = 1;
-            i += 2;
-            while i + 1 < b.len() && depth > 0 {
-                if let Some(ni) = skip_string_or_comment(b, i) {
-                    i = ni;
-                    continue;
-                }
-                if b[i..].starts_with(b"<<") {
-                    depth += 1;
-                    i += 2;
-                } else if b[i..].starts_with(b">>") {
-                    depth -= 1;
-                    i += 2;
-                } else {
-                    i += 1;
-                }
-            }
-            Some(i)
-        }
+        b'<' if b[i..].starts_with(b"<<") => Some(match dict_end(b, i) {
+            Ok(close) => close + 2,
+            Err(stop) => stop,
+        }),
         b'<' => Some(skip_pdf_hex_string(b, i)),
         b'/' => {
             i += 1;
@@ -515,37 +493,78 @@ pub(crate) fn parse_indirect_ref(s: &[u8]) -> Option<(u32, u16)> {
 /// Slice between the outermost `<< ... >>` of an indirect object's body.
 pub fn extract_outer_dict(obj_bytes: &[u8]) -> Option<&[u8]> {
     let open = obj_bytes.windows(2).position(|w| w == b"<<")?;
+    let close = dict_end(obj_bytes, open).ok()?;
+    Some(&obj_bytes[open + 2..close])
+}
+
+/// The index of the `>>` matching the `<<` at `open`. Literal strings and
+/// `%`-comments are skipped: either can carry `<<` / `>>` as raw bytes that
+/// would otherwise skew the nesting depth. `Err` carries the index the scan ran
+/// out at, for a caller that reads an unbalanced dict leniently.
+fn dict_end(b: &[u8], open: usize) -> Result<usize, usize> {
     let mut depth = 0i32;
     let mut i = open;
-    while i + 1 < obj_bytes.len() {
-        // Skip literal strings and `%`-comments: either can carry `<<` / `>>` as
-        // raw bytes that would otherwise skew the nesting depth.
-        if let Some(ni) = skip_string_or_comment(obj_bytes, i) {
+    while i + 1 < b.len() {
+        if let Some(ni) = skip_string_or_comment(b, i) {
             i = ni;
             continue;
         }
-        if obj_bytes[i..].starts_with(b"<<") {
+        if b[i..].starts_with(b"<<") {
             depth += 1;
             i += 2;
-        } else if obj_bytes[i..].starts_with(b">>") {
+        } else if b[i..].starts_with(b">>") {
             depth -= 1;
             if depth == 0 {
-                return Some(&obj_bytes[open + 2..i]);
+                return Ok(i);
             }
             i += 2;
         } else {
             i += 1;
         }
     }
-    None
+    Err(i)
+}
+
+/// The index of the first byte at or after `i` that is not whitespace.
+fn ws_end(b: &[u8], i: usize) -> usize {
+    let mut i = i;
+    while i < b.len() && matches!(b[i], b' ' | b'\t' | b'\n' | b'\r' | b'\x0c') {
+        i += 1;
+    }
+    i
 }
 
 fn skip_ws(s: &[u8]) -> &[u8] {
-    let mut i = 0;
-    while i < s.len() && matches!(s[i], b' ' | b'\t' | b'\n' | b'\r' | b'\x0c') {
-        i += 1;
-    }
-    &s[i..]
+    &s[ws_end(s, 0)..]
+}
+
+/// The inner dict bytes of object `id`. `what` names the object in both failure
+/// messages — `"{what} not found"` and `"{what} dict not parseable"` — under
+/// the caller's error `code`; an Option-returning caller calls `.ok()`.
+pub fn object_dict<'a>(
+    pdf: &'a [u8],
+    id: u32,
+    code: &'static str,
+    what: &str,
+) -> Result<&'a [u8], PdfError> {
+    let (s, e) = find_object_bytes(pdf, id).ok_or_else(|| err(code, format!("{what} not found")))?;
+    extract_outer_dict(&pdf[s..e]).ok_or_else(|| err(code, format!("{what} dict not parseable")))
+}
+
+/// Open the base's trailer: the xref offset, the trailer dict, and the catalog
+/// (`/Root`) object id, after refusing an xref stream. `code` carries the
+/// caller's error code for a missing or malformed `/Root`.
+pub(crate) fn open_trailer<'a>(
+    pdf: &'a [u8],
+    code: &'static str,
+) -> Result<(usize, &'a [u8], u32), PdfError> {
+    let xref_offset = find_startxref(pdf)?;
+    assert_traditional_xref(pdf, xref_offset)?;
+    let trailer = find_trailer_dict(pdf, xref_offset)?;
+    let (catalog_id, _) = find_dict_value(trailer, "Root")
+        .and_then(parse_indirect_ref)
+        .ok_or_else(|| err(code, "/Root missing or malformed in trailer"))?;
+    Ok((xref_offset, trailer, catalog_id))
 }
 
 /// Flatten the catalog's `/Pages` tree into page object ids in document order.
@@ -570,14 +589,7 @@ pub(crate) fn resolve_page_ids(pdf: &[u8], catalog_id: u32) -> Result<Vec<u32>, 
         if seen.len() > MAX_NODES {
             return Err(err(CODE_PARSE, "page tree exceeds 100 000 nodes"));
         }
-        let (s, e) = find_object_bytes(pdf, node_id)
-            .ok_or_else(|| err(CODE_PARSE, format!("page node {node_id} not found")))?;
-        let dict = extract_outer_dict(&pdf[s..e]).ok_or_else(|| {
-            err(
-                CODE_PARSE,
-                format!("page node {node_id} dict not parseable"),
-            )
-        })?;
+        let dict = object_dict(pdf, node_id, CODE_PARSE, &format!("page node {node_id}"))?;
         let typ = find_dict_value(dict, "Type")
             .map(|b| String::from_utf8_lossy(b.trim_ascii()).into_owned())
             .unwrap_or_default();
@@ -599,10 +611,7 @@ pub(crate) fn resolve_page_ids(pdf: &[u8], catalog_id: u32) -> Result<Vec<u32>, 
 
 /// The catalog's root `/Pages` node id.
 fn root_pages_id(pdf: &[u8], catalog_id: u32) -> Result<u32, PdfError> {
-    let (cs, ce) =
-        find_object_bytes(pdf, catalog_id).ok_or_else(|| err(CODE_PARSE, "catalog not found"))?;
-    let cat_dict = extract_outer_dict(&pdf[cs..ce])
-        .ok_or_else(|| err(CODE_PARSE, "catalog dict not parseable"))?;
+    let cat_dict = object_dict(pdf, catalog_id, CODE_PARSE, "catalog")?;
     find_dict_value(cat_dict, "Pages")
         .and_then(parse_indirect_ref)
         .map(|(id, _)| id)
@@ -613,14 +622,16 @@ fn root_pages_id(pdf: &[u8], catalog_id: u32) -> Result<u32, PdfError> {
 /// from the root `/Pages`. The stamp and flatten paths write geometry in
 /// unrotated user space and do not compensate, so a rotated base page would
 /// display every widget away from its intended box.
-pub(crate) fn assert_unrotated_page(
+///
+/// The inherited value is resolved once for the whole batch: reading it costs a
+/// full-file scan per page otherwise.
+pub(crate) fn assert_unrotated_pages(
     pdf: &[u8],
     catalog_id: u32,
-    page_id: u32,
+    page_ids: &[u32],
 ) -> Result<(), PdfError> {
     let read_rotate = |id: u32| -> Option<i64> {
-        let (s, e) = find_object_bytes(pdf, id)?;
-        let dict = extract_outer_dict(&pdf[s..e])?;
+        let dict = object_dict(pdf, id, CODE_PARSE, "page").ok()?;
         let raw = find_dict_value(dict, "Rotate")?;
         std::str::from_utf8(raw.trim_ascii())
             .ok()?
@@ -628,17 +639,18 @@ pub(crate) fn assert_unrotated_page(
             .parse::<i64>()
             .ok()
     };
-    let rotate = read_rotate(page_id)
-        .or_else(|| root_pages_id(pdf, catalog_id).ok().and_then(read_rotate))
-        .unwrap_or(0);
-    if rotate.rem_euclid(360) != 0 {
-        return Err(err(
-            "pdf::rotated_page",
-            format!(
-                "page object {page_id} has /Rotate {rotate}; the stamp spine only \
-                 handles unrotated pages"
-            ),
-        ));
+    let inherited = root_pages_id(pdf, catalog_id).ok().and_then(read_rotate);
+    for &page_id in page_ids {
+        let rotate = read_rotate(page_id).or(inherited).unwrap_or(0);
+        if rotate.rem_euclid(360) != 0 {
+            return Err(err(
+                "pdf::rotated_page",
+                format!(
+                    "page object {page_id} has /Rotate {rotate}; the stamp spine only \
+                     handles unrotated pages"
+                ),
+            ));
+        }
     }
     Ok(())
 }
@@ -705,21 +717,13 @@ fn normalize_rect(mb: [f32; 4]) -> [f32; 4] {
 /// The full rect rather than width/height, so a caller flipping page-relative
 /// top-left geometry can honour a non-zero page origin.
 pub(crate) fn page_media_boxes(pdf: &[u8]) -> Result<Vec<[f32; 4]>, PdfError> {
-    let xref_offset = find_startxref(pdf)?;
-    assert_traditional_xref(pdf, xref_offset)?;
-    let trailer = find_trailer_dict(pdf, xref_offset)?;
-    let (catalog_id, _) = find_dict_value(trailer, "Root")
-        .and_then(parse_indirect_ref)
-        .ok_or_else(|| err(CODE_PARSE, "/Root missing or malformed in trailer"))?;
+    let (_, _, catalog_id) = open_trailer(pdf, CODE_PARSE)?;
 
     let inherited = root_pages_media_box(pdf, catalog_id);
     let page_ids = resolve_page_ids(pdf, catalog_id)?;
     let mut out = Vec::with_capacity(page_ids.len());
     for id in page_ids {
-        let (s, e) = find_object_bytes(pdf, id)
-            .ok_or_else(|| err(CODE_PARSE, format!("page node {id} not found")))?;
-        let dict = extract_outer_dict(&pdf[s..e])
-            .ok_or_else(|| err(CODE_PARSE, format!("page node {id} dict not parseable")))?;
+        let dict = object_dict(pdf, id, CODE_PARSE, &format!("page node {id}"))?;
         let mb = find_dict_value(dict, "MediaBox")
             .and_then(parse_rect_array)
             .or(inherited)
@@ -732,8 +736,7 @@ pub(crate) fn page_media_boxes(pdf: &[u8]) -> Result<Vec<[f32; 4]>, PdfError> {
 /// The root `/Pages` node's `/MediaBox`, if present: the value pages inherit.
 fn root_pages_media_box(pdf: &[u8], catalog_id: u32) -> Option<[f32; 4]> {
     let pages_id = root_pages_id(pdf, catalog_id).ok()?;
-    let (s, e) = find_object_bytes(pdf, pages_id)?;
-    let dict = extract_outer_dict(&pdf[s..e])?;
+    let dict = object_dict(pdf, pages_id, CODE_PARSE, "root /Pages node").ok()?;
     find_dict_value(dict, "MediaBox").and_then(parse_rect_array)
 }
 
@@ -902,11 +905,11 @@ mod tests {
         let pdf = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
                     2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 /Rotate 90 >>\nendobj\n\
                     3 0 obj\n<< /Type /Page /Parent 2 0 R >>\nendobj\n";
-        let e = assert_unrotated_page(pdf, 1, 3).expect_err("rotated page rejected");
+        let e = assert_unrotated_pages(pdf, 1, &[3]).expect_err("rotated page rejected");
         assert_eq!(e.code, "pdf::rotated_page");
         let flat = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
                      2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\
                      3 0 obj\n<< /Type /Page /Parent 2 0 R >>\nendobj\n";
-        assert!(assert_unrotated_page(flat, 1, 3).is_ok());
+        assert!(assert_unrotated_pages(flat, 1, &[3]).is_ok());
     }
 }

--- a/crates/quillmark-pdf/src/stamp.rs
+++ b/crates/quillmark-pdf/src/stamp.rs
@@ -21,12 +21,9 @@ use pdf_writer::{Chunk, Finish, Name, Rect, Ref, Str, TextStr};
 use quillmark_core::RenderedRegion;
 
 use crate::error::PdfError;
-use crate::reader::{
-    err, extract_outer_dict, find_dict_value, find_object_bytes, parse_indirect_ref,
-    splice_dict_value, UpdatedObject,
-};
+use crate::reader::{err, object_dict, parse_indirect_ref, UpdatedObject};
 use crate::update::PdfUpdate;
-use crate::writer::{alloc_id, dict_object};
+use crate::writer::{alloc_id, append_refs_to_array_key, dict_object, OnNonArray};
 use crate::{FieldSpec, FieldType, FormFont, TextAlign};
 
 const CODE_PARSE: &str = "pdf::stamp_parse";
@@ -176,10 +173,7 @@ pub fn stamp(
 
         // A widget is fillable only if reachable both ways: the catalog's
         // `/AcroForm /Fields` (added here) and the page's `/Annots` (below).
-        let (cs, ce) = find_object_bytes(&pdf, up.catalog_id)
-            .ok_or_else(|| err(CODE_PARSE, "catalog not found"))?;
-        let cat_dict = extract_outer_dict(&pdf[cs..ce])
-            .ok_or_else(|| err(CODE_PARSE, "catalog dict not parseable"))?;
+        let cat_dict = object_dict(&pdf, up.catalog_id, CODE_PARSE, "catalog")?;
         let mut cat_inner = cat_dict.to_vec();
         cat_inner.extend_from_slice(format!(" /AcroForm {acroform_id} 0 R").as_bytes());
         up.objects.push(dict_object(up.catalog_id, &cat_inner));
@@ -189,10 +183,8 @@ pub fn stamp(
                 continue;
             }
             let page_obj_id = page_ids[page_idx];
-            let (s, e) = find_object_bytes(&pdf, page_obj_id)
-                .ok_or_else(|| err(CODE_PARSE, format!("page node {page_obj_id} not found")))?;
-            let pg_dict = extract_outer_dict(&pdf[s..e])
-                .ok_or_else(|| err(CODE_PARSE, format!("page node {page_obj_id} not parseable")))?;
+            let what = format!("page node {page_obj_id}");
+            let pg_dict = object_dict(&pdf, page_obj_id, CODE_PARSE, &what)?;
             up.objects.push(dict_object(
                 page_obj_id,
                 &rewrite_page_with_annots(pg_dict, widget_refs)?,
@@ -323,45 +315,22 @@ fn write_widget_object(spec: &FieldSpec, wid: Ref, page_ref: Ref) -> Vec<u8> {
 /// inline array (splice widget refs before `]`); indirect reference (hard
 /// error, the input contract requires inline annots).
 fn rewrite_page_with_annots(pg_dict: &[u8], widget_refs: &[u32]) -> Result<Vec<u8>, PdfError> {
-    let widgets_str = widget_refs
-        .iter()
-        .map(|r| format!("{r} 0 R"))
-        .collect::<Vec<_>>()
-        .join(" ");
+    append_refs_to_array_key(
+        pg_dict,
+        "Annots",
+        widget_refs,
+        CODE_PARSE,
+        OnNonArray::Reject(non_array_annots),
+    )
+}
 
-    match find_dict_value(pg_dict, "Annots") {
-        None => {
-            let mut out = pg_dict.to_vec();
-            out.extend_from_slice(format!(" /Annots [{widgets_str}]").as_bytes());
-            Ok(out)
-        }
-        Some(existing) => {
-            let trimmed = existing.trim_ascii();
-            if trimmed.starts_with(b"[") {
-                let end = trimmed
-                    .iter()
-                    .rposition(|&b| b == b']')
-                    .ok_or_else(|| err(CODE_PARSE, "/Annots array missing ]"))?;
-                let inner = &trimmed[1..end];
-                let merged = format!(
-                    "[{} {}]",
-                    String::from_utf8_lossy(inner).trim(),
-                    widgets_str
-                );
-                Ok(splice_dict_value(
-                    pg_dict,
-                    b"/Annots",
-                    existing,
-                    merged.as_bytes(),
-                ))
-            } else if parse_indirect_ref(existing).is_some() {
-                Err(err(
-                    "pdf::indirect_annots",
-                    "/Annots is an indirect reference; only inline arrays are supported",
-                ))
-            } else {
-                Err(err(CODE_PARSE, "/Annots is neither array nor indirect ref"))
-            }
-        }
+fn non_array_annots(existing: &[u8]) -> PdfError {
+    if parse_indirect_ref(existing).is_some() {
+        err(
+            "pdf::indirect_annots",
+            "/Annots is an indirect reference; only inline arrays are supported",
+        )
+    } else {
+        err(CODE_PARSE, "/Annots is neither array nor indirect ref")
     }
 }

--- a/crates/quillmark-pdf/src/update.rs
+++ b/crates/quillmark-pdf/src/update.rs
@@ -5,9 +5,8 @@
 
 use crate::error::PdfError;
 use crate::reader::{
-    append_incremental_update, assert_overwrite_gen_zero, assert_traditional_xref,
-    assert_unrotated_page, err, find_dict_value, find_startxref, find_trailer_dict,
-    parse_indirect_ref, resolve_page_ids, UpdatedObject,
+    append_incremental_update, assert_overwrite_gen_zero, assert_unrotated_pages, err,
+    find_dict_value, open_trailer, parse_indirect_ref, resolve_page_ids, UpdatedObject,
 };
 use crate::writer::apply_producer_stamp;
 use crate::FieldSpec;
@@ -34,19 +33,13 @@ impl PdfUpdate {
     /// Open `pdf` for an incremental update. The caller then pushes its objects
     /// onto [`objects`](Self::objects) and calls [`finish`](Self::finish).
     pub fn begin(pdf: &[u8], producer: Option<&str>) -> Result<Self, PdfError> {
-        let xref_offset = find_startxref(pdf)?;
-        assert_traditional_xref(pdf, xref_offset)?;
-
-        let trailer = find_trailer_dict(pdf, xref_offset)?;
+        let (xref_offset, trailer, catalog_id) = open_trailer(pdf, CODE_PARSE)?;
         if find_dict_value(trailer, "Encrypt").is_some() {
             return Err(err(
                 "pdf::encrypted",
                 "PDF is encrypted; the stamp spine does not handle encrypted PDFs",
             ));
         }
-        let (catalog_id, _) = find_dict_value(trailer, "Root")
-            .and_then(parse_indirect_ref)
-            .ok_or_else(|| err(CODE_PARSE, "/Root missing or malformed in trailer"))?;
         // The new trailer re-references the catalog as `/Root <id> 0 R`, so a
         // non-zero-generation catalog would be silently corrupted even when only
         // the producer is stamped (catalog not itself overwritten).
@@ -85,6 +78,7 @@ impl PdfUpdate {
         // Both assertions below re-scan the whole byte buffer, so validate each
         // distinct page once rather than pay O(fields × file_size).
         let mut checked = vec![false; page_count];
+        let mut targeted = Vec::new();
         for spec in fields {
             if spec.page >= page_count {
                 return Err(err(
@@ -101,11 +95,12 @@ impl PdfUpdate {
             // A targeted page is overwritten and referenced as gen 0, so a
             // non-zero-generation page would be silently corrupted.
             assert_overwrite_gen_zero(pdf, page_ids[spec.page], "page")?;
-            // Geometry is written in unrotated user space, so a rotated target
-            // page would mis-place every field.
-            assert_unrotated_page(pdf, self.catalog_id, page_ids[spec.page])?;
             checked[spec.page] = true;
+            targeted.push(page_ids[spec.page]);
         }
+        // Geometry is written in unrotated user space, so a rotated target page
+        // would mis-place every field.
+        assert_unrotated_pages(pdf, self.catalog_id, &targeted)?;
         Ok(page_ids)
     }
 

--- a/crates/quillmark-pdf/src/writer.rs
+++ b/crates/quillmark-pdf/src/writer.rs
@@ -4,8 +4,7 @@
 
 use crate::error::PdfError;
 use crate::reader::{
-    assert_overwrite_gen_zero, err, extract_outer_dict, find_dict_value, find_object_bytes,
-    splice_dict_value, UpdatedObject,
+    assert_overwrite_gen_zero, err, find_dict_value, object_dict, splice_dict_value, UpdatedObject,
 };
 
 const CODE_PARSE: &str = "pdf::write";
@@ -63,6 +62,59 @@ pub(crate) fn pdf_text_string(s: &str) -> Vec<u8> {
     }
 }
 
+/// What an existing value that is not an inline array means for
+/// [`append_refs_to_array_key`].
+pub enum OnNonArray {
+    /// Take it as the array's first element (`/Contents 4 0 R` → `[4 0 R …]`).
+    Wrap,
+    /// Refuse it, with the error the fn builds from the raw value.
+    Reject(fn(&[u8]) -> PdfError),
+}
+
+/// Append `refs` as indirect references to `dict`'s inline array `key`, writing
+/// a fresh single-element array when the key is absent. `code` carries the
+/// caller's error code for an array that never closes.
+pub fn append_refs_to_array_key(
+    dict: &[u8],
+    key: &str,
+    refs: &[u32],
+    code: &'static str,
+    on_non_array: OnNonArray,
+) -> Result<Vec<u8>, PdfError> {
+    let refs_str = refs
+        .iter()
+        .map(|r| format!("{r} 0 R"))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let Some(existing) = find_dict_value(dict, key) else {
+        let mut out = dict.to_vec();
+        out.extend_from_slice(format!(" /{key} [{refs_str}]").as_bytes());
+        return Ok(out);
+    };
+
+    let trimmed = existing.trim_ascii();
+    let inner = if trimmed.starts_with(b"[") {
+        let end = trimmed
+            .iter()
+            .rposition(|&b| b == b']')
+            .ok_or_else(|| err(code, format!("/{key} array missing ]")))?;
+        &trimmed[1..end]
+    } else {
+        match on_non_array {
+            OnNonArray::Wrap => trimmed,
+            OnNonArray::Reject(to_err) => return Err(to_err(existing)),
+        }
+    };
+    let merged = format!("[{} {refs_str}]", String::from_utf8_lossy(inner).trim());
+    Ok(splice_dict_value(
+        dict,
+        format!("/{key}").as_bytes(),
+        existing,
+        merged.as_bytes(),
+    ))
+}
+
 /// Replace `/Producer`'s value if present, else append the entry.
 pub(crate) fn upsert_producer(info_dict: &[u8], literal: &[u8]) -> Vec<u8> {
     let key = b"/Producer";
@@ -93,10 +145,8 @@ pub(crate) fn apply_producer_stamp(
             // Overwritten in place at generation 0; a non-zero-generation
             // `/Info` would be silently corrupted.
             assert_overwrite_gen_zero(pdf, info_id, "/Info")?;
-            let (s, e) = find_object_bytes(pdf, info_id)
-                .ok_or_else(|| err(CODE_PARSE, format!("/Info object {info_id} not found")))?;
-            let info_dict = extract_outer_dict(&pdf[s..e])
-                .ok_or_else(|| err(CODE_PARSE, "/Info dict not parseable"))?;
+            let what = format!("/Info object {info_id}");
+            let info_dict = object_dict(pdf, info_id, CODE_PARSE, &what)?;
             objects.push(dict_object(info_id, &upsert_producer(info_dict, &literal)));
             Ok(None)
         }

--- a/crates/quillmark-pdf/tests/stamp.rs
+++ b/crates/quillmark-pdf/tests/stamp.rs
@@ -10,23 +10,59 @@ fn build_base_pdf(n: usize) -> Vec<u8> {
     build_base_pdf_origin(n, [0.0, 0.0, 612.0, 792.0])
 }
 
+/// A schema-bound single-line text field carrying `value`. The spine's real
+/// producers assign the optional fields directly, so the tests do too.
+fn text_field(name: &str, schema: &str, page: usize, rect: [f32; 4], value: &str) -> FieldSpec {
+    let mut spec = FieldSpec::new(
+        name.into(),
+        page,
+        rect,
+        FieldType::Text { multiline: false },
+    );
+    spec.schema_field = Some(schema.into());
+    spec.value = Some(value.into());
+    spec
+}
+
 fn all_four_fields() -> Vec<FieldSpec> {
-    vec![
-        FieldSpec::new("FullName".into(), 0, [180.0, 700.0, 520.0, 720.0], FieldType::Text { multiline: false })
-            .with_schema_field("full_name".into())
-            .with_value("Ada Lovelace".into())
-            .with_tooltip("Full legal name".into()),
-        FieldSpec::new("Comments".into(), 0, [180.0, 600.0, 520.0, 680.0], FieldType::Text { multiline: true })
-            .with_schema_field("comments".into()),
-        FieldSpec::new("Agree".into(), 0, [180.0, 560.0, 194.0, 574.0], FieldType::Checkbox)
-            .with_schema_field("agree".into())
-            .with_value(quillmark_pdf::CHECKBOX_ON_STATE.into()),
-        FieldSpec::new("FavoriteColor".into(), 0, [180.0, 520.0, 520.0, 540.0], FieldType::Choice {
-                options: vec!["red".into(), "green".into(), "blue".into()],
-            })
-            .with_schema_field("favorite_color".into())
-            .with_value("green".into()),
-    ]
+    let mut full = text_field(
+        "FullName",
+        "full_name",
+        0,
+        [180.0, 700.0, 520.0, 720.0],
+        "Ada Lovelace",
+    );
+    full.tooltip = Some("Full legal name".into());
+
+    let mut comments = FieldSpec::new(
+        "Comments".into(),
+        0,
+        [180.0, 600.0, 520.0, 680.0],
+        FieldType::Text { multiline: true },
+    );
+    comments.schema_field = Some("comments".into());
+
+    let mut agree = FieldSpec::new(
+        "Agree".into(),
+        0,
+        [180.0, 560.0, 194.0, 574.0],
+        FieldType::Checkbox,
+    );
+    agree.schema_field = Some("agree".into());
+    agree.value = Some(quillmark_pdf::CHECKBOX_ON_STATE.into());
+
+    let mut color = FieldSpec::new(
+        "FavoriteColor".into(),
+        0,
+        [180.0, 520.0, 520.0, 540.0],
+        FieldType::Choice {
+            options: vec!["red".into(), "green".into(), "blue".into()],
+        },
+    );
+    color.schema_field = Some("favorite_color".into());
+    color.value = Some("green".into());
+
+    vec![full, comments, agree, color]
 }
 
 #[test]
@@ -122,8 +158,14 @@ fn stamps_all_four_field_types_into_valid_acroform() {
 #[test]
 fn signature_field_sets_sigflags() {
     let base = build_base_pdf(2);
-    let fields = vec![FieldSpec::new("Signature".into(), 1, [180.0, 100.0, 520.0, 140.0], FieldType::Signature)
-            .with_schema_field("signature".into())];
+    let mut sig = FieldSpec::new(
+        "Signature".into(),
+        1,
+        [180.0, 100.0, 520.0, 140.0],
+        FieldType::Signature,
+    );
+    sig.schema_field = Some("signature".into());
+    let fields = vec![sig];
     let result = stamp(base, &fields, &StampOptions::default()).expect("stamp ok");
 
     let doc = lopdf::Document::load_mem(&result).expect("reparse");
@@ -223,9 +265,13 @@ fn rotated_page_rejected_cleanly() {
     pdf.stream(content_id, &content.finish());
     let base = pdf.finish();
 
-    let fields = vec![FieldSpec::new("FullName".into(), 0, [180.0, 700.0, 520.0, 720.0], FieldType::Text { multiline: false })
-            .with_schema_field("full_name".into())
-            .with_value("Ada".into())];
+    let fields = vec![text_field(
+        "FullName",
+        "full_name",
+        0,
+        [180.0, 700.0, 520.0, 720.0],
+        "Ada",
+    )];
     let err = stamp(base, &fields, &StampOptions::default()).expect_err("rotated page rejected");
     assert_eq!(err.code, "pdf::rotated_page");
 }
@@ -254,9 +300,9 @@ fn implausible_size_errors_cleanly_without_panic() {
 #[test]
 fn field_targeting_missing_page_errors() {
     let base = build_base_pdf(1);
-    let fields = vec![FieldSpec::new("X".into(), 5, [0.0, 0.0, 10.0, 10.0], FieldType::Signature)
-            .with_schema_field("x".into())];
-    let err = stamp(base, &fields, &StampOptions::default()).expect_err("out of range");
+    let mut sig = FieldSpec::new("X".into(), 5, [0.0, 0.0, 10.0, 10.0], FieldType::Signature);
+    sig.schema_field = Some("x".into());
+    let err = stamp(base, &[sig], &StampOptions::default()).expect_err("out of range");
     assert!(err.message.contains("page"), "{}", err.message);
 }
 
@@ -386,9 +432,7 @@ fn nonzero_generation_page_rejected_cleanly() {
     // Same guard, reached via a page node a field targets (object 3).
     let mut base = build_base_pdf(1);
     replace_first(&mut base, b"3 0 obj", b"3 4 obj");
-    let fields = vec![FieldSpec::new("X".into(), 0, [10.0, 10.0, 100.0, 30.0], FieldType::Text { multiline: false })
-            .with_schema_field("x".into())
-            .with_value("hi".into())];
+    let fields = vec![text_field("X", "x", 0, [10.0, 10.0, 100.0, 30.0], "hi")];
     let err = stamp(base, &fields, &StampOptions::default())
         .expect_err("non-zero generation page rejected");
     assert_eq!(err.code, "pdf::nonzero_generation");
@@ -434,9 +478,7 @@ fn nonzero_mediabox_origin_flows_through() {
 #[test]
 fn inline_annots_are_merged_not_replaced() {
     let (base, existing) = build_base_with_inline_annot();
-    let fields = vec![FieldSpec::new("X".into(), 0, [10.0, 10.0, 100.0, 30.0], FieldType::Text { multiline: false })
-            .with_schema_field("x".into())
-            .with_value("hi".into())];
+    let fields = vec![text_field("X", "x", 0, [10.0, 10.0, 100.0, 30.0], "hi")];
     let result = stamp(base, &fields, &StampOptions::default()).expect("stamp ok");
 
     let doc = lopdf::Document::load_mem(&result).expect("reparse");
@@ -494,9 +536,7 @@ fn indirect_annots_rejected_cleanly() {
         out.extend_from_slice(&tampered[end..]);
         tampered = out;
     }
-    let fields = vec![FieldSpec::new("X".into(), 0, [10.0, 10.0, 100.0, 30.0], FieldType::Text { multiline: false })
-            .with_schema_field("x".into())
-            .with_value("hi".into())];
+    let fields = vec![text_field("X", "x", 0, [10.0, 10.0, 100.0, 30.0], "hi")];
     let err =
         stamp(tampered, &fields, &StampOptions::default()).expect_err("indirect /Annots rejected");
     assert_eq!(err.code, "pdf::indirect_annots");

--- a/crates/quillmark-pdf/tests/stamp.rs
+++ b/crates/quillmark-pdf/tests/stamp.rs
@@ -10,8 +10,7 @@ fn build_base_pdf(n: usize) -> Vec<u8> {
     build_base_pdf_origin(n, [0.0, 0.0, 612.0, 792.0])
 }
 
-/// A schema-bound single-line text field carrying `value`. The spine's real
-/// producers assign the optional fields directly, so the tests do too.
+/// A schema-bound single-line text field carrying `value`.
 fn text_field(name: &str, schema: &str, page: usize, rect: [f32; 4], value: &str) -> FieldSpec {
     let mut spec = FieldSpec::new(
         name.into(),

--- a/crates/quillmark/tests/common/mod.rs
+++ b/crates/quillmark/tests/common/mod.rs
@@ -1,0 +1,26 @@
+//! The `usaf_memo` fixture and an engine, loaded once per test binary rather
+//! than re-reading the 1.3 MB quill in every test.
+
+// Each integration test binary compiles this module and uses part of it.
+#![allow(dead_code)]
+
+use quillmark::{Document, Quill, Quillmark};
+use quillmark_fixtures::quills_path;
+use std::sync::LazyLock;
+
+static ENGINE: LazyLock<Quillmark> = LazyLock::new(Quillmark::new);
+
+static MEMO: LazyLock<Quill> = LazyLock::new(|| {
+    quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo should load")
+});
+
+/// The engine and the flagship `usaf_memo` quill.
+pub fn memo() -> (&'static Quillmark, &'static Quill) {
+    (&ENGINE, &MEMO)
+}
+
+/// [`memo`] plus the quill's seed document: one card per declared kind, each
+/// blank.
+pub fn seeded_memo() -> (&'static Quillmark, &'static Quill, Document) {
+    (&ENGINE, &MEMO, MEMO.seed_document())
+}

--- a/crates/quillmark/tests/usaf_memo_blank_enum_test.rs
+++ b/crates/quillmark/tests/usaf_memo_blank_enum_test.rs
@@ -7,8 +7,9 @@
 
 #![cfg(feature = "typst")]
 
-use quillmark::{OutputFormat, Quillmark, RenderOptions};
-use quillmark_fixtures::quills_path;
+use quillmark::{OutputFormat, RenderOptions};
+
+mod common;
 
 /// Every enum `usaf_memo` declares, authored blank at once: the main card's
 /// three and the indorsement kind's two.
@@ -41,9 +42,7 @@ Indorsement prose.
 
 #[test]
 fn every_enum_authored_blank_still_renders() {
-    let engine = Quillmark::new();
-    let quill =
-        quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo should load");
+    let (engine, quill) = common::memo();
 
     let parsed = quillmark::Document::parse(BLANK_EVERYWHERE)
         .expect("document should parse")
@@ -61,7 +60,7 @@ fn every_enum_authored_blank_still_renders() {
 
     let rendered = engine
         .render(
-            &quill,
+            quill,
             &parsed,
             &RenderOptions::default().with_output_format(OutputFormat::Pdf),
         )
@@ -76,16 +75,14 @@ fn every_enum_authored_blank_still_renders() {
 /// seal rather than falling back to an asset nobody chose.
 #[test]
 fn a_blank_seal_omits_the_seal_rather_than_choosing_one() {
-    let engine = Quillmark::new();
-    let quill =
-        quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo should load");
+    let (engine, quill) = common::memo();
 
     let render = |seal: &str| {
         let md = BLANK_EVERYWHERE.replace("letterhead_seal: \"\"", seal);
         let doc = quillmark::Document::parse(&md).expect("parse").document;
         engine
             .render(
-                &quill,
+                quill,
                 &doc,
                 &RenderOptions::default().with_output_format(OutputFormat::Pdf),
             )

--- a/crates/quillmark/tests/usaf_memo_body_test.rs
+++ b/crates/quillmark/tests/usaf_memo_body_test.rs
@@ -7,16 +7,16 @@
 
 #![cfg(feature = "typst")]
 
-use quillmark::{Document, Quillmark};
-use quillmark_fixtures::quills_path;
+use quillmark::Document;
+
+mod common;
 
 /// `$body` regions as (content span, top edge) pairs in content order.
 fn body_regions(body: &str) -> Vec<([usize; 2], f32)> {
     let markdown = format!("~~~card-yaml\n$quill: usaf_memo\n$kind: main\n~~~\n\n{body}\n");
-    let engine = Quillmark::new();
-    let quill = quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo loads");
+    let (engine, quill) = common::memo();
     let parsed = Document::parse(&markdown).expect("parses").document;
-    let session = engine.open(&quill, &parsed).expect("opens");
+    let session = engine.open(quill, &parsed).expect("opens");
     let mut regions: Vec<_> = session
         .regions()
         .iter()
@@ -84,7 +84,7 @@ fn the_run_in_style_still_runs_in() {
 /// walk's warning is the only place that says so.
 #[test]
 fn a_rule_in_the_memo_body_warns() {
-    let quill = quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo loads");
+    let (_engine, quill) = common::memo();
     let markdown = "~~~card-yaml\n$quill: usaf_memo\n$kind: main\n~~~\n\none\n\n***\n\ntwo\n";
     let warnings: Vec<_> = quill
         .parse(markdown)

--- a/crates/quillmark/tests/usaf_memo_date_field_test.rs
+++ b/crates/quillmark/tests/usaf_memo_date_field_test.rs
@@ -8,8 +8,9 @@
 
 #![cfg(feature = "typst")]
 
-use quillmark::{OutputFormat, Quillmark, RenderOptions};
-use quillmark_fixtures::quills_path;
+use quillmark::{OutputFormat, RenderOptions};
+
+mod common;
 
 const PT_PER_IN: f32 = 72.0;
 
@@ -27,15 +28,12 @@ const LONGEST_DATE_PT: f32 = 96.32;
 const DEFAULT_FONT_SIZE_PT: f32 = 12.0;
 
 fn seeded_memo_pdf() -> Vec<u8> {
-    let engine = Quillmark::new();
-    let quill =
-        quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo should load");
     // One card per declared kind, each blank: the indorsement date is unset,
     // which is the case the widget exists for.
-    let parsed = quill.seed_document();
+    let (engine, quill, parsed) = common::seeded_memo();
     let result = engine
         .render(
-            &quill,
+            quill,
             &parsed,
             &RenderOptions::default().with_output_format(OutputFormat::Pdf),
         )

--- a/crates/quillmark/tests/usaf_memo_regions_test.rs
+++ b/crates/quillmark/tests/usaf_memo_regions_test.rs
@@ -7,20 +7,17 @@
 
 use std::collections::HashSet;
 
-use quillmark::{OutputFormat, Quillmark, RenderOptions};
-use quillmark_fixtures::quills_path;
+use quillmark::{OutputFormat, RenderOptions};
+
+mod common;
 
 #[test]
 fn usaf_memo_regions_cover_body_signature_and_cards() {
-    let engine = Quillmark::new();
-    let quill =
-        quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo should load");
-
     // One card per declared kind, so the indorsement addresses are present.
-    let parsed = quill.seed_document();
+    let (engine, quill, parsed) = common::seeded_memo();
 
     let mut session = engine
-        .open(&quill, &parsed)
+        .open(quill, &parsed)
         .expect("usaf_memo should open a session");
 
     let regions = session.regions();
@@ -47,9 +44,8 @@ fn usaf_memo_regions_cover_body_signature_and_cards() {
         fields.contains("references.0"),
         "each `references` element regions on its own address: {fields:?}"
     );
-    let kinds: Vec<Option<&str>> = parsed.cards().iter().map(|c| c.kind()).collect();
     let translated: HashSet<String> =
-        quillmark_core::regions_to_doc_path(regions.clone(), &kinds)
+        quillmark_core::regions_to_doc_path(regions.clone(), &parsed.card_kinds())
             .into_iter()
             .map(|r| r.field)
             .collect();
@@ -85,7 +81,7 @@ fn usaf_memo_regions_cover_body_signature_and_cards() {
 
     let with_regions = engine
         .render(
-            &quill,
+            quill,
             &parsed,
             &RenderOptions::default().with_output_format(OutputFormat::Pdf).with_regions(true),
         )
@@ -97,7 +93,7 @@ fn usaf_memo_regions_cover_body_signature_and_cards() {
 
     let without_regions = engine
         .render(
-            &quill,
+            quill,
             &parsed,
             &RenderOptions::default().with_output_format(OutputFormat::Pdf),
         )
@@ -115,11 +111,8 @@ fn usaf_memo_regions_cover_body_signature_and_cards() {
 /// recorded window wherever the package finally places them.
 #[test]
 fn usaf_memo_date_region_rides_the_vendored_display() {
-    let engine = Quillmark::new();
-    let quill =
-        quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo should load");
-    let parsed = quill.seed_document();
-    let mut session = engine.open(&quill, &parsed).expect("open a session");
+    let (engine, quill, parsed) = common::seeded_memo();
+    let mut session = engine.open(quill, &parsed).expect("open a session");
 
     // The seed leaves the date blank: a native `today()` fallback inks no field
     // region, so commit a real date first.
@@ -153,12 +146,9 @@ fn usaf_memo_date_region_rides_the_vendored_display() {
 /// endorser's date is the one memo field a preview cannot route a click to.
 #[test]
 fn a_blank_indorsement_date_regions_through_its_fill_in_widget() {
-    let engine = Quillmark::new();
-    let quill =
-        quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo should load");
     // The seed leaves the indorsement date blank, which is the fill-in case.
-    let parsed = quill.seed_document();
-    let session = engine.open(&quill, &parsed).expect("open a session");
+    let (engine, quill, parsed) = common::seeded_memo();
+    let session = engine.open(quill, &parsed).expect("open a session");
 
     let regions = session.regions();
     let date = regions
@@ -179,7 +169,7 @@ fn a_blank_indorsement_date_regions_through_its_fill_in_widget() {
 
     let pdf = engine
         .render(
-            &quill,
+            quill,
             &parsed,
             &RenderOptions::default().with_output_format(OutputFormat::Pdf),
         )

--- a/crates/quillmark/tests/usaf_memo_signature_test.rs
+++ b/crates/quillmark/tests/usaf_memo_signature_test.rs
@@ -5,8 +5,9 @@
 
 #![cfg(feature = "typst")]
 
-use quillmark::{OutputFormat, Quillmark, RenderOptions};
-use quillmark_fixtures::quills_path;
+use quillmark::{OutputFormat, RenderOptions};
+
+mod common;
 
 const PT_PER_IN: f32 = 72.0;
 const SIG_BLOCK_LEFT_IN: f32 = 4.5;
@@ -47,15 +48,11 @@ fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 
 #[test]
 fn usaf_memo_signature_widget_aligns_with_signature_block() {
-    let engine = Quillmark::new();
-    let quill =
-        quillmark::quill_from_path(quills_path("usaf_memo")).expect("usaf_memo should load");
-
     // One card per declared kind, so both `Signature` and `Ind_0_Signature` emit.
-    let parsed = quill.seed_document();
+    let (engine, quill, parsed) = common::seeded_memo();
 
     let result = engine.render(
-        &quill,
+        quill,
         &parsed,
         &RenderOptions::default().with_output_format(OutputFormat::Pdf),
     );


### PR DESCRIPTION
A comprehensive simplify review of the rust-facing codebase (Python, CLI, and WASM bindings out of scope), followed by the clear wins it surfaced. Six review passes covered `core/quill`, `core/document`, core top-level + the `quillmark` facade, `content`, the Typst backend, and `pdfform` + `quillmark-pdf`, each against four angles: reuse, simplification, efficiency, altitude. 53 of the 61 verified findings landed here; the ten that were complex, design-level, or behavior-changing are filed as #1328–#1337.

**Net: −245 lines** (1,829 insertions, 2,074 deletions across 53 files), with the hot paths cheaper:

- **Per-keystroke costs removed** — validation read the payload by deep copy, `build_payload` triple-cloned every parsed value, `apply_text_delta` cloned the whole line vector, `Content::validate` walked the text four times, the typst emitter rescanned the full mark list per segment, the meta literal and widget regions were rebuilt per apply, and `LiveSession` re-ran the backend region scan per query. All are now single-pass, borrowed, or cached per commit.
- **One definition per mechanism** — the typst `open`/`update` pipeline, the span-scan entry points, the pdf reader's object/trailer/dict/whitespace scanners, the stamp/flatten array splice, core's emission dispatch, prescan inspection, error constructors, and the discriminant-reading cascade each collapse to a single shared form.
- **Dead public API deleted** (the `!`): `FileTreeNode` query methods, `Payload::contains_key`, `PayloadItem::nested_comments`, the `QuillValue` scalar constructors, the `FieldSpec` builders, and two `normalize` helpers gone private — none had a caller in the workspace or bindings.
- **Two intentional output shifts**, both in the changelog entry: a blank pdfform document returns the base PDF unchanged instead of appending an orphan-font revision (new test pins it), and three `quillmark-pdf` parse-failure messages share one spelling (codes unchanged).

Verification: `cargo test --workspace` green (exit 0) after every slice and on the final head; `cargo check --workspace --all-targets` (bindings included) clean; the core/document changes were additionally diffed byte-for-byte against pre-change HEAD across emitted-markdown, parse, and error-display probes, and the pdfform flatten change was verified by hash-identical PDF/SVG/PNG/RGBA renders of the sample form in filled and blank states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFvUxgR244dFCVDpoebH94

---
_Generated by [Claude Code](https://claude.ai/code/session_01EFvUxgR244dFCVDpoebH94)_