### PR TITLE
fix(typst): guard document text at every position Typst reads as syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@
   The guard now takes Typst's own test, and covers a list item's body head as
   well as column 0, that being a line start the parser reads as one.
 
+- fix(typst): **bold text, a table cell or an indented paragraph opening with
+  `-`, `=`, `+`, `/` or `N.` renders as that text.** Typst reads the head of
+  every content block `[…]` as a line start of its own, so the marker in
+  `**/ x**` or in a table cell reached it as a term list whose colon is missing
+  and failed the compile, while `**- x**` drew a bullet list inside the bold.
+  Indentation is trivia and holds that line start open behind it, so a
+  paragraph beginning `  / x` failed the same way. The line-anchor guard now
+  covers every position Typst reads as a line start.
+
 ## v0.108.2 - 2026-08-20
 
 - fix(core): **storage blobs tagged `@0.81.0` and `@0.82.0` load again.** Both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- fix(typst): **a paragraph holding one bare `/` renders instead of failing the
+  compile.** Typst's heading `=`, list `-`/`+`/`N.`, and term `/` markers fire
+  on a space after them *or* on the line ending there; the emitter's
+  line-anchor guard tested only for the space, so a run that was one bare
+  marker reached Typst unescaped — `/` as a term list whose colon is missing
+  (`expected colon`), the other four as an empty heading, bullet or enum item.
+  The guard now takes Typst's own test, and covers a list item's body head as
+  well as column 0, that being a line start the parser reads as one.
+
 ## v0.108.2 - 2026-08-20
 
 - fix(core): **storage blobs tagged `@0.81.0` and `@0.82.0` load again.** Both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@
   paragraph beginning `  / x` failed the same way. The line-anchor guard now
   covers every position Typst reads as a line start.
 
+- fix(typst): **text directly after inline code, bold or an image renders when
+  it opens with `(` or `.name`.** Typst reads a `(` directly after a `#…`
+  expression as that call's arguments and a `.` before an identifier as a field
+  access, so the emitter's own `#raw(…)`, `#strong[…]` and `#image(…)` handed
+  the text behind them to Typst as code — `` `x`(y) `` became a call on
+  content, which fails the compile. Such a run now takes the same `\` prefix
+  the line-anchor guard uses. Debug builds parse every emission with Typst's
+  parser, so markup that reaches it as syntax fails a test rather than a render.
+
 ## v0.108.2 - 2026-08-20
 
 - fix(core): **storage blobs tagged `@0.81.0` and `@0.82.0` load again.** Both

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -12,10 +12,12 @@
 //!
 //! **Line-anchored text.** [`escape_markup`](crate::emit::escape_markup)
 //! neutralizes inline markup but is
-//! position-blind; Typst's heading `= `, list `- `/`+ `/`N. `, and term `/ ` are
-//! only special as the first token of a source line. Text opening with one lands
-//! at column 0 and would render as that block, so the emitter prefixes a single
-//! `\` there (`opens_line_anchor`). Styling-only: `#`, `[`, `$` are already
+//! position-blind; Typst's heading `=`, list `-`/`+`/`N.`, and term `/` are only
+//! special as the first token of a source line, and each fires on a space after it
+//! or on the line ending there. Text opening with one lands at column 0 and would
+//! render as that block — a lone `/` as a term list whose colon is missing, which
+//! is a parse error — so the emitter prefixes a single `\` there
+//! (`opens_line_anchor`). Styling-only: `#`, `[`, `$` are already
 //! escaped, so this is no code-execution vector.
 //!
 //! **The 2→4 escape coupling.** Each run records only its `(content, generated)`
@@ -72,19 +74,21 @@ pub fn escape_string(s: &str) -> String {
 }
 
 /// Does `s` open a line-anchored Typst block: heading `= `, bullet `- `, enum
-/// `+ `/`N. `, term `/ `? The trailing space is required, so `=foo`, `-5`,
-/// `and/or`, `1.item` are inert and ordinary prose is untouched.
+/// `+ `/`N. `, term `/ `? The marker token is followed by whitespace or ends the
+/// run, which is Typst's own test (`space_or_end`), so `=foo`, `-5`, `and/or`,
+/// `1.item` are inert and a paragraph holding one bare `/` is a slash rather
+/// than a term list whose colon is missing. The run ends at a mark, an island,
+/// or the line, and everything the emitter opens there starts `#`, so the end
+/// case escapes one line-final marker and never a token mid-line.
 fn opens_line_anchor(s: &str) -> bool {
     let b = s.as_bytes();
+    let clear = |n: usize| s[n..].chars().next().is_none_or(char::is_whitespace);
     match b.first().copied() {
-        Some(b'=') => {
-            let n = b.iter().take_while(|&&c| c == b'=').count();
-            b.get(n) == Some(&b' ')
-        }
-        Some(b'-') | Some(b'+') | Some(b'/') => b.get(1) == Some(&b' '),
+        Some(b'=') => clear(b.iter().take_while(|&&c| c == b'=').count()),
+        Some(b'-') | Some(b'+') | Some(b'/') => clear(1),
         Some(c) if c.is_ascii_digit() => {
             let n = b.iter().take_while(|&&c| c.is_ascii_digit()).count();
-            b.get(n) == Some(&b'.') && b.get(n + 1) == Some(&b' ')
+            b.get(n) == Some(&b'.') && clear(n + 1)
         }
         _ => false,
     }
@@ -601,6 +605,25 @@ impl<'a> Emit<'a> {
         });
     }
 
+    /// Is the emitter where Typst's line-anchored syntax is live: column 0 of a
+    /// generated source line, indentation ahead of it not counting, or the head of a
+    /// list item's body, which the parser reads as a line start of its own. A
+    /// heading's body is not one, and neither is any position prose has reached.
+    fn at_line_anchor(&self) -> bool {
+        let head = |s: &str| {
+            let s = s.trim_end_matches([' ', '\t']);
+            s.is_empty() || s.ends_with('\n')
+        };
+        head(&self.out)
+            || ["- ", "+ "]
+                .iter()
+                .any(|m| self.out.strip_suffix(m).is_some_and(head))
+            || self.out.strip_suffix(". ").is_some_and(|s| {
+                let before = s.trim_end_matches(|c: char| c.is_ascii_digit());
+                before.len() < s.len() && head(before)
+            })
+    }
+
     /// Wrapping marks nest via a close-and-reopen boundary sweep; `code` marks
     /// render atomically as `#raw("…")`; interior `\n`s become `#linebreak()`.
     fn emit_inline(
@@ -617,9 +640,7 @@ impl<'a> Emit<'a> {
         // The scratch buffer's bytes land at `base` once appended, so each run's
         // generated span is `base + buf.len()`, absolute into `self.out`.
         let base = self.out.len();
-        // Typst's line-anchored syntax is active only at column 0 of a
-        // generated source line.
-        let at_col0 = self.out.trim_end_matches([' ', '\t']).ends_with('\n') || self.out.is_empty();
+        let at_col0 = self.at_line_anchor();
         let mut buf = String::new();
         sweep_marks(lo, hi, &wraps, &mut buf, |buf, pos| {
             let c = self.chars[pos];
@@ -1530,11 +1551,16 @@ mod tests {
 
     #[test]
     fn line_anchor_predicate() {
-        for yes in ["= h", "== h", "- b", "+ n", "/ term: d", "1. i", "42. i"] {
+        for yes in [
+            "= h", "== h", "- b", "+ n", "/ term: d", "1. i", "42. i",
+            // Nothing after the marker: Typst reads the line's end as the space
+            // it wants, so a run that is one bare marker opens a block too.
+            "=", "==", "-", "+", "/", "1.", "42.",
+        ] {
             assert!(opens_line_anchor(yes), "{yes:?} should trigger");
         }
         for no in [
-            "=foo", "==foo", "-5 degrees", "and/or", "1.item", "1) i", "hi", "", " = x",
+            "=foo", "==foo", "-5 degrees", "and/or", "1.item", "1) i", "hi", "", " = x", "1",
         ] {
             assert!(!opens_line_anchor(no), "{no:?} should not trigger");
         }
@@ -1551,6 +1577,12 @@ mod tests {
         assert_eq!(emit_marked("+ x", vec![]), "\\+ x\n\n");
         assert_eq!(emit_marked("/ t: d", vec![]), "\\/ t: d\n\n");
         assert_eq!(emit_marked("1. x", vec![]), "\\1. x\n\n");
+        // A paragraph that is one bare marker: the same escape, on the marker Typst
+        // reads off the line's end. Unescaped, `/` alone is a term list missing its
+        // colon and the compile fails outright.
+        assert_eq!(emit_marked("/", vec![]), "\\/\n\n");
+        assert_eq!(emit_marked("=", vec![]), "\\=\n\n");
+        assert_eq!(emit_marked("-", vec![]), "\\-\n\n");
         // Non-trigger prose is untouched.
         assert_eq!(emit_marked("hello = x", vec![]), "hello = x\n\n");
         assert_eq!(emit_marked("=x no space", vec![]), "=x no space\n\n");

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -18,13 +18,18 @@
 //! block — a lone `/` as a term list whose colon is missing, which is a parse
 //! error — so the emitter prefixes a single `\` (`opens_line_anchor`).
 //!
-//! That position is Typst's `at_start`, and it is four places, not one: column 0
+//! That position is Typst's `at_start`, and it is four places: column 0
 //! with indentation ahead of it not counting, a list item's body head, the head
 //! of every content block `[…]` the emitter opens (each wrap, each table cell),
 //! and the run of spaces or tabs behind any of them, which Typst reads as trivia.
 //! A heading's body is none of them. `at_line_anchor` answers the first two,
 //! `sweep_marks` carries the third, `emit_run` the fourth. Styling-only:
 //! `#`, `[`, `$` are already escaped, so this is no code-execution vector.
+//!
+//! **Expression tails.** The same `\` guards the other direction. Typst reads a
+//! `(` directly after a `#…` expression as that call's arguments and a `.` before
+//! an identifier as a field access, so the text behind an emitted `#raw(…)`,
+//! `#image(…)` or a wrap's `]` would reach it as code (`continues_expr`).
 //!
 //! **The 2→4 escape coupling.** Each run records only its `(content, generated)`
 //! pair; per-char spans are *recomputed* by a scan treating `//`→`\/\/` as a
@@ -100,6 +105,32 @@ fn opens_line_anchor(s: &str) -> bool {
         }
         _ => false,
     }
+}
+
+/// Does `s` continue the `#…` expression written before it? Typst reads a `(`
+/// directly after one as that call's arguments and a `.` before an identifier
+/// as a field access, either swallowing document text into code: a `` `x` ``
+/// followed by `(y)` emits `#raw("x")(y)`, a call on content. `[` needs no rule,
+/// [`escape_markup`] having escaped it already, and trivia between the two ends
+/// the expression on its own.
+fn continues_expr(s: &str) -> bool {
+    let mut c = s.chars();
+    match c.next() {
+        Some('(') => true,
+        Some('.') => c.next().is_some_and(typst::syntax::is_id_start),
+        _ => false,
+    }
+}
+
+/// What the emitter last wrote, which decides the guard the next text run needs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Tail {
+    /// Typst's `at_start`: a heading, list or term marker is live here.
+    Anchor,
+    /// The end of a `#…` expression, which [`continues_expr`] can extend.
+    Expr,
+    /// Ink, which ends both.
+    Text,
 }
 
 /// The escape discipline a text run was generated under: which scan inverts its
@@ -204,6 +235,20 @@ pub struct Emission {
     pub segments: Vec<SegmentMap>,
 }
 
+impl Emission {
+    /// A syntax error in emitted markup is a lowering bug, never a document's.
+    /// Typst's parser is the only faithful judge of its own grammar, so debug
+    /// builds run it over every emission.
+    fn new(markup: String, segments: Vec<SegmentMap>) -> Self {
+        debug_assert!(
+            !typst::syntax::parse(&markup).diagnosis().errors,
+            "emitted markup does not parse: {:?}\n{markup:?}",
+            typst::syntax::parse(&markup).errors_and_warnings().0,
+        );
+        Emission { markup, segments }
+    }
+}
+
 /// What stops codegen mid-walk. Each carries the diagnostic code the render
 /// error reports, so folding a check into the walk does not relabel it.
 #[derive(Debug, thiserror::Error)]
@@ -243,10 +288,7 @@ pub fn emit_content(rt: &Content) -> Result<Emission, EmitError> {
     let mut e = Emit::new(rt);
     let n = rt.lines.len();
     e.emit_block_level(0..n, 0);
-    Ok(Emission {
-        markup: e.out,
-        segments: e.segments,
-    })
+    Ok(Emission::new(e.out, e.segments))
 }
 
 /// Lower an [`is_inline`] content to pure inline markup, omitting the block
@@ -262,10 +304,7 @@ pub(crate) fn emit_content_inline(rt: &Content) -> Result<Emission, EmitError> {
     // `is_inline` guarantees depth 0, so `emit_content`'s nesting guard is moot.
     let mut e = Emit::new(rt);
     e.emit_segment(0..rt.lines.len());
-    Ok(Emission {
-        markup: e.out,
-        segments: e.segments,
-    })
+    Ok(Emission::new(e.out, e.segments))
 }
 
 struct Emit<'a> {
@@ -648,23 +687,29 @@ impl<'a> Emit<'a> {
         // The scratch buffer's bytes land at `base` once appended, so each run's
         // generated span is `base + buf.len()`, absolute into `self.out`.
         let base = self.out.len();
-        let at_anchor = self.at_line_anchor();
+        let open = if self.at_line_anchor() {
+            Tail::Anchor
+        } else {
+            Tail::Text
+        };
         let mut buf = String::new();
-        sweep_marks(lo, hi, &wraps, &mut buf, at_anchor, |buf, pos, anchored| {
+        sweep_marks(lo, hi, &wraps, &mut buf, open, |buf, pos, tail| {
             let c = self.chars[pos];
             if c == '\n' {
                 buf.push_str("#linebreak()");
-                return (pos + 1, false);
+                return (pos + 1, Tail::Expr);
             }
             if c == ISLAND_SLOT {
                 let markup = self.island_markup(pos);
                 buf.push_str(&markup);
-                return (pos + 1, false);
+                // An island type this build does not know renders nothing.
+                let left = if markup.is_empty() { tail } else { Tail::Expr };
+                return (pos + 1, left);
             }
-            let (re, still_anchored, (content, g, ctx)) =
-                emit_run(buf, pos, hi, &self.chars, &wraps, &codes, anchored);
+            let (re, left, (content, g, ctx)) =
+                emit_run(buf, pos, hi, &self.chars, &wraps, &codes, tail);
             runs.push((content, (base + g.start)..(base + g.end), ctx));
-            (re, still_anchored)
+            (re, left)
         });
         self.out.push_str(&buf);
         runs
@@ -715,11 +760,11 @@ fn clip_wraps_to_codes(wraps: &mut Vec<Wrap>, codes: &[(usize, usize)]) {
 
 /// The mark boundary sweep, shared by prose inline emission and table-cell
 /// rendering: opens `wraps` (longer span first, then kind-ord) and
-/// closes-and-reopens deeper survivors at overlaps. `emit_run(out, pos,
-/// anchored)` writes the content at `pos` and returns the next position and
-/// whether the line anchor outlives what it wrote. Every wrap `open` ends `[`,
-/// and a content block's head is a line start of Typst's own, so the anchor
-/// rearms at each one. `wraps` must already be clipped against the code spans
+/// closes-and-reopens deeper survivors at overlaps. `emit_run(out, pos, tail)`
+/// writes the content at `pos` and returns the next position and the [`Tail`] it
+/// leaves. Every wrap `open` ends `[`, and a content block's head is a line
+/// start of Typst's own, so the anchor rearms at each one; each `]` completes a
+/// call instead. `wraps` must already be clipped against the code spans
 /// ([`clip_wraps_to_codes`]), so no wrap `end` hides inside a span the
 /// callback's cursor jumps over.
 fn sweep_marks(
@@ -727,8 +772,8 @@ fn sweep_marks(
     hi: usize,
     wraps: &[Wrap],
     out: &mut String,
-    mut anchored: bool,
-    mut emit_run: impl FnMut(&mut String, usize, bool) -> (usize, bool),
+    mut tail: Tail,
+    mut emit_run: impl FnMut(&mut String, usize, Tail) -> (usize, Tail),
 ) {
     // Open marks, outermost first. Storing the index (not `(end, ord)`) keeps
     // each mark's identity, so a reopened mark re-emits its OWN delimiter: two
@@ -742,14 +787,14 @@ fn sweep_marks(
             while stack.len() > idx {
                 let wi = stack.pop().unwrap();
                 out.push(']');
-                anchored = false;
+                tail = Tail::Expr;
                 if wraps[wi].end != pos {
                     reopen.push(wi);
                 }
             }
             for wi in reopen.into_iter().rev() {
                 out.push_str(&wraps[wi].open);
-                anchored = true;
+                tail = Tail::Anchor;
                 stack.push(wi);
             }
         }
@@ -760,11 +805,11 @@ fn sweep_marks(
         opening.sort_by(|&a, &b| wraps[b].end.cmp(&wraps[a].end).then(wraps[a].ord.cmp(&wraps[b].ord)));
         for wi in opening {
             out.push_str(&wraps[wi].open);
-            anchored = true;
+            tail = Tail::Anchor;
             stack.push(wi);
         }
-        let (next, still_anchored) = emit_run(out, pos, anchored);
-        anchored = still_anchored;
+        let (next, left) = emit_run(out, pos, tail);
+        tail = left;
         pos = next;
     }
     // The codegen embeds this markup in a `#let _qm = [ .. ]` block that one
@@ -841,13 +886,13 @@ fn wraps_and_codes(marks: &[Mark], lo: usize, hi: usize) -> (Vec<Wrap>, Vec<(usi
 }
 
 /// One run of a mark sweep: the atomic `#raw(..)` code span starting at `pos`,
-/// or the plain text up to the next boundary. Returns the position after it,
-/// whether the line anchor survives it, and its `(content, generated, context)`
-/// pair, `generated` indexing `out` itself. `anchored` arms the line-anchor `\`
-/// guard, whose byte sits *outside* the run's window so
-/// `generated == escape_markup(content)` stays exact.
+/// or the plain text up to the next boundary. Returns the position after it, the
+/// [`Tail`] it leaves, and its `(content, generated, context)` pair, `generated`
+/// indexing `out` itself. `tail` arms one of the two `\` guards — the
+/// line-anchor one and [`continues_expr`]'s — whose byte sits *outside* the
+/// run's window so `generated == escape_markup(content)` stays exact.
 ///
-/// Under the guard a run opening with spaces or tabs stops at the first
+/// Under [`Tail::Anchor`] a run opening with spaces or tabs stops at the first
 /// character that is neither: Typst reads them as trivia and holds the anchor
 /// open behind them, while `\` before a space is its linebreak rather than an
 /// escape, so the guard byte has to land on the marker itself.
@@ -858,8 +903,8 @@ fn emit_run(
     chars: &[char],
     wraps: &[Wrap],
     codes: &[(usize, usize)],
-    anchored: bool,
-) -> (usize, bool, (Range<usize>, Range<usize>, EscapeCtx)) {
+    tail: Tail,
+) -> (usize, Tail, (Range<usize>, Range<usize>, EscapeCtx)) {
     if let Some(&(cs, ce)) = codes.iter().find(|(s, _)| *s == pos) {
         let content: String = chars[cs..ce].iter().collect();
         out.push_str("#raw(\"");
@@ -867,25 +912,30 @@ fn emit_run(
         out.push_str(&escape_string(&content));
         let g1 = out.len();
         out.push_str("\")");
-        return (ce, false, (cs..ce, g0..g1, EscapeCtx::StringLit));
+        return (ce, Tail::Expr, (cs..ce, g0..g1, EscapeCtx::StringLit));
     }
     let mut re = next_boundary(pos, hi, chars, wraps, codes);
     let trivia = |c: char| c == ' ' || c == '\t';
-    if anchored && trivia(chars[pos]) {
+    if tail == Tail::Anchor && trivia(chars[pos]) {
         re = (pos..re).find(|&p| !trivia(chars[p])).unwrap_or(re);
     }
     let content: String = chars[pos..re].iter().collect();
-    if anchored && opens_line_anchor(&content) {
+    let guarded = match tail {
+        Tail::Anchor => opens_line_anchor(&content),
+        Tail::Expr => continues_expr(&content),
+        Tail::Text => false,
+    };
+    if guarded {
         out.push('\\');
     }
     let g0 = out.len();
     out.push_str(&escape_markup(&content));
     let g1 = out.len();
-    (
-        re,
-        anchored && content.chars().all(trivia),
-        (pos..re, g0..g1, EscapeCtx::Markup),
-    )
+    let left = match tail {
+        Tail::Anchor if content.chars().all(trivia) => Tail::Anchor,
+        _ => Tail::Text,
+    };
+    (re, left, (pos..re, g0..g1, EscapeCtx::Markup))
 }
 
 /// A cell is flat inline (no islands, no line breaks), so its markup carries no
@@ -896,10 +946,9 @@ fn cell_markup(text: &str, marks: &[Mark]) -> String {
     let (mut wraps, codes) = wraps_and_codes(marks, 0, chars.len());
     clip_wraps_to_codes(&mut wraps, &codes);
     let mut out = String::new();
-    sweep_marks(0, chars.len(), &wraps, &mut out, true, |out, pos, anchored| {
-        let (re, still_anchored, _) =
-            emit_run(out, pos, chars.len(), &chars, &wraps, &codes, anchored);
-        (re, still_anchored)
+    sweep_marks(0, chars.len(), &wraps, &mut out, Tail::Anchor, |out, pos, tail| {
+        let (re, left, _) = emit_run(out, pos, chars.len(), &chars, &wraps, &codes, tail);
+        (re, left)
     });
     out
 }
@@ -1067,6 +1116,10 @@ mod tests {
             "Hello~World",
             "Use path/to/file for the file",
             "Path: C:\\\\Users\\\\file",
+            // guarded runs, whose `\` sits outside the window
+            "`x`(y)",
+            "**b**(y)",
+            "  = x",
             // thematic breaks
             "one\n\n---\n\ntwo",
             "one\n\n***\n\ntwo",
@@ -1647,10 +1700,27 @@ mod tests {
         }
     }
 
+    /// A `#…` expression the emitter wrote runs on into a `(` or a `.field`
+    /// directly after it, so those take the same `\` prefix as a line anchor.
+    #[test]
+    fn expression_tail_prefixes_backslash() {
+        assert_eq!(emit("`x`(y)").markup, "#raw(\"x\")\\(y)\n\n");
+        assert_eq!(emit("**b**(y)").markup, "#strong[b]\\(y)\n\n");
+        assert_eq!(emit("`x`.len").markup, "#raw(\"x\")\\.len\n\n");
+        assert_eq!(
+            emit("![i](u)(y)").markup,
+            "#image(\"u\", alt: \"i\")\\(y)\n\n"
+        );
+        assert_eq!(emit("a\\\n(b)").markup, "a#linebreak()\\(b)\n\n");
+        // Typst ends the expression on trivia, and on a `.` no identifier follows.
+        assert_eq!(emit("`x` (y)").markup, "#raw(\"x\") (y)\n\n");
+        assert_eq!(emit("`x`.5").markup, "#raw(\"x\").5\n\n");
+        // Prose reaching a `(` is no expression tail.
+        assert_eq!(emit("a(y)").markup, "a(y)\n\n");
+    }
+
     /// Typst's own parser over the emitter's output: the block-level nodes it
-    /// finds are exactly the ones the content asked for. Every marker case here
-    /// rendered as a block, or failed the compile, before the guard reached its
-    /// position.
+    /// finds are exactly the ones the content asked for.
     #[test]
     fn typst_reads_only_the_blocks_the_content_asked_for() {
         use typst::syntax::{parse, SyntaxKind, SyntaxNode};

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -13,12 +13,18 @@
 //! **Line-anchored text.** [`escape_markup`](crate::emit::escape_markup)
 //! neutralizes inline markup but is
 //! position-blind; Typst's heading `=`, list `-`/`+`/`N.`, and term `/` are only
-//! special as the first token of a source line, and each fires on a space after it
-//! or on the line ending there. Text opening with one lands at column 0 and would
-//! render as that block — a lone `/` as a term list whose colon is missing, which
-//! is a parse error — so the emitter prefixes a single `\` there
-//! (`opens_line_anchor`). Styling-only: `#`, `[`, `$` are already
-//! escaped, so this is no code-execution vector.
+//! special as the first token of a markup line, and each fires on a space after it
+//! or on the line ending there. Text opening with one there would render as that
+//! block — a lone `/` as a term list whose colon is missing, which is a parse
+//! error — so the emitter prefixes a single `\` (`opens_line_anchor`).
+//!
+//! That position is Typst's `at_start`, and it is four places, not one: column 0
+//! with indentation ahead of it not counting, a list item's body head, the head
+//! of every content block `[…]` the emitter opens (each wrap, each table cell),
+//! and the run of spaces or tabs behind any of them, which Typst reads as trivia.
+//! A heading's body is none of them. `at_line_anchor` answers the first two,
+//! `sweep_marks` carries the third, `emit_run` the fourth. Styling-only:
+//! `#`, `[`, `$` are already escaped, so this is no code-execution vector.
 //!
 //! **The 2→4 escape coupling.** Each run records only its `(content, generated)`
 //! pair; per-char spans are *recomputed* by a scan treating `//`→`\/\/` as a
@@ -79,7 +85,9 @@ pub fn escape_string(s: &str) -> String {
 /// `1.item` are inert and a paragraph holding one bare `/` is a slash rather
 /// than a term list whose colon is missing. The run ends at a mark, an island,
 /// or the line, and everything the emitter opens there starts `#`, so the end
-/// case escapes one line-final marker and never a token mid-line.
+/// case escapes one line-final marker and never a token mid-line. `s` starts at
+/// the marker: [`emit_run`] cuts a run's leading trivia away, so a space here is
+/// prose rather than an indented marker.
 fn opens_line_anchor(s: &str) -> bool {
     let b = s.as_bytes();
     let clear = |n: usize| s[n..].chars().next().is_none_or(char::is_whitespace);
@@ -605,7 +613,7 @@ impl<'a> Emit<'a> {
         });
     }
 
-    /// Is the emitter where Typst's line-anchored syntax is live: column 0 of a
+    /// Does the segment about to open sit at a line anchor: column 0 of a
     /// generated source line, indentation ahead of it not counting, or the head of a
     /// list item's body, which the parser reads as a line start of its own. A
     /// heading's body is not one, and neither is any position prose has reached.
@@ -640,27 +648,23 @@ impl<'a> Emit<'a> {
         // The scratch buffer's bytes land at `base` once appended, so each run's
         // generated span is `base + buf.len()`, absolute into `self.out`.
         let base = self.out.len();
-        let at_col0 = self.at_line_anchor();
+        let at_anchor = self.at_line_anchor();
         let mut buf = String::new();
-        sweep_marks(lo, hi, &wraps, &mut buf, |buf, pos| {
+        sweep_marks(lo, hi, &wraps, &mut buf, at_anchor, |buf, pos, anchored| {
             let c = self.chars[pos];
             if c == '\n' {
                 buf.push_str("#linebreak()");
-                return pos + 1;
+                return (pos + 1, false);
             }
             if c == ISLAND_SLOT {
                 let markup = self.island_markup(pos);
                 buf.push_str(&markup);
-                return pos + 1;
+                return (pos + 1, false);
             }
-            // `buf.is_empty()` gates the line-anchor guard to the segment's
-            // first content: a wrap already opened here would put the token
-            // mid-line.
-            let anchored = at_col0 && buf.is_empty();
-            let (re, (content, g, ctx)) =
+            let (re, still_anchored, (content, g, ctx)) =
                 emit_run(buf, pos, hi, &self.chars, &wraps, &codes, anchored);
             runs.push((content, (base + g.start)..(base + g.end), ctx));
-            re
+            (re, still_anchored)
         });
         self.out.push_str(&buf);
         runs
@@ -711,16 +715,20 @@ fn clip_wraps_to_codes(wraps: &mut Vec<Wrap>, codes: &[(usize, usize)]) {
 
 /// The mark boundary sweep, shared by prose inline emission and table-cell
 /// rendering: opens `wraps` (longer span first, then kind-ord) and
-/// closes-and-reopens deeper survivors at overlaps. `emit_run(out, pos)` writes
-/// the content at `pos` and returns the next position. `wraps` must already be
-/// clipped against the code spans ([`clip_wraps_to_codes`]), so no wrap `end`
-/// hides inside a span the callback's cursor jumps over.
+/// closes-and-reopens deeper survivors at overlaps. `emit_run(out, pos,
+/// anchored)` writes the content at `pos` and returns the next position and
+/// whether the line anchor outlives what it wrote. Every wrap `open` ends `[`,
+/// and a content block's head is a line start of Typst's own, so the anchor
+/// rearms at each one. `wraps` must already be clipped against the code spans
+/// ([`clip_wraps_to_codes`]), so no wrap `end` hides inside a span the
+/// callback's cursor jumps over.
 fn sweep_marks(
     lo: usize,
     hi: usize,
     wraps: &[Wrap],
     out: &mut String,
-    mut emit_run: impl FnMut(&mut String, usize) -> usize,
+    mut anchored: bool,
+    mut emit_run: impl FnMut(&mut String, usize, bool) -> (usize, bool),
 ) {
     // Open marks, outermost first. Storing the index (not `(end, ord)`) keeps
     // each mark's identity, so a reopened mark re-emits its OWN delimiter: two
@@ -734,12 +742,14 @@ fn sweep_marks(
             while stack.len() > idx {
                 let wi = stack.pop().unwrap();
                 out.push(']');
+                anchored = false;
                 if wraps[wi].end != pos {
                     reopen.push(wi);
                 }
             }
             for wi in reopen.into_iter().rev() {
                 out.push_str(&wraps[wi].open);
+                anchored = true;
                 stack.push(wi);
             }
         }
@@ -750,9 +760,12 @@ fn sweep_marks(
         opening.sort_by(|&a, &b| wraps[b].end.cmp(&wraps[a].end).then(wraps[a].ord.cmp(&wraps[b].ord)));
         for wi in opening {
             out.push_str(&wraps[wi].open);
+            anchored = true;
             stack.push(wi);
         }
-        pos = emit_run(out, pos);
+        let (next, still_anchored) = emit_run(out, pos, anchored);
+        anchored = still_anchored;
+        pos = next;
     }
     // The codegen embeds this markup in a `#let _qm = [ .. ]` block that one
     // unclosed `[` would break, failing the whole helper file's parse. Clipping
@@ -828,10 +841,16 @@ fn wraps_and_codes(marks: &[Mark], lo: usize, hi: usize) -> (Vec<Wrap>, Vec<(usi
 }
 
 /// One run of a mark sweep: the atomic `#raw(..)` code span starting at `pos`,
-/// or the plain text up to the next boundary. Returns the position after it plus
-/// its `(content, generated, context)` pair, `generated` indexing `out` itself.
-/// `anchored` arms the line-anchor `\` guard, whose byte sits *outside* the
-/// run's window so `generated == escape_markup(content)` stays exact.
+/// or the plain text up to the next boundary. Returns the position after it,
+/// whether the line anchor survives it, and its `(content, generated, context)`
+/// pair, `generated` indexing `out` itself. `anchored` arms the line-anchor `\`
+/// guard, whose byte sits *outside* the run's window so
+/// `generated == escape_markup(content)` stays exact.
+///
+/// Under the guard a run opening with spaces or tabs stops at the first
+/// character that is neither: Typst reads them as trivia and holds the anchor
+/// open behind them, while `\` before a space is its linebreak rather than an
+/// escape, so the guard byte has to land on the marker itself.
 fn emit_run(
     out: &mut String,
     pos: usize,
@@ -840,7 +859,7 @@ fn emit_run(
     wraps: &[Wrap],
     codes: &[(usize, usize)],
     anchored: bool,
-) -> (usize, (Range<usize>, Range<usize>, EscapeCtx)) {
+) -> (usize, bool, (Range<usize>, Range<usize>, EscapeCtx)) {
     if let Some(&(cs, ce)) = codes.iter().find(|(s, _)| *s == pos) {
         let content: String = chars[cs..ce].iter().collect();
         out.push_str("#raw(\"");
@@ -848,9 +867,13 @@ fn emit_run(
         out.push_str(&escape_string(&content));
         let g1 = out.len();
         out.push_str("\")");
-        return (ce, (cs..ce, g0..g1, EscapeCtx::StringLit));
+        return (ce, false, (cs..ce, g0..g1, EscapeCtx::StringLit));
     }
-    let re = next_boundary(pos, hi, chars, wraps, codes);
+    let mut re = next_boundary(pos, hi, chars, wraps, codes);
+    let trivia = |c: char| c == ' ' || c == '\t';
+    if anchored && trivia(chars[pos]) {
+        re = (pos..re).find(|&p| !trivia(chars[p])).unwrap_or(re);
+    }
     let content: String = chars[pos..re].iter().collect();
     if anchored && opens_line_anchor(&content) {
         out.push('\\');
@@ -858,18 +881,25 @@ fn emit_run(
     let g0 = out.len();
     out.push_str(&escape_markup(&content));
     let g1 = out.len();
-    (re, (pos..re, g0..g1, EscapeCtx::Markup))
+    (
+        re,
+        anchored && content.chars().all(trivia),
+        (pos..re, g0..g1, EscapeCtx::Markup),
+    )
 }
 
 /// A cell is flat inline (no islands, no line breaks), so its markup carries no
-/// source-map runs.
+/// source-map runs. It opens at the head of the `[…]` [`table_markup`] wraps it
+/// in, which is a line anchor.
 fn cell_markup(text: &str, marks: &[Mark]) -> String {
     let chars: Vec<char> = text.chars().collect();
     let (mut wraps, codes) = wraps_and_codes(marks, 0, chars.len());
     clip_wraps_to_codes(&mut wraps, &codes);
     let mut out = String::new();
-    sweep_marks(0, chars.len(), &wraps, &mut out, |out, pos| {
-        emit_run(out, pos, chars.len(), &chars, &wraps, &codes, false).0
+    sweep_marks(0, chars.len(), &wraps, &mut out, true, |out, pos, anchored| {
+        let (re, still_anchored, _) =
+            emit_run(out, pos, chars.len(), &chars, &wraps, &codes, anchored);
+        (re, still_anchored)
     });
     out
 }
@@ -1567,8 +1597,7 @@ mod tests {
     }
 
     /// The source map stays exact because the `\` sits outside every run's
-    /// `generated` window. A wrap opening at the start puts the token mid-line,
-    /// so no `\` is added there.
+    /// `generated` window.
     #[test]
     fn line_anchor_paragraph_prefixes_backslash() {
         // Bare paragraph starts → escaped.
@@ -1586,13 +1615,17 @@ mod tests {
         // Non-trigger prose is untouched.
         assert_eq!(emit_marked("hello = x", vec![]), "hello = x\n\n");
         assert_eq!(emit_marked("=x no space", vec![]), "=x no space\n\n");
-        // A wrap at the start neutralizes the line-anchor already → no `\`.
+        // A wrap opens a content block, whose head is a line start of Typst's own.
         assert_eq!(
-            emit_marked(
-                "= x",
-                vec![Mark::new(0, 3, MarkKind::Strong)],
-            ),
-            "#strong[= x]\n\n",
+            emit_marked("= x", vec![Mark::new(0, 3, MarkKind::Strong)]),
+            "#strong[\\= x]\n\n",
+        );
+        // Indentation is trivia and holds the anchor open behind it, so the guard
+        // lands on the marker: before the space it would be Typst's linebreak.
+        assert_eq!(emit_marked("  = x", vec![]), "  \\= x\n\n");
+        assert_eq!(
+            emit_marked("  = x", vec![Mark::new(0, 5, MarkKind::Emph)]),
+            "#emph[  \\= x]\n\n",
         );
 
         // Source-map integrity: every run's generated slice equals the escape of
@@ -1611,6 +1644,69 @@ mod tests {
                 };
                 assert_eq!(&ec.markup[generated.clone()], expect, "run slices to its escape");
             }
+        }
+    }
+
+    /// Typst's own parser over the emitter's output: the block-level nodes it
+    /// finds are exactly the ones the content asked for. Every marker case here
+    /// rendered as a block, or failed the compile, before the guard reached its
+    /// position.
+    #[test]
+    fn typst_reads_only_the_blocks_the_content_asked_for() {
+        use typst::syntax::{parse, SyntaxKind, SyntaxNode};
+
+        fn blocks(n: &SyntaxNode, out: &mut Vec<SyntaxKind>) {
+            if matches!(
+                n.kind(),
+                SyntaxKind::Heading
+                    | SyntaxKind::ListItem
+                    | SyntaxKind::EnumItem
+                    | SyntaxKind::TermItem
+            ) {
+                out.push(n.kind());
+            }
+            for c in n.children() {
+                blocks(c, out);
+            }
+        }
+        let found = |markup: &str| {
+            let mut v = Vec::new();
+            blocks(&parse(markup), &mut v);
+            v
+        };
+
+        let all = |text: &str, kind| vec![Mark::new(0, text.chars().count(), kind)];
+        for (markup, want) in [
+            // Column 0, with the marker ending the run or the line.
+            (emit_marked("/ t", vec![]), vec![]),
+            (emit_marked("/", vec![]), vec![]),
+            (emit_marked("=", vec![]), vec![]),
+            // Behind indentation, which Typst reads as trivia.
+            (emit_marked("  / t", vec![]), vec![]),
+            (emit_marked("\t- b", vec![]), vec![]),
+            // A wrap's content block.
+            (emit_marked("/ t", all("/ t", MarkKind::Strong)), vec![]),
+            (emit_marked("= h", all("= h", MarkKind::Strong)), vec![]),
+            (emit_marked("  - b", all("  - b", MarkKind::Emph)), vec![]),
+            (emit_marked("1. n", all("1. n", MarkKind::Strike)), vec![]),
+            // A table cell's.
+            (
+                emit("| / t | = h |\n| --- | --- |\n| - b | 1. n |").markup,
+                vec![],
+            ),
+            // A list item's body head, whose own item is the one block here.
+            (emit("- /").markup, vec![SyntaxKind::ListItem]),
+            // Real blocks still reach Typst as blocks.
+            (
+                emit("# h\n\n- a\n- b").markup,
+                vec![
+                    SyntaxKind::Heading,
+                    SyntaxKind::ListItem,
+                    SyntaxKind::ListItem,
+                ],
+            ),
+        ] {
+            assert_eq!(found(&markup), want, "for {markup:?}");
         }
     }
 }

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -740,34 +740,61 @@ mod tests {
             );
             Quill::from_tree(FileTreeNode::Directory { files }).expect("quill")
         };
+        let counts = |rt: &Content| {
+            let json =
+                serde_json::json!({ "body": quillmark_content::serial::to_canonical_value(rt) });
+            let q = quill();
+            let plate_content = read_plate(&q).expect("plate");
+            let transform_schema = build_transform_schema(q.config());
+            let schema_meta = SchemaMeta::from_schema_json(transform_schema.as_json());
+            let data = transformed_data(&json);
+            let (world, _w) =
+                world::QuillWorld::new_with_data(&q, &plate_content, data.as_ref(), &schema_meta)
+                    .expect("world");
+            let (document, _warn) = compile::compile_document(&world).expect("compile");
+            let intro = document.introspector();
+            let count = |e| intro.query(&Selector::Elem(e, None)).len();
+            [
+                count(<HeadingElem as NativeElement>::ELEM),
+                count(<ListElem as NativeElement>::ELEM),
+                count(<EnumElem as NativeElement>::ELEM),
+                count(<TermsElem as NativeElement>::ELEM),
+            ]
+        };
         // `Para` lines directly: markdown import would parse `- `/`+ `/`N. ` as
         // real lists, which is not the bug.
-        use quillmark_content::model::{Line, LineKind, Content};
+        //
+        // The second half is the same five markers with nothing after them, which
+        // Typst reads off the line's end: the bare `/` is a term list missing its
+        // colon, so an unescaped one fails the compile rather than the count.
+        use quillmark_content::model::{Container, Line, LineKind, Content};
         let para = |_: usize| Line::new(LineKind::Para);
         let mut rt = Content::new(
-            "= Heading\n- bullet\n+ numbered\n1. dotted\n/ term: desc".to_string(),
-            (0..5).map(para).collect(),
+            "= Heading\n- bullet\n+ numbered\n1. dotted\n/ term: desc\n=\n-\n+\n1.\n/"
+                .to_string(),
+            (0..10).map(para).collect(),
         );
         rt.normalize();
         assert_eq!(rt.validate(), Ok(()), "content invariants");
-        let q = quill();
-        let json =
-            serde_json::json!({ "body": quillmark_content::serial::to_canonical_value(&rt) });
-        let plate_content = read_plate(&q).expect("plate");
-        let transform_schema = build_transform_schema(q.config());
-        let schema_meta = SchemaMeta::from_schema_json(transform_schema.as_json());
-        let data = transformed_data(&json);
-        let (world, _w) =
-            world::QuillWorld::new_with_data(&q, &plate_content, data.as_ref(), &schema_meta)
-                .expect("world");
-        let (document, _warn) = compile::compile_document(&world).expect("compile");
+        assert_eq!(counts(&rt), [0, 0, 0, 0], "paragraph text stays literal");
 
-        let intro = document.introspector();
-        let count = |e| intro.query(&Selector::Elem(e, None)).len();
-        assert_eq!(count(<HeadingElem as NativeElement>::ELEM), 0, "no heading");
-        assert_eq!(count(<ListElem as NativeElement>::ELEM), 0, "no bullet list");
-        assert_eq!(count(<EnumElem as NativeElement>::ELEM), 0, "no enum");
-        assert_eq!(count(<TermsElem as NativeElement>::ELEM), 0, "no term list");
+        // A list item's body head is a line start of Typst's own, the marker
+        // sitting where indentation would: the same five, one item each, and the
+        // one bullet list they make is the only block the compile may produce.
+        let item = |ordinal: u64| {
+            Line::new(LineKind::Para).with_containers(vec![Container::ListItem {
+                ordered: false,
+                start: 1,
+                ordinal,
+            }])
+        };
+        let mut rt = Content::new(
+            "=\n-\n+\n1.\n/".to_string(),
+            (0..5).map(item).collect(),
+        );
+        rt.normalize();
+        assert_eq!(rt.validate(), Ok(()), "content invariants");
+        assert_eq!(counts(&rt), [0, 1, 0, 0], "item text stays literal");
     }
 
     #[test]

--- a/prose/canon/CONVERT.md
+++ b/prose/canon/CONVERT.md
@@ -45,12 +45,18 @@ Two escapers guard the two Typst contexts; both live in `emit`:
 
 Both are position-blind. Typst's heading `=`, list `-`/`+`/`N.`, and term `/`
 are special only as a line's first token, each firing on a space after it or on
-the line ending there, so a text run landing in that position — column 0, or a
-list item's body head, which the parser reads as one — takes a single `\`
-prefix. The byte sits outside every source-map run window, so
+the line ending there, so a text run landing in that position takes a single
+`\` prefix. The byte sits outside every source-map run window, so
 `generated == escape_markup(content)` stays exact. Unprefixed, a paragraph
 holding one bare `/` is a term list whose colon is missing, and the compile
 fails.
+
+That position is Typst's `at_start`, and it is four places: column 0, a list
+item's body head, the head of every content block `[…]` the emitter opens — one
+per wrap, one per table cell — and the spaces or tabs behind any of them, which
+Typst reads as trivia. A heading's body is none of them. The guard lands on the
+marker rather than ahead of the indentation: `\` before a space is Typst's
+linebreak, not an escape.
 
 ## Element mapping
 

--- a/prose/canon/CONVERT.md
+++ b/prose/canon/CONVERT.md
@@ -58,6 +58,15 @@ Typst reads as trivia. A heading's body is none of them. The guard lands on the
 marker rather than ahead of the indentation: `\` before a space is Typst's
 linebreak, not an escape.
 
+The same `\` guards the tail of a `#…` expression. Typst reads a `(` directly
+after one as that call's arguments and a `.` before an identifier as a field
+access, so an emitted `#raw(…)`, a wrap's closing `]` and an island's `)` would
+each run on into the document text behind them. Trivia between the two ends the
+expression on its own.
+
+Debug builds parse every emission with Typst's own parser: a syntax error there
+is a lowering bug, never a document's.
+
 ## Element mapping
 
 | Content construct | Typst |

--- a/prose/canon/CONVERT.md
+++ b/prose/canon/CONVERT.md
@@ -43,6 +43,15 @@ Two escapers guard the two Typst contexts; both live in `emit`:
   `\ " \n \r \t` and other control characters as `\u{…}`. Applied to `#link` /
   `#image` URLs, code content, and code-fence language tags.
 
+Both are position-blind. Typst's heading `=`, list `-`/`+`/`N.`, and term `/`
+are special only as a line's first token, each firing on a space after it or on
+the line ending there, so a text run landing in that position — column 0, or a
+list item's body head, which the parser reads as one — takes a single `\`
+prefix. The byte sits outside every source-map run window, so
+`generated == escape_markup(content)` stays exact. Unprefixed, a paragraph
+holding one bare `/` is a term list whose colon is missing, and the compile
+fails.
+
 ## Element mapping
 
 | Content construct | Typst |


### PR DESCRIPTION
Closes #1344, and widens it: the diagnosis there is correct but scoped to two of the four positions Typst reads as a line start, and the tripwire it motivates found a second bug of the same shape.

## The positions

Typst's `at_start` — where heading `=`, list `-`/`+`/`N.` and term `/` are live — is four places (`typst-syntax` 0.15.1, `parser.rs`):

| position | parser | guarded before |
|---|---|---|
| column 0 | root markup | yes |
| a list item's body head | `list_item`, `markup(p, true, …)` | #1344's fix |
| the head of every content block `[…]` | `content_block`, `markup(p, true, …)` | no |
| spaces or tabs behind any of them | trivia, `had_newline` | no |

A heading's body is none of them (`heading`, `markup(p, false, …)`), so `= /` stays inert.

The emitter opens a content block per wrap and per table cell, and switched the guard **off** there. From plain markdown, on `main`:

```
"**/ x**"        → #strong[/ x]        ERR expected colon   ← compile fails
"| / t | b |"    → #table(…[/ t]…)     ERR expected colon   ← compile fails
"  / x"          → "  / x"             ERR expected colon   ← compile fails
"**- x**"        → #strong[- x]        ListItem             ← silent wrong ink
"*+ x*"          → #emph[+ x]          EnumItem
"**= x**"        → #strong[= x]        Heading
"| = h | 1. n |" → #table(…[= h]…)     Heading, EnumItem
```

## The change

`sweep_marks` carries what the emitter last wrote instead of the callback inferring it from the buffer: cleared on `]`, rearmed on each wrap open, taken back from whatever the run leaves. `emit_run` cuts a run's leading spaces and tabs so the guard lands on the marker — `\` before a space is Typst's linebreak, not an escape — and reports the anchor those spaces hold open. `cell_markup` opens anchored.

The guard byte still sits outside every run's `generated` window, so `generated == escape_markup(content)` is unchanged and the source map stays exact.

## The second bug

The tripwire (`Emission::new` parses every emission with `typst::syntax::parse` under `debug_assert`) came up red on the existing proptest's first run, on a bug unrelated to #1344: Typst reads a `(` directly after a `#…` expression as that call's arguments, and a `.` before an identifier as a field access (`code_expr_prec` under `atomic`).

```
`x`(y)      → #raw("x")(y)         a call on content → compile fails
**b**(y)    → #strong[b](y)        same
`x`.len     → #raw("x").len        field access on content
[i](u)(y)  → #image("u", …)(y)    same
```

Plain markdown, no editor involved. The sweep already carried one piece of "what did I last write", so it carries a three-case `Tail` instead of a bool, and an expression tail takes the same `\` prefix a line anchor does. `[` needs no rule — `escape_markup` escapes it already — and trivia ends the expression on its own, so `` `x` (y) `` and `` `x`.5 `` stay unguarded.

It is a separate commit; drop it and the tripwire together if you'd rather it went in on its own.

## Commits

- `0520313` — #1344's fix, cherry-picked from `claude/slash-command-table-controls-x1udof` so this branch stands alone. Drop it if that branch merges first.
- `ad23737` — the anchor positions above.
- `3e9146a` — the expression-tail guard and the parse tripwire.

## Tests

`cargo test --workspace`: 59 test binaries, 0 failures. The regression test reads the emitter's output with Typst's own parser and pins the block-level nodes to the ones the content asked for — verified red when either half of the anchor change is reverted.

## Still open

The content model forbids `\r` but validates `"a\u{2028}/ x"` as a single-line paragraph. Typst treats U+2028, U+2029, U+000B, U+000C and U+0085 as newlines, so that text emits a real second source line and the `/ x` on it fails the compile, guard and all. It's a fidelity bug, not an injection one — `#` is still escaped. The fix belongs in the content crate, where `\r` is already stripped, and wants its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWn4FY96eExzdMc55kBu9z

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWn4FY96eExzdMc55kBu9z)_