### PR TITLE
core: restore the V0_81_0 and V0_82_0 storage read shims (#1327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- fix(core): **storage blobs tagged `@0.81.0` load again.** The `V0_81_0` read
+  shim retired in #929 is restored: a stored document carrying
+  `quillmark/document@0.81.0` migrates forward to the current model on read
+  instead of failing as an unknown schema version. #929 retired it on the basis
+  that nothing persisted on this lineage predates `@0.92.0`; #1327 reports
+  stored rows in that shape, so the premise was wrong. The migration is
+  structural (the sentinel becomes a prelude of typed `$` items, every other
+  item maps 1:1) and targets `V0_92_0` directly, skipping `@0.82.0`. The write
+  path is untouched: re-serializing a migrated row emits `@0.93.0`.
+
+  `@0.82.0` stays unreadable, on two grounds that do not apply to `@0.81.0`:
+  its tag never named one frozen shape (`0.82.0` was yanked, so `0.83.0`
+  extended that DTO in place under the same tag and every release through
+  `0.91.0` wrote it), and it carries the `$id` payload item that `0.100.0`
+  removed from the live model as a hard cutover. Reading it needs a policy
+  decision for `$id`, not just a restored type tree (#1327)
+
 - refactor!: **one definition per mechanism across the rust crates.** A
   whole-codebase simplify pass: the typst session compiles through one
   `recompile` pipeline whose derived tables (regions, span windows, page hashes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,30 @@
 
 ## Unreleased
 
-- fix(core): **storage blobs tagged `@0.81.0` load again.** The `V0_81_0` read
-  shim retired in #929 is restored: a stored document carrying
-  `quillmark/document@0.81.0` migrates forward to the current model on read
-  instead of failing as an unknown schema version. #929 retired it on the basis
-  that nothing persisted on this lineage predates `@0.92.0`; #1327 reports
-  stored rows in that shape, so the premise was wrong. The migration is
-  structural (the sentinel becomes a prelude of typed `$` items, every other
-  item maps 1:1) and targets `V0_92_0` directly, skipping `@0.82.0`. The write
-  path is untouched: re-serializing a migrated row emits `@0.93.0`.
+- fix(core): **storage blobs tagged `@0.81.0` and `@0.82.0` load again.** The
+  two read shims retired in #929 are restored: a stored document carrying
+  either tag migrates forward to the current model on read instead of failing
+  as an unknown schema version. Migrations chain again
+  (`V0_81_0 → V0_82_0 → V0_92_0 → V0_93_0`); the write path is untouched, so
+  re-serializing a migrated row emits `@0.93.0`.
 
-  `@0.82.0` stays unreadable, on two grounds that do not apply to `@0.81.0`:
-  its tag never named one frozen shape (`0.82.0` was yanked, so `0.83.0`
-  extended that DTO in place under the same tag and every release through
-  `0.91.0` wrote it), and it carries the `$id` payload item that `0.100.0`
-  removed from the live model as a hard cutover. Reading it needs a policy
-  decision for `$id`, not just a restored type tree (#1327)
+  The `V0_82_0 → V0_92_0` hop is **lossy in one place**: the `$id` payload item
+  is dropped. `0.100.0` removed `$id` from the live model as a hard cutover, so
+  the alternative is refusing the row. `$id` reached no backend and the engine
+  never read it; a consumer that kept a key there re-establishes it under a
+  `$ext` namespace it owns.
+
+  #929 retired both shims on two premises, both wrong. Nothing persisted on
+  this lineage was said to predate `@0.92.0` — #1327 reports stored `@0.81.0`
+  rows. And `0.82.0` was said to have been yanked — it was not. Every
+  published Quillmark version is live on crates.io, npm, and PyPI; the yank
+  was an intention recorded in the commit that added `$ext` (#630),
+  restated as settled fact in `docs/migrations/0.82-to-0.83.md`, and never
+  carried out. That guide now carries the correction. Because the yank never
+  happened, `@0.82.0` names a shape *union* rather than a frozen format —
+  `0.83.0` added `$ext` in place under the unchanged tag and every release
+  through `0.91.0` wrote it — so the restored reader accepts the union
+  (#1327)
 
 - refactor!: **one definition per mechanism across the rust crates.** A
   whole-codebase simplify pass: the typst session compiles through one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,30 +2,23 @@
 
 ## Unreleased
 
-- fix(core): **storage blobs tagged `@0.81.0` and `@0.82.0` load again.** The
-  two read shims retired in #929 are restored: a stored document carrying
-  either tag migrates forward to the current model on read instead of failing
-  as an unknown schema version. Migrations chain again
-  (`V0_81_0 → V0_82_0 → V0_92_0 → V0_93_0`); the write path is untouched, so
-  re-serializing a migrated row emits `@0.93.0`.
+- fix(core): **storage blobs tagged `@0.81.0` and `@0.82.0` load again.** Both
+  tags migrate forward on read instead of failing as an unknown schema version.
+  Migrations chain (`V0_81_0 → V0_82_0 → V0_92_0 → V0_93_0`); the write path is
+  untouched, so re-serializing a migrated row emits `@0.93.0`.
 
-  The `V0_82_0 → V0_92_0` hop is **lossy in one place**: the `$id` payload item
-  is dropped. `0.100.0` removed `$id` from the live model as a hard cutover, so
-  the alternative is refusing the row. `$id` reached no backend and the engine
-  never read it; a consumer that kept a key there re-establishes it under a
-  `$ext` namespace it owns.
+  The `V0_82_0` hop is **lossy in one place**: the `$id` payload item is
+  dropped, the live model having no counterpart for it. The alternative is
+  refusing the row. A consumer that kept a key under `$id` re-establishes it
+  under a `$ext` namespace it owns.
 
-  #929 retired both shims on two premises, both wrong. Nothing persisted on
-  this lineage was said to predate `@0.92.0` — #1327 reports stored `@0.81.0`
-  rows. And `0.82.0` was said to have been yanked — it was not. Every
-  published Quillmark version is live on crates.io, npm, and PyPI; the yank
-  was an intention recorded in the commit that added `$ext` (#630),
-  restated as settled fact in `docs/migrations/0.82-to-0.83.md`, and never
-  carried out. That guide now carries the correction. Because the yank never
-  happened, `@0.82.0` names a shape *union* rather than a frozen format —
-  `0.83.0` added `$ext` in place under the unchanged tag and every release
-  through `0.91.0` wrote it — so the restored reader accepts the union
-  (#1327)
+  This reverses the #929 retirement, whose two premises were both wrong. Rows
+  do predate `@0.92.0` — #1327 reports stored `@0.81.0` ones. And `0.82.0` was
+  not yanked: every published Quillmark version is live on crates.io, npm, and
+  PyPI. `docs/migrations/0.82-to-0.83.md`, which carried that claim, now
+  carries the correction. Because no yank happened, `@0.82.0` names a shape
+  union rather than a frozen format — every release from `0.83.0` through
+  `0.91.0` stamped it — so the restored reader accepts the union (#1327)
 
 - refactor!: **one definition per mechanism across the rust crates.** A
   whole-codebase simplify pass: the typst session compiles through one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@
   This reverses the #929 retirement, whose two premises were both wrong. Rows
   do predate `@0.92.0` — #1327 reports stored `@0.81.0` ones. And `0.82.0` was
   not yanked: every published Quillmark version is live on crates.io, npm, and
-  PyPI. `docs/migrations/0.82-to-0.83.md`, which carried that claim, now
-  carries the correction. Because no yank happened, `@0.82.0` names a shape
+  PyPI. Because no yank happened, `@0.82.0` names a shape
   union rather than a frozen format — every release from `0.83.0` through
   `0.91.0` stamped it — so the restored reader accepts the union (#1327)
 

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -18,12 +18,11 @@
 //!   per-field `nested_fills` list and the `$seed` item variant, body as a
 //!   markdown string. Read-only: the body cold-imports and the document
 //!   migrates forward to V0_93_0 on read.
-//! - **`quillmark/document@0.82.0`**: the same unified item list without
-//!   `nested_fills` or `$seed`, plus the `$id` item. Its tag names a shape
-//!   *union*, not a frozen format: `0.83.0` added `$ext` in place under the
-//!   unchanged tag, and every release through `0.91.0` wrote it. Read-only,
-//!   and the one **lossy** hop: `$id` is dropped, having no live counterpart
-//!   since `0.100.0` removed it.
+//! - **`quillmark/document@0.82.0`**: the same item list without
+//!   `nested_fills` or `$seed`, plus `$id`. The tag names a shape **union**
+//!   rather than one frozen format — `$ext` entered under it unchanged — so
+//!   the reader accepts every shape stamped with it. Read-only, and the one
+//!   **lossy** hop: `$id` has no live counterpart and is dropped.
 //! - **`quillmark/document@0.81.0`**: the oldest wire format still read. The
 //!   pre-unification shape: a separate `sentinel` (the typed `$quill` /
 //!   `$kind`) beside a `frontmatter` item list carrying user fields and
@@ -633,11 +632,9 @@ impl From<CommentPathSegmentV0_92_0> for CommentPathSegment {
 
 // ─── V0_81_0 wire format ──────────────────────────────────────────────────────
 //
-// Read + migrate-forward only. `0.81.0` is the sole release that wrote this tag,
-// so unlike `@0.82.0` it names one frozen shape.
-//
-// It predates `$id` (`0.82.0`) and `$ext` (`0.83.0`), so the forward hop below
-// loses nothing.
+// Read + migrate-forward only. One release wrote this tag, so unlike `@0.82.0`
+// it names one frozen shape. It carries neither `$id` nor `$ext`, so the hop
+// below is lossless.
 
 /// Frozen `0.81.0` representation of a [`Document`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -711,9 +708,8 @@ pub enum CommentPathSegmentV0_81_0 {
 
 // ─── V0_81_0 → V0_82_0 migration ──────────────────────────────────────────────
 //
-// Structural: the sentinel becomes a prelude of typed `$` items and every other
-// item maps 1:1. Typed validation — quill reference, field names, depth —
-// happens once, further down the chain.
+// Quill-reference, field-name, and depth validation happen once, further down
+// the chain.
 
 impl From<DocumentV0_81_0> for DocumentV0_82_0 {
     fn from(d: DocumentV0_81_0) -> Self {
@@ -728,9 +724,8 @@ impl From<CardV0_81_0> for CardV0_82_0 {
     fn from(c: CardV0_81_0) -> Self {
         let mut items: Vec<PayloadItemV0_82_0> = Vec::new();
 
-        // `Main` implies `$kind: main`, which V0_81_0 left implicit in the
-        // sentinel; the reconstructed model carries it so the markdown emit
-        // produces a parseable document.
+        // The sentinel leaves `$kind: main` implicit; the live model needs it
+        // explicit for the markdown emit to produce a parseable document.
         match c.sentinel {
             SentinelV0_81_0::Main { quill } => {
                 items.push(PayloadItemV0_82_0::Quill { value: quill });
@@ -743,8 +738,8 @@ impl From<CardV0_81_0> for CardV0_82_0 {
             }
         }
 
-        // V0_81_0 tracked no `$`-line comments, so comment positions migrate
-        // as-is, after the `$` prelude.
+        // Comments migrate as-is, landing after the `$` prelude: V0_81_0
+        // tracks no `$`-line comments to interleave them with.
         for item in c.frontmatter.items {
             items.push(match item {
                 FrontmatterItemV0_81_0::Field { key, value, fill } => {
@@ -797,10 +792,9 @@ impl From<CommentPathSegmentV0_81_0> for CommentPathSegmentV0_82_0 {
 
 // ─── V0_82_0 wire format ──────────────────────────────────────────────────────
 //
-// Read + migrate-forward only. Its tag names a shape *union*, not a frozen
-// format: `0.83.0` added `Ext` in place under the unchanged tag, and every
-// release through `0.91.0` wrote it. Accepting the union is what lets a row
-// from any of those writers load.
+// Read + migrate-forward only. The tag names a shape union, not one frozen
+// format: `Ext` entered under it unchanged. Accepting the union is what lets a
+// row from any writer that stamped `@0.82.0` decode here.
 
 /// Frozen `0.82.0` representation of a [`Document`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -835,10 +829,11 @@ pub enum PayloadItemV0_82_0 {
     Quill { value: String },
     /// `$kind` system metadata.
     Kind { value: String },
-    /// `$id` system metadata. The live model has no counterpart: `0.100.0`
-    /// removed `$id`, so this is the one item the forward migration drops.
+    /// `$id` system metadata. The live model has no counterpart, so this is
+    /// the one item the forward migration drops.
     Id { value: String },
-    /// `$ext` system metadata. Added by `0.83.0` under this same tag.
+    /// `$ext` system metadata: an opaque mapping carrying out-of-band
+    /// extension data.
     Ext {
         value: serde_json::Map<String, serde_json::Value>,
     },
@@ -873,14 +868,10 @@ pub enum CommentPathSegmentV0_82_0 {
     Index(usize),
 }
 
-// ─── V0_82_0 → V0_92_0 migration (lossy: `$id` is dropped) ────────────────────
+// ─── V0_82_0 → V0_92_0 migration ──────────────────────────────────────────────
 //
-// Every item maps 1:1 but `Id`, which has no live counterpart since `0.100.0`
-// removed `$id`. Dropping it is the deliberate trade: the alternative is
-// refusing to read the row at all, and `$id` reached no backend and was never
-// read by the engine. A consumer that kept a key there re-establishes it under
-// a `$ext` namespace it owns. The V0_92_0 additions are absent by construction:
-// `nested_fills` empty, no `Seed`.
+// Lossy by decision: `$id` has no live counterpart, and dropping it is chosen
+// over refusing the row.
 
 impl From<DocumentV0_82_0> for DocumentV0_92_0 {
     fn from(d: DocumentV0_82_0) -> Self {
@@ -918,7 +909,7 @@ impl From<PayloadV0_82_0> for PayloadV0_92_0 {
 }
 
 impl PayloadItemV0_92_0 {
-    /// `None` for the `$id` item, which has no live counterpart.
+    /// `None` for `$id`, which has no live counterpart.
     fn from_v0_82_0(item: PayloadItemV0_82_0) -> Option<Self> {
         Some(match item {
             PayloadItemV0_82_0::Id { .. } => return None,
@@ -1154,8 +1145,6 @@ title: Hi
 
     #[test]
     fn v0_82_0_ext_item_loads() {
-        // `$ext` was added under the unchanged `@0.82.0` tag by `0.83.0`, so a
-        // row from any writer through `0.91.0` carries it.
         let json = r#"{
             "schema": "quillmark/document@0.82.0",
             "main": {
@@ -1174,8 +1163,6 @@ title: Hi
 
     #[test]
     fn v0_82_0_id_item_is_dropped_not_rejected() {
-        // The one lossy hop. `$id` left the live model in `0.100.0`; a row
-        // carrying it loads without it rather than failing to load at all.
         let json = r#"{
             "schema": "quillmark/document@0.82.0",
             "main": {
@@ -1202,8 +1189,8 @@ title: Hi
 
     #[test]
     fn v0_82_0_seed_item_is_rejected() {
-        // `$seed` is what the `@0.92.0` bump was for; it is not a legal
-        // `@0.82.0` item, so a blob claiming the older tag must not load.
+        // `$seed` is what the `@0.92.0` bump added: a blob claiming the older
+        // tag cannot legitimately carry one.
         let json = r#"{
             "schema": "quillmark/document@0.82.0",
             "main": {
@@ -1274,9 +1261,9 @@ title: Hi
 
     #[test]
     fn v0_81_0_comments_and_fill_survive_the_migration() {
-        // The two things the sentinel split could have dropped: comment order
-        // relative to the `$` prelude, and nested-comment paths, which V0_81_0
-        // carried in the same payload-level absolute form V0_92_0 uses.
+        // The two the sentinel split could drop: comment order against the `$`
+        // prelude, and nested-comment paths, whose absolute payload-level form
+        // V0_81_0 and V0_92_0 share.
         let json = r#"{
             "schema": "quillmark/document@0.81.0",
             "main": {
@@ -1306,8 +1293,7 @@ title: Hi
         assert!(md.contains("!must_fill"), "{md}");
         assert!(md.contains("# inline note"), "{md}");
 
-        // The migrated document equals the same document re-parsed from its
-        // own markdown: the migration invents nothing the parser would not.
+        // The migration invents nothing the parser would not.
         let reparsed = Document::parse(&md).unwrap().document;
         assert_eq!(doc, reparsed);
     }

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -1313,26 +1313,6 @@ title: Hi
     }
 
     #[test]
-    fn v0_81_0_body_that_cannot_import_is_a_clean_error() {
-        // The one fallible hop: the stored markdown body cold-imports through
-        // the V0_92_0 → V0_93_0 migration, so a body no parse could produce
-        // reports rather than aborting.
-        let deep = "> ".repeat(512) + "x";
-        let json = serde_json::json!({
-            "schema": "quillmark/document@0.81.0",
-            "main": {
-                "sentinel": {"kind": "main", "quill": "q@1.0"},
-                "frontmatter": {"items": []},
-                "body": deep
-            },
-            "cards": []
-        })
-        .to_string();
-        // Either it imports or it reports; it never panics.
-        let _ = serde_json::from_str::<Document>(&json);
-    }
-
-    #[test]
     fn rejects_main_card_without_quill() {
         let json = r#"{
             "schema": "quillmark/document@0.92.0",

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -18,15 +18,16 @@
 //!   per-field `nested_fills` list and the `$seed` item variant, body as a
 //!   markdown string. Read-only: the body cold-imports and the document
 //!   migrates forward to V0_93_0 on read.
+//! - **`quillmark/document@0.82.0`**: the same unified item list without
+//!   `nested_fills` or `$seed`, plus the `$id` item. Its tag names a shape
+//!   *union*, not a frozen format: `0.83.0` added `$ext` in place under the
+//!   unchanged tag, and every release through `0.91.0` wrote it. Read-only,
+//!   and the one **lossy** hop: `$id` is dropped, having no live counterpart
+//!   since `0.100.0` removed it.
 //! - **`quillmark/document@0.81.0`**: the oldest wire format still read. The
 //!   pre-unification shape: a separate `sentinel` (the typed `$quill` /
 //!   `$kind`) beside a `frontmatter` item list carrying user fields and
-//!   comments only. Read-only, migrated forward to V0_92_0 on read.
-//!
-//!   `@0.82.0` sits between the two and has **no reader**. Its tag never named
-//!   one frozen shape: `0.82.0` was yanked, so the `0.83.0`–`0.91.0` releases
-//!   extended that DTO in place under the same tag. It also carries the `$id`
-//!   item, which the live model no longer has any home for.
+//!   comments only. Read-only, migrated forward to V0_82_0 on read.
 //!
 //! The canonical design (including the step-by-step procedure for adding
 //! a schema version) is `prose/canon/DOCUMENT_STORAGE.md`.
@@ -86,9 +87,13 @@ pub enum StoredDocument {
     /// migrated forward to V0_93_0 on reconstruction.
     #[serde(rename = "quillmark/document@0.92.0")]
     V0_92_0(DocumentV0_92_0),
+    /// Legacy (V0_82_0) document model: unified payload items without
+    /// `nested_fills` or `$seed`, carrying `$id`. Read-only; migrated forward
+    /// on reconstruction, dropping `$id`.
+    #[serde(rename = "quillmark/document@0.82.0")]
+    V0_82_0(DocumentV0_82_0),
     /// Legacy (V0_81_0) document model: a separate `sentinel` beside a
-    /// `frontmatter` item list. Read-only; migrated forward to V0_92_0 on
-    /// reconstruction.
+    /// `frontmatter` item list. Read-only; migrated forward on reconstruction.
     #[serde(rename = "quillmark/document@0.81.0")]
     V0_81_0(DocumentV0_81_0),
 }
@@ -403,15 +408,18 @@ impl TryFrom<StoredDocument> for Document {
 
     fn try_from(stored: StoredDocument) -> Result<Self, Self::Error> {
         // Only the newest DTO converts to the live model; older versions migrate
-        // forward (V0_81 → V0_92 → V0_93). The V0_92 → V0_93 hop cold-imports the
-        // body, so every arm below the newest is fallible.
+        // forward (V0_81 → V0_82 → V0_92 → V0_93). The V0_92 → V0_93 hop
+        // cold-imports the body, so every arm below the newest is fallible.
         match stored {
             StoredDocument::V0_93_0(payload) => Document::try_from(payload),
             StoredDocument::V0_92_0(payload) => {
                 Document::try_from(DocumentV0_93_0::try_from(payload)?)
             }
-            StoredDocument::V0_81_0(payload) => Document::try_from(DocumentV0_93_0::try_from(
+            StoredDocument::V0_82_0(payload) => Document::try_from(DocumentV0_93_0::try_from(
                 DocumentV0_92_0::from(payload),
+            )?),
+            StoredDocument::V0_81_0(payload) => Document::try_from(DocumentV0_93_0::try_from(
+                DocumentV0_92_0::from(DocumentV0_82_0::from(payload)),
             )?),
         }
     }
@@ -627,6 +635,9 @@ impl From<CommentPathSegmentV0_92_0> for CommentPathSegment {
 //
 // Read + migrate-forward only. `0.81.0` is the sole release that wrote this tag,
 // so unlike `@0.82.0` it names one frozen shape.
+//
+// It predates `$id` (`0.82.0`) and `$ext` (`0.83.0`), so the forward hop below
+// loses nothing.
 
 /// Frozen `0.81.0` representation of a [`Document`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -698,39 +709,37 @@ pub enum CommentPathSegmentV0_81_0 {
     Index(usize),
 }
 
-// ─── V0_81_0 → V0_92_0 migration ──────────────────────────────────────────────
+// ─── V0_81_0 → V0_82_0 migration ──────────────────────────────────────────────
 //
-// Purely structural, and it skips the retired `@0.82.0` tree: the sentinel
-// becomes a prelude of typed `$` items, every other item maps 1:1, and the
-// V0_92_0 additions are absent by construction (`nested_fills` empty, no `Seed`).
-// Typed validation — quill reference, field names, depth — happens once, on the
-// V0_92_0 side.
+// Structural: the sentinel becomes a prelude of typed `$` items and every other
+// item maps 1:1. Typed validation — quill reference, field names, depth —
+// happens once, further down the chain.
 
-impl From<DocumentV0_81_0> for DocumentV0_92_0 {
+impl From<DocumentV0_81_0> for DocumentV0_82_0 {
     fn from(d: DocumentV0_81_0) -> Self {
-        DocumentV0_92_0 {
-            main: CardV0_92_0::from(d.main),
-            cards: d.cards.into_iter().map(CardV0_92_0::from).collect(),
+        DocumentV0_82_0 {
+            main: CardV0_82_0::from(d.main),
+            cards: d.cards.into_iter().map(CardV0_82_0::from).collect(),
         }
     }
 }
 
-impl From<CardV0_81_0> for CardV0_92_0 {
+impl From<CardV0_81_0> for CardV0_82_0 {
     fn from(c: CardV0_81_0) -> Self {
-        let mut items: Vec<PayloadItemV0_92_0> = Vec::new();
+        let mut items: Vec<PayloadItemV0_82_0> = Vec::new();
 
         // `Main` implies `$kind: main`, which V0_81_0 left implicit in the
         // sentinel; the reconstructed model carries it so the markdown emit
         // produces a parseable document.
         match c.sentinel {
             SentinelV0_81_0::Main { quill } => {
-                items.push(PayloadItemV0_92_0::Quill { value: quill });
-                items.push(PayloadItemV0_92_0::Kind {
+                items.push(PayloadItemV0_82_0::Quill { value: quill });
+                items.push(PayloadItemV0_82_0::Kind {
                     value: "main".into(),
                 });
             }
             SentinelV0_81_0::Card { tag } => {
-                items.push(PayloadItemV0_92_0::Kind { value: tag });
+                items.push(PayloadItemV0_82_0::Kind { value: tag });
             }
         }
 
@@ -739,27 +748,22 @@ impl From<CardV0_81_0> for CardV0_92_0 {
         for item in c.frontmatter.items {
             items.push(match item {
                 FrontmatterItemV0_81_0::Field { key, value, fill } => {
-                    PayloadItemV0_92_0::Field {
-                        key,
-                        value,
-                        fill,
-                        nested_fills: Vec::new(),
-                    }
+                    PayloadItemV0_82_0::Field { key, value, fill }
                 }
                 FrontmatterItemV0_81_0::Comment { text, inline } => {
-                    PayloadItemV0_92_0::Comment { text, inline }
+                    PayloadItemV0_82_0::Comment { text, inline }
                 }
             });
         }
 
-        CardV0_92_0 {
-            payload: PayloadV0_92_0 {
+        CardV0_82_0 {
+            payload: PayloadV0_82_0 {
                 items,
                 nested_comments: c
                     .frontmatter
                     .nested_comments
                     .into_iter()
-                    .map(NestedCommentV0_92_0::from)
+                    .map(NestedCommentV0_82_0::from)
                     .collect(),
             },
             body: c.body,
@@ -767,8 +771,175 @@ impl From<CardV0_81_0> for CardV0_92_0 {
     }
 }
 
-impl From<NestedCommentV0_81_0> for NestedCommentV0_92_0 {
+impl From<NestedCommentV0_81_0> for NestedCommentV0_82_0 {
     fn from(nc: NestedCommentV0_81_0) -> Self {
+        NestedCommentV0_82_0 {
+            container_path: nc
+                .container_path
+                .into_iter()
+                .map(CommentPathSegmentV0_82_0::from)
+                .collect(),
+            position: nc.position,
+            text: nc.text,
+            inline: nc.inline,
+        }
+    }
+}
+
+impl From<CommentPathSegmentV0_81_0> for CommentPathSegmentV0_82_0 {
+    fn from(seg: CommentPathSegmentV0_81_0) -> Self {
+        match seg {
+            CommentPathSegmentV0_81_0::Key(k) => CommentPathSegmentV0_82_0::Key(k),
+            CommentPathSegmentV0_81_0::Index(i) => CommentPathSegmentV0_82_0::Index(i),
+        }
+    }
+}
+
+// ─── V0_82_0 wire format ──────────────────────────────────────────────────────
+//
+// Read + migrate-forward only. Its tag names a shape *union*, not a frozen
+// format: `0.83.0` added `Ext` in place under the unchanged tag, and every
+// release through `0.91.0` wrote it. Accepting the union is what lets a row
+// from any of those writers load.
+
+/// Frozen `0.82.0` representation of a [`Document`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DocumentV0_82_0 {
+    pub main: CardV0_82_0,
+    #[serde(default)]
+    pub cards: Vec<CardV0_82_0>,
+}
+
+/// Frozen `0.82.0` representation of a [`Card`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CardV0_82_0 {
+    pub payload: PayloadV0_82_0,
+    #[serde(default)]
+    pub body: String,
+}
+
+/// Frozen `0.82.0` representation of a [`Payload`].
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct PayloadV0_82_0 {
+    #[serde(default)]
+    pub items: Vec<PayloadItemV0_82_0>,
+    #[serde(default)]
+    pub nested_comments: Vec<NestedCommentV0_82_0>,
+}
+
+/// Frozen `0.82.0` representation of a unified payload item.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum PayloadItemV0_82_0 {
+    /// `$quill` system metadata: the quill reference string.
+    Quill { value: String },
+    /// `$kind` system metadata.
+    Kind { value: String },
+    /// `$id` system metadata. The live model has no counterpart: `0.100.0`
+    /// removed `$id`, so this is the one item the forward migration drops.
+    Id { value: String },
+    /// `$ext` system metadata. Added by `0.83.0` under this same tag.
+    Ext {
+        value: serde_json::Map<String, serde_json::Value>,
+    },
+    /// A user-defined field.
+    Field {
+        key: String,
+        value: serde_json::Value,
+        #[serde(default)]
+        fill: bool,
+    },
+    /// A YAML comment.
+    Comment {
+        text: String,
+        #[serde(default)]
+        inline: bool,
+    },
+}
+
+/// Frozen `0.82.0` representation of a [`NestedComment`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NestedCommentV0_82_0 {
+    pub container_path: Vec<CommentPathSegmentV0_82_0>,
+    pub position: usize,
+    pub text: String,
+    pub inline: bool,
+}
+
+/// Frozen `0.82.0` representation of a [`CommentPathSegment`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum CommentPathSegmentV0_82_0 {
+    Key(String),
+    Index(usize),
+}
+
+// ─── V0_82_0 → V0_92_0 migration (lossy: `$id` is dropped) ────────────────────
+//
+// Every item maps 1:1 but `Id`, which has no live counterpart since `0.100.0`
+// removed `$id`. Dropping it is the deliberate trade: the alternative is
+// refusing to read the row at all, and `$id` reached no backend and was never
+// read by the engine. A consumer that kept a key there re-establishes it under
+// a `$ext` namespace it owns. The V0_92_0 additions are absent by construction:
+// `nested_fills` empty, no `Seed`.
+
+impl From<DocumentV0_82_0> for DocumentV0_92_0 {
+    fn from(d: DocumentV0_82_0) -> Self {
+        DocumentV0_92_0 {
+            main: CardV0_92_0::from(d.main),
+            cards: d.cards.into_iter().map(CardV0_92_0::from).collect(),
+        }
+    }
+}
+
+impl From<CardV0_82_0> for CardV0_92_0 {
+    fn from(c: CardV0_82_0) -> Self {
+        CardV0_92_0 {
+            payload: PayloadV0_92_0::from(c.payload),
+            body: c.body,
+        }
+    }
+}
+
+impl From<PayloadV0_82_0> for PayloadV0_92_0 {
+    fn from(p: PayloadV0_82_0) -> Self {
+        PayloadV0_92_0 {
+            items: p
+                .items
+                .into_iter()
+                .filter_map(PayloadItemV0_92_0::from_v0_82_0)
+                .collect(),
+            nested_comments: p
+                .nested_comments
+                .into_iter()
+                .map(NestedCommentV0_92_0::from)
+                .collect(),
+        }
+    }
+}
+
+impl PayloadItemV0_92_0 {
+    /// `None` for the `$id` item, which has no live counterpart.
+    fn from_v0_82_0(item: PayloadItemV0_82_0) -> Option<Self> {
+        Some(match item {
+            PayloadItemV0_82_0::Id { .. } => return None,
+            PayloadItemV0_82_0::Quill { value } => PayloadItemV0_92_0::Quill { value },
+            PayloadItemV0_82_0::Kind { value } => PayloadItemV0_92_0::Kind { value },
+            PayloadItemV0_82_0::Ext { value } => PayloadItemV0_92_0::Ext { value },
+            PayloadItemV0_82_0::Field { key, value, fill } => PayloadItemV0_92_0::Field {
+                key,
+                value,
+                fill,
+                nested_fills: Vec::new(),
+            },
+            PayloadItemV0_82_0::Comment { text, inline } => {
+                PayloadItemV0_92_0::Comment { text, inline }
+            }
+        })
+    }
+}
+
+impl From<NestedCommentV0_82_0> for NestedCommentV0_92_0 {
+    fn from(nc: NestedCommentV0_82_0) -> Self {
         NestedCommentV0_92_0 {
             container_path: nc
                 .container_path
@@ -782,11 +953,11 @@ impl From<NestedCommentV0_81_0> for NestedCommentV0_92_0 {
     }
 }
 
-impl From<CommentPathSegmentV0_81_0> for CommentPathSegmentV0_92_0 {
-    fn from(seg: CommentPathSegmentV0_81_0) -> Self {
+impl From<CommentPathSegmentV0_82_0> for CommentPathSegmentV0_92_0 {
+    fn from(seg: CommentPathSegmentV0_82_0) -> Self {
         match seg {
-            CommentPathSegmentV0_81_0::Key(k) => CommentPathSegmentV0_92_0::Key(k),
-            CommentPathSegmentV0_81_0::Index(i) => CommentPathSegmentV0_92_0::Index(i),
+            CommentPathSegmentV0_82_0::Key(k) => CommentPathSegmentV0_92_0::Key(k),
+            CommentPathSegmentV0_82_0::Index(i) => CommentPathSegmentV0_92_0::Index(i),
         }
     }
 }
@@ -955,11 +1126,96 @@ title: Hi
     }
 
     #[test]
-    fn retired_v0_82_0_schema_tag_is_rejected() {
-        // `@0.82.0` has no reader: rejected, never migrated. Its tag never named
-        // one frozen shape (yanked release, extended in place through 0.91.0).
-        let json = r#"{"schema":"quillmark/document@0.82.0",
-            "main":{"payload":{"items":[]},"body":""},"cards":[]}"#;
+    fn v0_82_0_payload_loads_via_migration() {
+        let json = r#"{
+            "schema": "quillmark/document@0.82.0",
+            "main": {
+                "payload": {"items": [
+                    {"type": "quill", "value": "usaf_memo@0.1"},
+                    {"type": "kind", "value": "main"},
+                    {"type": "field", "key": "title", "value": "Hello"}
+                ]},
+                "body": "Body."
+            },
+            "cards": []
+        }"#;
+        let doc: Document = serde_json::from_str(json).unwrap();
+        assert_eq!(doc.main().kind(), Some("main"));
+        assert_eq!(
+            doc.main().payload().get("title").unwrap().as_str(),
+            Some("Hello")
+        );
+        let reser = serde_json::to_string(&doc).unwrap();
+        assert_eq!(
+            peek_storage_version(&reser).as_deref(),
+            Some(STORAGE_V0_93_0)
+        );
+    }
+
+    #[test]
+    fn v0_82_0_ext_item_loads() {
+        // `$ext` was added under the unchanged `@0.82.0` tag by `0.83.0`, so a
+        // row from any writer through `0.91.0` carries it.
+        let json = r#"{
+            "schema": "quillmark/document@0.82.0",
+            "main": {
+                "payload": {"items": [
+                    {"type": "quill", "value": "q@1.0"},
+                    {"type": "kind", "value": "main"},
+                    {"type": "ext", "value": {"editor": {"pinned": true}}}
+                ]},
+                "body": ""
+            },
+            "cards": []
+        }"#;
+        let doc: Document = serde_json::from_str(json).unwrap();
+        assert!(doc.main().ext().is_some());
+    }
+
+    #[test]
+    fn v0_82_0_id_item_is_dropped_not_rejected() {
+        // The one lossy hop. `$id` left the live model in `0.100.0`; a row
+        // carrying it loads without it rather than failing to load at all.
+        let json = r#"{
+            "schema": "quillmark/document@0.82.0",
+            "main": {
+                "payload": {"items": [
+                    {"type": "quill", "value": "q@1.0"},
+                    {"type": "kind", "value": "main"},
+                    {"type": "id", "value": "card-7"},
+                    {"type": "field", "key": "title", "value": "Hello"}
+                ]},
+                "body": ""
+            },
+            "cards": []
+        }"#;
+        let doc: Document = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            doc.main().payload().get("title").unwrap().as_str(),
+            Some("Hello")
+        );
+        let md = doc.to_markdown();
+        assert!(!md.contains("$id"), "{md}");
+        assert!(!md.contains("card-7"), "{md}");
+        assert_eq!(doc, Document::parse(&md).unwrap().document);
+    }
+
+    #[test]
+    fn v0_82_0_seed_item_is_rejected() {
+        // `$seed` is what the `@0.92.0` bump was for; it is not a legal
+        // `@0.82.0` item, so a blob claiming the older tag must not load.
+        let json = r#"{
+            "schema": "quillmark/document@0.82.0",
+            "main": {
+                "payload": {"items": [
+                    {"type": "quill", "value": "q@1.0"},
+                    {"type": "kind", "value": "main"},
+                    {"type": "seed", "value": {"indorsement": {"from": "X"}}}
+                ]},
+                "body": ""
+            },
+            "cards": []
+        }"#;
         assert!(serde_json::from_str::<Document>(json).is_err());
     }
 

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -14,10 +14,19 @@
 //!   `to_canonical_json`), not a markdown string. Two byte disciplines in one
 //!   envelope: the outer structure is compact `serde_json` in struct +
 //!   payload-insertion order, every `body` subtree is recursively key-sorted.
-//! - **`quillmark/document@0.92.0`**: the oldest wire format still read. The
-//!   unified [`Payload`] item list with a per-field `nested_fills` list and the
-//!   `$seed` item variant, body as a markdown string. Read-only: the body
-//!   cold-imports and the document migrates forward to V0_93_0 on read.
+//! - **`quillmark/document@0.92.0`**: the unified [`Payload`] item list with a
+//!   per-field `nested_fills` list and the `$seed` item variant, body as a
+//!   markdown string. Read-only: the body cold-imports and the document
+//!   migrates forward to V0_93_0 on read.
+//! - **`quillmark/document@0.81.0`**: the oldest wire format still read. The
+//!   pre-unification shape: a separate `sentinel` (the typed `$quill` /
+//!   `$kind`) beside a `frontmatter` item list carrying user fields and
+//!   comments only. Read-only, migrated forward to V0_92_0 on read.
+//!
+//!   `@0.82.0` sits between the two and has **no reader**. Its tag never named
+//!   one frozen shape: `0.82.0` was yanked, so the `0.83.0`–`0.91.0` releases
+//!   extended that DTO in place under the same tag. It also carries the `$id`
+//!   item, which the live model no longer has any home for.
 //!
 //! The canonical design (including the step-by-step procedure for adding
 //! a schema version) is `prose/canon/DOCUMENT_STORAGE.md`.
@@ -77,6 +86,11 @@ pub enum StoredDocument {
     /// migrated forward to V0_93_0 on reconstruction.
     #[serde(rename = "quillmark/document@0.92.0")]
     V0_92_0(DocumentV0_92_0),
+    /// Legacy (V0_81_0) document model: a separate `sentinel` beside a
+    /// `frontmatter` item list. Read-only; migrated forward to V0_92_0 on
+    /// reconstruction.
+    #[serde(rename = "quillmark/document@0.81.0")]
+    V0_81_0(DocumentV0_81_0),
 }
 
 /// Failure while reconstructing a [`Document`] from a [`StoredDocument`].
@@ -389,12 +403,16 @@ impl TryFrom<StoredDocument> for Document {
 
     fn try_from(stored: StoredDocument) -> Result<Self, Self::Error> {
         // Only the newest DTO converts to the live model; older versions migrate
-        // forward. The V0_92 → V0_93 hop cold-imports the body, so it is fallible.
+        // forward (V0_81 → V0_92 → V0_93). The V0_92 → V0_93 hop cold-imports the
+        // body, so every arm below the newest is fallible.
         match stored {
             StoredDocument::V0_93_0(payload) => Document::try_from(payload),
             StoredDocument::V0_92_0(payload) => {
                 Document::try_from(DocumentV0_93_0::try_from(payload)?)
             }
+            StoredDocument::V0_81_0(payload) => Document::try_from(DocumentV0_93_0::try_from(
+                DocumentV0_92_0::from(payload),
+            )?),
         }
     }
 }
@@ -605,6 +623,174 @@ impl From<CommentPathSegmentV0_92_0> for CommentPathSegment {
     }
 }
 
+// ─── V0_81_0 wire format ──────────────────────────────────────────────────────
+//
+// Read + migrate-forward only. `0.81.0` is the sole release that wrote this tag,
+// so unlike `@0.82.0` it names one frozen shape.
+
+/// Frozen `0.81.0` representation of a [`Document`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DocumentV0_81_0 {
+    pub main: CardV0_81_0,
+    #[serde(default)]
+    pub cards: Vec<CardV0_81_0>,
+}
+
+/// Frozen `0.81.0` representation of a [`Card`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CardV0_81_0 {
+    pub sentinel: SentinelV0_81_0,
+    #[serde(default)]
+    pub frontmatter: FrontmatterV0_81_0,
+    #[serde(default)]
+    pub body: String,
+}
+
+/// Frozen `0.81.0` representation of a card discriminator (sentinel).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum SentinelV0_81_0 {
+    Main { quill: String },
+    Card { tag: String },
+}
+
+/// Frozen `0.81.0` representation of a card payload (user fields only).
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct FrontmatterV0_81_0 {
+    #[serde(default)]
+    pub items: Vec<FrontmatterItemV0_81_0>,
+    #[serde(default)]
+    pub nested_comments: Vec<NestedCommentV0_81_0>,
+}
+
+/// Frozen `0.81.0` representation of a payload item. The `$` entries live in
+/// the sentinel, and neither `$ext` (`0.83.0`) nor `$seed` (`0.92.0`) existed,
+/// so `Field` and `Comment` are the whole set.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum FrontmatterItemV0_81_0 {
+    Field {
+        key: String,
+        value: serde_json::Value,
+        #[serde(default)]
+        fill: bool,
+    },
+    Comment {
+        text: String,
+        #[serde(default)]
+        inline: bool,
+    },
+}
+
+/// Frozen `0.81.0` representation of a [`NestedComment`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NestedCommentV0_81_0 {
+    pub container_path: Vec<CommentPathSegmentV0_81_0>,
+    pub position: usize,
+    pub text: String,
+    pub inline: bool,
+}
+
+/// Frozen `0.81.0` representation of a [`CommentPathSegment`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum CommentPathSegmentV0_81_0 {
+    Key(String),
+    Index(usize),
+}
+
+// ─── V0_81_0 → V0_92_0 migration ──────────────────────────────────────────────
+//
+// Purely structural, and it skips the retired `@0.82.0` tree: the sentinel
+// becomes a prelude of typed `$` items, every other item maps 1:1, and the
+// V0_92_0 additions are absent by construction (`nested_fills` empty, no `Seed`).
+// Typed validation — quill reference, field names, depth — happens once, on the
+// V0_92_0 side.
+
+impl From<DocumentV0_81_0> for DocumentV0_92_0 {
+    fn from(d: DocumentV0_81_0) -> Self {
+        DocumentV0_92_0 {
+            main: CardV0_92_0::from(d.main),
+            cards: d.cards.into_iter().map(CardV0_92_0::from).collect(),
+        }
+    }
+}
+
+impl From<CardV0_81_0> for CardV0_92_0 {
+    fn from(c: CardV0_81_0) -> Self {
+        let mut items: Vec<PayloadItemV0_92_0> = Vec::new();
+
+        // `Main` implies `$kind: main`, which V0_81_0 left implicit in the
+        // sentinel; the reconstructed model carries it so the markdown emit
+        // produces a parseable document.
+        match c.sentinel {
+            SentinelV0_81_0::Main { quill } => {
+                items.push(PayloadItemV0_92_0::Quill { value: quill });
+                items.push(PayloadItemV0_92_0::Kind {
+                    value: "main".into(),
+                });
+            }
+            SentinelV0_81_0::Card { tag } => {
+                items.push(PayloadItemV0_92_0::Kind { value: tag });
+            }
+        }
+
+        // V0_81_0 tracked no `$`-line comments, so comment positions migrate
+        // as-is, after the `$` prelude.
+        for item in c.frontmatter.items {
+            items.push(match item {
+                FrontmatterItemV0_81_0::Field { key, value, fill } => {
+                    PayloadItemV0_92_0::Field {
+                        key,
+                        value,
+                        fill,
+                        nested_fills: Vec::new(),
+                    }
+                }
+                FrontmatterItemV0_81_0::Comment { text, inline } => {
+                    PayloadItemV0_92_0::Comment { text, inline }
+                }
+            });
+        }
+
+        CardV0_92_0 {
+            payload: PayloadV0_92_0 {
+                items,
+                nested_comments: c
+                    .frontmatter
+                    .nested_comments
+                    .into_iter()
+                    .map(NestedCommentV0_92_0::from)
+                    .collect(),
+            },
+            body: c.body,
+        }
+    }
+}
+
+impl From<NestedCommentV0_81_0> for NestedCommentV0_92_0 {
+    fn from(nc: NestedCommentV0_81_0) -> Self {
+        NestedCommentV0_92_0 {
+            container_path: nc
+                .container_path
+                .into_iter()
+                .map(CommentPathSegmentV0_92_0::from)
+                .collect(),
+            position: nc.position,
+            text: nc.text,
+            inline: nc.inline,
+        }
+    }
+}
+
+impl From<CommentPathSegmentV0_81_0> for CommentPathSegmentV0_92_0 {
+    fn from(seg: CommentPathSegmentV0_81_0) -> Self {
+        match seg {
+            CommentPathSegmentV0_81_0::Key(k) => CommentPathSegmentV0_92_0::Key(k),
+            CommentPathSegmentV0_81_0::Index(i) => CommentPathSegmentV0_92_0::Index(i),
+        }
+    }
+}
+
 /// Reject a payload no markdown-parsed `Document` could produce: too many
 /// fields or a duplicate user-field key. The markdown parser already
 /// rejects both; this only guards hand-crafted storage DTOs.
@@ -769,17 +955,125 @@ title: Hi
     }
 
     #[test]
-    fn retired_legacy_schema_tags_are_rejected() {
-        // `@0.81.0` and `@0.82.0` have no reader: rejected, never migrated.
-        for tag in ["quillmark/document@0.81.0", "quillmark/document@0.82.0"] {
-            let json = format!(
-                r#"{{"schema":"{tag}","main":{{"payload":{{"items":[]}},"body":""}},"cards":[]}}"#
-            );
-            assert!(
-                serde_json::from_str::<Document>(&json).is_err(),
-                "expected {tag} to be rejected as an unknown schema"
-            );
-        }
+    fn retired_v0_82_0_schema_tag_is_rejected() {
+        // `@0.82.0` has no reader: rejected, never migrated. Its tag never named
+        // one frozen shape (yanked release, extended in place through 0.91.0).
+        let json = r#"{"schema":"quillmark/document@0.82.0",
+            "main":{"payload":{"items":[]},"body":""},"cards":[]}"#;
+        assert!(serde_json::from_str::<Document>(json).is_err());
+    }
+
+    #[test]
+    fn v0_81_0_payload_loads_via_migration() {
+        let json = r#"{
+            "schema": "quillmark/document@0.81.0",
+            "main": {
+                "sentinel": {"kind": "main", "quill": "usaf_memo@0.1"},
+                "frontmatter": {
+                    "items": [{"kind": "field", "key": "title", "value": "Hello"}]
+                },
+                "body": "Body."
+            },
+            "cards": []
+        }"#;
+        let doc: Document = serde_json::from_str(json).unwrap();
+        assert_eq!(doc.main().kind(), Some("main"));
+        assert_eq!(doc.quill_reference().to_string(), "usaf_memo@0.1");
+        assert_eq!(
+            doc.main().payload().get("title").unwrap().as_str(),
+            Some("Hello")
+        );
+        let reser = serde_json::to_string(&doc).unwrap();
+        assert_eq!(
+            peek_storage_version(&reser).as_deref(),
+            Some(STORAGE_V0_93_0)
+        );
+    }
+
+    #[test]
+    fn v0_81_0_with_composable_card_migrates() {
+        let json = r#"{
+            "schema": "quillmark/document@0.81.0",
+            "main": {
+                "sentinel": {"kind": "main", "quill": "q@1.0"},
+                "frontmatter": {"items": []},
+                "body": ""
+            },
+            "cards": [
+                {
+                    "sentinel": {"kind": "card", "tag": "indorsement"},
+                    "frontmatter": {"items": [{"kind": "field", "key": "for", "value": "X"}]},
+                    "body": "C body"
+                }
+            ]
+        }"#;
+        let doc: Document = serde_json::from_str(json).unwrap();
+        assert_eq!(doc.cards().len(), 1);
+        assert_eq!(doc.cards()[0].kind(), Some("indorsement"));
+        assert_eq!(
+            doc.cards()[0].payload().get("for").unwrap().as_str(),
+            Some("X")
+        );
+    }
+
+    #[test]
+    fn v0_81_0_comments_and_fill_survive_the_migration() {
+        // The two things the sentinel split could have dropped: comment order
+        // relative to the `$` prelude, and nested-comment paths, which V0_81_0
+        // carried in the same payload-level absolute form V0_92_0 uses.
+        let json = r#"{
+            "schema": "quillmark/document@0.81.0",
+            "main": {
+                "sentinel": {"kind": "main", "quill": "q@1.0"},
+                "frontmatter": {
+                    "items": [
+                        {"kind": "comment", "text": "a top-level comment"},
+                        {"kind": "field", "key": "subject", "value": "S", "fill": true},
+                        {"kind": "field", "key": "memo_for", "value": ["ORG/SYMBOL"]}
+                    ],
+                    "nested_comments": [
+                        {
+                            "container_path": [{"Key": "memo_for"}],
+                            "position": 0,
+                            "text": "inline note",
+                            "inline": true
+                        }
+                    ]
+                },
+                "body": "Body."
+            },
+            "cards": []
+        }"#;
+        let doc: Document = serde_json::from_str(json).unwrap();
+        let md = doc.to_markdown();
+        assert!(md.contains("# a top-level comment"), "{md}");
+        assert!(md.contains("!must_fill"), "{md}");
+        assert!(md.contains("# inline note"), "{md}");
+
+        // The migrated document equals the same document re-parsed from its
+        // own markdown: the migration invents nothing the parser would not.
+        let reparsed = Document::parse(&md).unwrap().document;
+        assert_eq!(doc, reparsed);
+    }
+
+    #[test]
+    fn v0_81_0_body_that_cannot_import_is_a_clean_error() {
+        // The one fallible hop: the stored markdown body cold-imports through
+        // the V0_92_0 → V0_93_0 migration, so a body no parse could produce
+        // reports rather than aborting.
+        let deep = "> ".repeat(512) + "x";
+        let json = serde_json::json!({
+            "schema": "quillmark/document@0.81.0",
+            "main": {
+                "sentinel": {"kind": "main", "quill": "q@1.0"},
+                "frontmatter": {"items": []},
+                "body": deep
+            },
+            "cards": []
+        })
+        .to_string();
+        // Either it imports or it reports; it never panics.
+        let _ = serde_json::from_str::<Document>(&json);
     }
 
     #[test]

--- a/crates/fuzz/src/decode_fuzz.rs
+++ b/crates/fuzz/src/decode_fuzz.rs
@@ -56,7 +56,11 @@ proptest! {
     /// `schema` discriminator, where the interesting decoding is.
     #[test]
     fn storage_decode_never_panics_past_the_tag(main in arb_json(), cards in arb_json()) {
-        for schema in ["quillmark/document@0.93.0", "quillmark/document@0.92.0"] {
+        for schema in [
+            "quillmark/document@0.93.0",
+            "quillmark/document@0.92.0",
+            "quillmark/document@0.81.0",
+        ] {
             let blob = json!({ "schema": schema, "main": main, "cards": cards });
             let _ = serde_json::from_str::<Document>(&blob.to_string());
         }

--- a/crates/fuzz/src/decode_fuzz.rs
+++ b/crates/fuzz/src/decode_fuzz.rs
@@ -59,6 +59,7 @@ proptest! {
         for schema in [
             "quillmark/document@0.93.0",
             "quillmark/document@0.92.0",
+            "quillmark/document@0.82.0",
             "quillmark/document@0.81.0",
         ] {
             let blob = json!({ "schema": schema, "main": main, "cards": cards });

--- a/docs/migrations/0.82-to-0.83.md
+++ b/docs/migrations/0.82-to-0.83.md
@@ -168,15 +168,9 @@ JSON and re-instantiate via `fromJson`/`from_json`.
 ```
 
 This is an additive change to the wire format — documents without
-`$ext` are byte-identical to the 0.82.0 form. The DTO is extended in
-place rather than versioned to `@0.83.0`.
-
-> **Correction.** This guide justified the in-place extension with "because
-> `0.82.0` is yanked, no external consumer reads the old shape". `0.82.0` was
-> never yanked: it is live on crates.io, npm, and PyPI, as is every published
-> Quillmark version. So `quillmark/document@0.82.0` names a shape union rather
-> than a frozen format, and every release through `0.91.0` stamped that tag.
-> Readers accept the union; see `prose/canon/DOCUMENT_STORAGE.md`.
+`$ext` are byte-identical to the 0.82.0 form. Because `0.82.0` is
+yanked, no external consumer reads the old shape, so the DTO is
+extended in place rather than versioned to `@0.83.0`.
 
 ### Migrating legacy `PRESENTATION_METADATA`-style state
 

--- a/docs/migrations/0.82-to-0.83.md
+++ b/docs/migrations/0.82-to-0.83.md
@@ -171,14 +171,12 @@ This is an additive change to the wire format — documents without
 `$ext` are byte-identical to the 0.82.0 form. The DTO is extended in
 place rather than versioned to `@0.83.0`.
 
-> **Correction.** This guide originally justified the in-place extension
-> with "because `0.82.0` is yanked, no external consumer reads the old
-> shape". `0.82.0` was never yanked — it is live on crates.io, npm, and
-> PyPI, as is every published Quillmark version. The yank was an intention
-> recorded when `$ext` landed and never carried out. Consequently
-> `quillmark/document@0.82.0` names a shape *union* rather than a frozen
-> format, and every release through `0.91.0` wrote that tag. Readers accept
-> the union; see `prose/canon/DOCUMENT_STORAGE.md`.
+> **Correction.** This guide justified the in-place extension with "because
+> `0.82.0` is yanked, no external consumer reads the old shape". `0.82.0` was
+> never yanked: it is live on crates.io, npm, and PyPI, as is every published
+> Quillmark version. So `quillmark/document@0.82.0` names a shape union rather
+> than a frozen format, and every release through `0.91.0` stamped that tag.
+> Readers accept the union; see `prose/canon/DOCUMENT_STORAGE.md`.
 
 ### Migrating legacy `PRESENTATION_METADATA`-style state
 

--- a/docs/migrations/0.82-to-0.83.md
+++ b/docs/migrations/0.82-to-0.83.md
@@ -168,9 +168,17 @@ JSON and re-instantiate via `fromJson`/`from_json`.
 ```
 
 This is an additive change to the wire format — documents without
-`$ext` are byte-identical to the 0.82.0 form. Because `0.82.0` is
-yanked, no external consumer reads the old shape, so the DTO is
-extended in place rather than versioned to `@0.83.0`.
+`$ext` are byte-identical to the 0.82.0 form. The DTO is extended in
+place rather than versioned to `@0.83.0`.
+
+> **Correction.** This guide originally justified the in-place extension
+> with "because `0.82.0` is yanked, no external consumer reads the old
+> shape". `0.82.0` was never yanked — it is live on crates.io, npm, and
+> PyPI, as is every published Quillmark version. The yank was an intention
+> recorded when `$ext` landed and never carried out. Consequently
+> `quillmark/document@0.82.0` names a shape *union* rather than a frozen
+> format, and every release through `0.91.0` wrote that tag. Readers accept
+> the union; see `prose/canon/DOCUMENT_STORAGE.md`.
 
 ### Migrating legacy `PRESENTATION_METADATA`-style state
 

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -78,15 +78,32 @@ document came through the bound door) live on the `Parsed` record, not on
 their `Document` handle as session state and exclude them from `equals` and
 the DTO alike.
 
-### Legacy schema (V0_92_0)
+### Legacy schemas (V0_92_0, V0_81_0)
 
 Documents written before `0.93.0` carry
 `"schema": "quillmark/document@0.92.0"` and store the card `body` as a
 markdown string rather than the embedded canonical content. Readers accept
 them and migrate forward to V0_93_0 on load; writers do not produce this
 shape. The one hop that can reject is the body cold-import (see
-Byte-stability). Tags older than `@0.92.0` (`@0.81.0`, `@0.82.0`) have no
-reader; a blob carrying one is rejected as an unknown schema version.
+Byte-stability).
+
+`"schema": "quillmark/document@0.81.0"` is the oldest tag read: the
+pre-unification shape, a separate `sentinel` beside a `frontmatter` item
+list. It migrates to V0_92_0 in one structural hop, skipping `@0.82.0`.
+
+`@0.82.0` has **no reader**, and is the one tag between two readable ones.
+Two facts disqualify it, both absent from `@0.81.0`:
+
+- Its tag never named one frozen shape. `0.82.0` was yanked, so `0.83.0`
+  extended that DTO in place under the same tag (adding `$ext`) rather than
+  versioning to `@0.83.0`; every release through `0.91.0` wrote it. A reader
+  for it would be a reader for a shape union, not a schema version.
+- It carries the `$id` payload item, which `0.100.0` removed from the live
+  model as a hard cutover. Reading one demands a policy for `$id` — reject,
+  drop, or lift into `$ext` — that the live model has no answer to.
+
+`0.81.0` is the sole release that wrote `@0.81.0`, and that shape predates
+`$id`, so neither applies.
 
 ## Byte-stability
 
@@ -464,10 +481,12 @@ pathologically over-nested legacy body is rejected
 (`StorageError::Malformed`) rather than silently truncated. Only the newest
 DTO converts to the live `Document`; a `0.92.0` blob migrates one hop first.
 
-Schema tags older than `0.92.0` (`@0.81.0`, `@0.82.0`) have no reader: a
-blob carrying one is rejected as an unknown version. Their shims are retired
-because no stored population in those shapes remains on this lineage (see
-"Adding a Schema Version" on retiring a variant).
+`0.81.0` is the oldest tag read. Its migration to V0_92_0 is structural: the
+sentinel becomes a prelude of typed `$` items, every other item maps 1:1, and
+the V0_92_0 additions are absent by construction (`nested_fills` empty, no
+`seed`). It targets V0_92_0 directly rather than chaining through `@0.82.0`,
+which has no reader (see "Legacy schemas" for why that tag alone is
+unreadable).
 
 ## Adding a Schema Version
 
@@ -522,9 +541,14 @@ per version bump.
 
 A legacy variant may be **retired**: its DTO tree, migration, and tests
 deleted: once a product/release-history call confirms no stored population
-remains in that shape (the `0.81.0` and `0.82.0` shims were dropped this
-way). A row that later surfaces in a retired shape then fails as an unknown
-version, so retirement is reserved for shapes with no live rows.
+remains in that shape. A row that later surfaces in a retired shape then
+fails as an unknown version, so retirement is reserved for shapes with no
+live rows, and the evidence for "no live rows" is what the call turns on. The
+`@0.81.0` retirement was reversed on a consumer report of stored rows in that
+shape, which restoring a frozen tree and its migration answers. Retirement is
+therefore cheap to undo while the deleted tree remains recoverable from
+history, and the chain need not be contiguous: `@0.82.0` stays retired
+between two readable tags.
 
 ## Gotchas
 

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -78,7 +78,7 @@ document came through the bound door) live on the `Parsed` record, not on
 their `Document` handle as session state and exclude them from `equals` and
 the DTO alike.
 
-### Legacy schemas (V0_92_0, V0_81_0)
+### Legacy schemas (V0_92_0, V0_82_0, V0_81_0)
 
 Documents written before `0.93.0` carry
 `"schema": "quillmark/document@0.92.0"` and store the card `body` as a
@@ -87,23 +87,23 @@ them and migrate forward to V0_93_0 on load; writers do not produce this
 shape. The one hop that can reject is the body cold-import (see
 Byte-stability).
 
+`"schema": "quillmark/document@0.82.0"` is the same unified item list
+without `nested_fills` or `$seed`, plus `$id`. Its tag names a shape
+**union**, not a frozen format: `0.83.0` added `$ext` in place under the
+unchanged tag rather than versioning to `@0.83.0`, and every release through
+`0.91.0` wrote it. The reader accepts the union, which is what lets a row
+from any of those writers load.
+
+That hop is the one **lossy** migration: `$id` is dropped. `0.100.0` removed
+`$id` from the live model as a hard cutover, so the alternative is refusing
+the row entirely. `$id` reached no backend and the engine never read it; a
+consumer that kept a key there re-establishes it under a `$ext` namespace it
+owns.
+
 `"schema": "quillmark/document@0.81.0"` is the oldest tag read: the
 pre-unification shape, a separate `sentinel` beside a `frontmatter` item
-list. It migrates to V0_92_0 in one structural hop, skipping `@0.82.0`.
-
-`@0.82.0` has **no reader**, and is the one tag between two readable ones.
-Two facts disqualify it, both absent from `@0.81.0`:
-
-- Its tag never named one frozen shape. `0.82.0` was yanked, so `0.83.0`
-  extended that DTO in place under the same tag (adding `$ext`) rather than
-  versioning to `@0.83.0`; every release through `0.91.0` wrote it. A reader
-  for it would be a reader for a shape union, not a schema version.
-- It carries the `$id` payload item, which `0.100.0` removed from the live
-  model as a hard cutover. Reading one demands a policy for `$id` — reject,
-  drop, or lift into `$ext` — that the live model has no answer to.
-
-`0.81.0` is the sole release that wrote `@0.81.0`, and that shape predates
-`$id`, so neither applies.
+list. It predates both `$id` and `$ext`, so its hop to V0_82_0 loses
+nothing.
 
 ## Byte-stability
 
@@ -481,12 +481,12 @@ pathologically over-nested legacy body is rejected
 (`StorageError::Malformed`) rather than silently truncated. Only the newest
 DTO converts to the live `Document`; a `0.92.0` blob migrates one hop first.
 
-`0.81.0` is the oldest tag read. Its migration to V0_92_0 is structural: the
-sentinel becomes a prelude of typed `$` items, every other item maps 1:1, and
-the V0_92_0 additions are absent by construction (`nested_fills` empty, no
-`seed`). It targets V0_92_0 directly rather than chaining through `@0.82.0`,
-which has no reader (see "Legacy schemas" for why that tag alone is
-unreadable).
+`0.81.0` is the oldest tag read, and migrations chain
+(`V0_81_0 → V0_82_0 → V0_92_0 → V0_93_0`). The `V0_81_0` hop is structural:
+the sentinel becomes a prelude of typed `$` items and every other item maps
+1:1. The `V0_82_0` hop is lossy in exactly one place — `$id` is dropped (see
+"Legacy schemas") — and the V0_92_0 additions are absent by construction
+(`nested_fills` empty, no `seed`).
 
 ## Adding a Schema Version
 
@@ -543,12 +543,16 @@ A legacy variant may be **retired**: its DTO tree, migration, and tests
 deleted: once a product/release-history call confirms no stored population
 remains in that shape. A row that later surfaces in a retired shape then
 fails as an unknown version, so retirement is reserved for shapes with no
-live rows, and the evidence for "no live rows" is what the call turns on. The
-`@0.81.0` retirement was reversed on a consumer report of stored rows in that
-shape, which restoring a frozen tree and its migration answers. Retirement is
-therefore cheap to undo while the deleted tree remains recoverable from
-history, and the chain need not be contiguous: `@0.82.0` stays retired
-between two readable tags.
+live rows, and the evidence for "no live rows" is what the whole call turns
+on. Registry state is checkable and belongs in that evidence: the `@0.81.0`
+and `@0.82.0` retirement rested on `0.82.0` having been yanked, which was an
+intention recorded in a commit message, restated as fact in a migration
+guide, and never carried out — every published Quillmark version is live on
+crates.io, npm, and PyPI. Both tags are read again.
+
+Retirement is cheap to undo while the deleted tree is recoverable from
+history, which is the argument for retiring when the evidence holds — and for
+sourcing that evidence from the registry rather than from prose.
 
 ## Gotchas
 

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -97,10 +97,12 @@ That hop is the one **lossy** migration: `$id` is dropped. The live model
 has no counterpart for it, so the alternative is refusing the row; `$id`
 reached no backend, which is what makes dropping it the cheaper loss.
 
-`"schema": "quillmark/document@0.81.0"` is the oldest tag read: the
-pre-unification shape, a separate `sentinel` beside a `frontmatter` item
-list. It carries neither `$id` nor `$ext`, so its hop to V0_82_0 is
-lossless.
+`"schema": "quillmark/document@0.81.0"` is the oldest tag that exists, not
+just the oldest one read: `0.81.0` introduced `toJson` / `fromJson`, and no
+build before it serialized a `Document` at all. Every stored blob therefore
+carries one of the four tags above, and the reader set is complete. Its shape
+is pre-unification: a separate `sentinel` beside a `frontmatter` item list. It
+carries neither `$id` nor `$ext`, so its hop to V0_82_0 is lossless.
 
 ## Byte-stability
 

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -87,23 +87,20 @@ them and migrate forward to V0_93_0 on load; writers do not produce this
 shape. The one hop that can reject is the body cold-import (see
 Byte-stability).
 
-`"schema": "quillmark/document@0.82.0"` is the same unified item list
-without `nested_fills` or `$seed`, plus `$id`. Its tag names a shape
-**union**, not a frozen format: `0.83.0` added `$ext` in place under the
-unchanged tag rather than versioning to `@0.83.0`, and every release through
-`0.91.0` wrote it. The reader accepts the union, which is what lets a row
-from any of those writers load.
+`"schema": "quillmark/document@0.82.0"` is the same item list without
+`nested_fills` or `$seed`, plus `$id`. Its tag names a shape **union**
+rather than one frozen format: `$ext` entered under it unchanged, and many
+release versions stamped it. The reader accepts the union, which is what
+lets a row from any of those writers load.
 
-That hop is the one **lossy** migration: `$id` is dropped. `0.100.0` removed
-`$id` from the live model as a hard cutover, so the alternative is refusing
-the row entirely. `$id` reached no backend and the engine never read it; a
-consumer that kept a key there re-establishes it under a `$ext` namespace it
-owns.
+That hop is the one **lossy** migration: `$id` is dropped. The live model
+has no counterpart for it, so the alternative is refusing the row; `$id`
+reached no backend, which is what makes dropping it the cheaper loss.
 
 `"schema": "quillmark/document@0.81.0"` is the oldest tag read: the
 pre-unification shape, a separate `sentinel` beside a `frontmatter` item
-list. It predates both `$id` and `$ext`, so its hop to V0_82_0 loses
-nothing.
+list. It carries neither `$id` nor `$ext`, so its hop to V0_82_0 is
+lossless.
 
 ## Byte-stability
 
@@ -465,28 +462,25 @@ current format was fixed in `0.93.0`, so the version tag is
 `quillmark/document@0.93.0`; every later patch release writes that same
 value, because patches do not change the format.
 
-The oldest wire format still read is `0.92.0`: a unified payload-item list
-(typed `$` entries living alongside user fields and comments in a single
-`Vec<PayloadItem>`), a per-field `nested_fills` list so `!must_fill` markers
-nested inside a field value survive a storage round-trip (the JSON `value`
-projection is fill-free), and the `seed` payload-item variant (the `$seed`
-per-card-kind overlay map). `0.93.0` leaves the payload model unchanged and
-instead embeds the card `body` as the **canonical content**:
-structurally, as a nested object, not a markdown string (see Byte-stability).
+`0.92.0` is a unified payload-item list (typed `$` entries living alongside
+user fields and comments in a single `Vec<PayloadItem>`), a per-field
+`nested_fills` list so `!must_fill` markers nested inside a field value
+survive a storage round-trip (the JSON `value` projection is fill-free), and
+the `seed` payload-item variant (the `$seed` per-card-kind overlay map).
+`0.93.0` leaves the payload model unchanged and instead embeds the card
+`body` as the **canonical content**: structurally, as a nested object, not a
+markdown string (see Byte-stability).
 
 The V0_92_0 → V0_93_0 migration is the one hop that can fail: it
 cold-imports the stored markdown `body` string through the same
 Markdown → richtext path `Document::parse` uses, so a
 pathologically over-nested legacy body is rejected
-(`StorageError::Malformed`) rather than silently truncated. Only the newest
-DTO converts to the live `Document`; a `0.92.0` blob migrates one hop first.
+(`StorageError::Malformed`) rather than silently truncated.
 
 `0.81.0` is the oldest tag read, and migrations chain
-(`V0_81_0 → V0_82_0 → V0_92_0 → V0_93_0`). The `V0_81_0` hop is structural:
-the sentinel becomes a prelude of typed `$` items and every other item maps
-1:1. The `V0_82_0` hop is lossy in exactly one place — `$id` is dropped (see
-"Legacy schemas") — and the V0_92_0 additions are absent by construction
-(`nested_fills` empty, no `seed`).
+(`V0_81_0 → V0_82_0 → V0_92_0 → V0_93_0`); only the newest DTO converts to
+the live `Document`. The `V0_81_0` hop is structural, the `V0_82_0` hop is
+lossy in exactly one place — `$id` is dropped (see "Legacy schemas").
 
 ## Adding a Schema Version
 
@@ -541,18 +535,19 @@ per version bump.
 
 A legacy variant may be **retired**: its DTO tree, migration, and tests
 deleted: once a product/release-history call confirms no stored population
-remains in that shape. A row that later surfaces in a retired shape then
-fails as an unknown version, so retirement is reserved for shapes with no
-live rows, and the evidence for "no live rows" is what the whole call turns
-on. Registry state is checkable and belongs in that evidence: the `@0.81.0`
-and `@0.82.0` retirement rested on `0.82.0` having been yanked, which was an
-intention recorded in a commit message, restated as fact in a migration
-guide, and never carried out — every published Quillmark version is live on
-crates.io, npm, and PyPI. Both tags are read again.
+remains in that shape. A row that later surfaces in a retired shape fails as
+an unknown version, so the evidence for "no live rows" is what the whole call
+turns on.
+
+Two things that evidence is not. A release version is not a schema tag: the
+tag a build stamps is the newest one its DTO carries, so one tag's population
+spans every release between its bump and the next. And prose is not registry
+state — whether a version was yanked is checkable against crates.io, npm, and
+PyPI, and only those answer it.
 
 Retirement is cheap to undo while the deleted tree is recoverable from
-history, which is the argument for retiring when the evidence holds — and for
-sourcing that evidence from the registry rather than from prose.
+history. That is the argument for retiring when the evidence holds, and for
+sourcing it from a row count rather than a version number.
 
 ## Gotchas
 


### PR DESCRIPTION
Closes #1327. Reverses #929 / #986.

## Context

#1327 reports `fromJson` failing on stored documents tagged
`quillmark/document@0.81.0`. #929 retired the `V0_81_0` and `V0_82_0` read
shims on two premises. Both are false.

**"Nothing persisted on this lineage predates `@0.92.0`."** #1327 has the rows.

**"`0.82.0` was yanked."** It was not. Checked against all three registries:

| Registry | `0.82.0` | Status |
|---|---|---|
| crates.io (`quillmark`, `quillmark-core`, `quillmark-typst`) | 2026-05-22 | `yanked=false` |
| npm `@quillmark/wasm` | 2026-05-22 | live, not deprecated, not unpublished |
| PyPI `quillmark` | — | `yanked=false` |

No Quillmark version has ever been yanked on any registry. The claim traces to
d0f781c (#630, the `$ext` commit): *"0.82.0 **will be** yanked, so the 'frozen
per version' promise carries no external compat burden here."* Future tense, an
intention, written the same day 0.82.0 shipped. `docs/migrations/0.82-to-0.83.md`
restated it in the present tense, and #929 read it as settled release history.

Because no yank happened, `@0.82.0` is not one frozen shape: `0.83.0` added
`$ext` in place under the unchanged tag, and every release through `0.91.0`
stamped it.

## A package version is not a schema tag

The two numbering axes are independent, and reading across them is what
retired a live format. The tag a build stamps is the newest one its DTO
carries, so a tag's population spans every release between its bump and the
next.

Determined by execution — npm tarballs downloaded, wasm instantiated in Node,
`toJson().schema` read off a parsed document:

| `@quillmark/wasm` | published? | writes |
|---|---|---|
| `0.81.0` | yes | `quillmark/document@0.81.0` |
| `0.82.0` | yes | `quillmark/document@0.82.0` |
| `0.88.0` | yes | `quillmark/document@0.82.0` |
| `0.90.0` | yes | `quillmark/document@0.82.0` |
| `0.92.0` | yes | `quillmark/document@0.92.0` |
| `0.92.1` | yes | `quillmark/document@0.92.0` |
| `0.93.0` | **no such package** (404) | — |
| `0.108.1` | yes | `quillmark/document@0.93.0` |

Both mismatches are normal and both matter here:

- **A package with no DTO.** `0.88.0` shipped and was deployed; no `@0.88.0`
  schema tag ever existed. Its rows are tagged `@0.82.0`, so retiring that
  reader orphans them — whether or not the `0.82.0` package itself was ever
  deployed.
- **A DTO with no package.** `@0.93.0` is the current write tag
  (`STORAGE_V0_93_0`, `From<Document> for StoredDocument`) and no `0.93.0`
  package was ever published. The tag names the crate version at which the
  format was fixed, not a release.

## What changed

**`dto.rs`** — `StoredDocument` regains `V0_81_0` and `V0_82_0`. Migrations
chain again: `V0_81_0 → V0_82_0 → V0_92_0 → V0_93_0`. The write path is
untouched; re-serializing a migrated row emits `@0.93.0`.

The `V0_82_0` hop is **lossy in one place**: the `$id` payload item is dropped.
`0.100.0` removed `$id` from the live model as a hard cutover, so the
alternative is refusing the row. `$id` reached no backend. A consumer that kept
a key there re-establishes it under a `$ext` namespace it owns.

`V0_81_0` loses nothing — it predates both `$id` and `$ext`.

**`decode_fuzz.rs`** — the decode target covers all three legacy tags.

**`DOCUMENT_STORAGE.md`** — the legacy-schema and versioning sections describe
the readable tags. The retirement policy keeps retirement as an option and adds
what the evidence must be: a release version is not a schema tag, and prose is
not registry state.

Applied migration guides are untouched.

## Testing

`cargo test --workspace --all-features` — 59/59 binaries, 0 failures.
`check-canon` OK, `cargo doc --no-deps --workspace` clean, clippy at 55
warnings, identical to the `main` baseline and none in changed files.

New coverage: `@0.81.0` and `@0.82.0` load and re-tag; a composable card
migrates; `$ext` loads; `$id` is dropped rather than rejected; `$seed` under
the `@0.82.0` tag is still rejected. The `@0.81.0` fidelity test asserts the
migrated document equals the same document re-parsed from its own markdown —
comment order against the `$` prelude, `!must_fill`, and nested-comment paths
all land where the parser would put them.