### PR TITLE
fix(blueprint): expand a container-typed variant cell per property

### DIFF
--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -268,24 +268,25 @@ fn append_scalar(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
     items.push(PayloadItem::comment_inline(type_expression(field)));
 }
 
-/// Build the per-property body of a defaultless typed container: the value
-/// mapping (each property at its own cell, in declaration order), the nested
-/// comments (description + `# e.g.` + inline type annotation, addressed by
-/// `container_path`/slot), and the nested fill paths. `prefix` is the container
+/// Build the per-property body of a defaultless typed container into `map`:
+/// each property at its own cell in declaration order, plus the nested comments
+/// (description + `# e.g.` + inline type annotation, addressed by
+/// `container_path`/slot) and the nested fill paths. `prefix` is the container
 /// path of the mapping relative to the field value (`[]` for a typed dict,
 /// `[Index(0)]` for a typed table's synthetic row).
+///
+/// A property's slot is where it lands in `map`, so a caller seating its own
+/// cell first (a variant's discriminant) shifts the rest by handing over a
+/// mapping that already holds it.
 fn build_property_mapping(
+    map: &mut JsonMap<String, JsonValue>,
     props: &IndexMap<String, Box<FieldSchema>>,
     prefix: &[PathSegment],
-) -> (
-    JsonMap<String, JsonValue>,
-    Vec<NestedComment>,
-    Vec<Vec<PathSegment>>,
-) {
-    let mut map = JsonMap::new();
+) -> (Vec<NestedComment>, Vec<Vec<PathSegment>>) {
     let mut nested = Vec::new();
     let mut fills = Vec::new();
-    for (slot, prop) in props.values().map(|b| b.as_ref()).enumerate() {
+    for prop in props.values().map(|b| b.as_ref()) {
+        let slot = map.len();
         if let Some(desc) = collapse_opt(&prop.description) {
             nested.push(NestedComment {
                 container_path: prefix.to_vec(),
@@ -318,7 +319,7 @@ fn build_property_mapping(
             inline: true,
         });
     }
-    (map, nested, fills)
+    (nested, fills)
 }
 
 /// One property's contribution to its parent's mapping: its value, and the
@@ -348,7 +349,8 @@ fn container_cell(
     path: &[PathSegment],
 ) -> (JsonValue, Vec<NestedComment>, Vec<Vec<PathSegment>>) {
     if let Some(props) = typed_dict_props(field) {
-        let (map, nested, fills) = build_property_mapping(props, path);
+        let mut map = JsonMap::new();
+        let (nested, fills) = build_property_mapping(&mut map, props, path);
         return (JsonValue::Object(map), nested, fills);
     }
 
@@ -364,7 +366,8 @@ fn container_cell(
         None => {
             let mut row_path = path.to_vec();
             row_path.push(PathSegment::Index(0));
-            let (row, nested, fills) = build_property_mapping(row_props, &row_path);
+            let mut row = JsonMap::new();
+            let (nested, fills) = build_property_mapping(&mut row, row_props, &row_path);
             (
                 JsonValue::Array(vec![JsonValue::Object(row)]),
                 nested,
@@ -401,7 +404,6 @@ fn append_variant(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
 
     let member = scalar_value(field);
     let mut map = JsonMap::new();
-    let mut nested = Vec::new();
     let mut fills = Vec::new();
     map.insert(
         VARIANT_DISCRIMINANT_KEY.to_string(),
@@ -416,42 +418,18 @@ fn append_variant(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
         fills.push(vec![PathSegment::Key(VARIANT_DISCRIMINANT_KEY.to_string())]);
     }
 
+    // A cell is a field of the container, so it expands as one: the mapping
+    // already holding the discriminant is what seats the live world one slot
+    // past it.
     let live = member.as_str().and_then(|m| field.variant_fields(m));
-    if let Some(fields) = live {
-        for (slot, prop) in fields.values().map(|b| b.as_ref()).enumerate() {
-            // Slot 0 is the discriminant, so every variant field sits one past it.
-            let position = slot + 1;
-            if let Some(desc) = collapse_opt(&prop.description) {
-                nested.push(NestedComment {
-                    container_path: Vec::new(),
-                    position,
-                    text: desc,
-                    inline: false,
-                });
-            }
-            if prop.default.is_some() {
-                if let Some(eg) = prop.example.as_ref() {
-                    nested.push(NestedComment {
-                        container_path: Vec::new(),
-                        position,
-                        text: format!("e.g. {}", eg_hint(eg)),
-                        inline: false,
-                    });
-                }
-            }
-            let (json, fill) = scalar_cell(prop);
-            map.insert(prop.name.clone(), json);
-            if fill {
-                fills.push(vec![PathSegment::Key(prop.name.clone())]);
-            }
-            nested.push(NestedComment {
-                container_path: Vec::new(),
-                position,
-                text: type_expression(prop),
-                inline: true,
-            });
+    let nested = match live {
+        Some(fields) => {
+            let (nested, sub_fills) = build_property_mapping(&mut map, fields, &[]);
+            fills.extend(sub_fills);
+            nested
         }
-    }
+        None => Vec::new(),
+    };
 
     push_container_field(
         items,

--- a/crates/core/src/quill/tests/variant_tests.rs
+++ b/crates/core/src/quill/tests/variant_tests.rs
@@ -608,6 +608,84 @@ fn the_blueprint_emits_the_default_worlds_cells_and_round_trips() {
     assert!(value.get("controlled_by").is_some());
 }
 
+/// A cell holds a container like any field, so the blueprint expands one per
+/// property. A flattened cell would hand the author a scalar slot where the
+/// schema wants a mapping, drop every property's own description and `default:`,
+/// and stamp the marker on a path the obligation predicate never addresses.
+#[test]
+fn the_blueprint_expands_a_container_cell_per_property() {
+    const YAML: &str = r#"
+quill:
+  name: variant_container
+  version: "0.1.0"
+  backend: typst
+  description: variant container probe
+
+typst:
+  plate_file: plate.typ
+
+main:
+  fields:
+    classification:
+      type: enum
+      values: [UNCLASSIFIED, CUI]
+      default: CUI
+      variants:
+        CUI:
+          controlled_by:
+            type: object
+            description: Controlling office.
+            properties:
+              office: { type: string, description: Office symbol. }
+              phone: { type: string, default: "" }
+          citations:
+            type: array
+            items:
+              type: object
+              properties:
+                src: { type: string }
+"#;
+    let bp = QuillConfig::from_yaml(YAML).expect("loads").blueprint();
+    assert!(
+        bp.contains(concat!(
+            "  # Controlling office.\n",
+            "  controlled_by: # object\n",
+            "    # Office symbol.\n",
+            "    office: !must_fill # string\n",
+            "    phone: \"\" # string\n",
+            "  citations: # array<object>\n",
+            "    - src: !must_fill # string\n",
+        )),
+        "{bp}"
+    );
+
+    // The marked cells are the cells the schema-side predicate warns at: a
+    // container is a namespace on both surfaces, never a cell on either.
+    let document = Document::parse(&bp).expect("the blueprint parses").document;
+    let warned: Vec<String> = quill_from_yaml(YAML)
+        .validate(&document)
+        .into_iter()
+        .filter(|d| d.code.as_deref() == Some("validation::must_fill"))
+        .filter_map(|d| d.path)
+        .collect();
+    assert!(
+        warned.contains(&"main.classification.controlled_by.office".to_string())
+            && warned.contains(&"main.classification.citations[0].src".to_string()),
+        "{warned:?}"
+    );
+    assert!(
+        !warned
+            .iter()
+            .any(|p| p == "main.classification.controlled_by"),
+        "{warned:?}"
+    );
+
+    let reparsed = Document::parse(&document.to_markdown())
+        .expect("re-emit parses")
+        .document;
+    assert_eq!(document, reparsed, "the expansion round-trips");
+}
+
 /// Which world is live decides which fields are even candidates, so the
 /// discriminant must resolve before the field set is walked.
 #[test]


### PR DESCRIPTION
Closes #1328.

## The bug

A variant's cell went through `scalar_cell`, so an `object` or `array<object>` cell flattened to a bare marker:

```yaml
variants:
  CUI:
    controlled_by:
      type: object
      description: Controlling office.
      properties:
        office: { type: string, description: Office symbol. }
        phone:  { type: string, default: "" }
    citations:
      type: array
      items: { type: object, properties: { src: { type: string } } }
```

emitted

```
classification: # enum<UNCLASSIFIED | CUI>
  value: CUI
  # Controlling office.
  controlled_by: !must_fill # object
  citations: !must_fill # array<object>
```

Three things go wrong there. The blueprint hands the author a scalar slot where the schema types a mapping, so filling it in as shown produces a type error. Every property's own description, `default:` and annotation is dropped — `phone`'s `default: ""` never reaches the reader at all. And the `!must_fill` lands on `classification.controlled_by`, a path the obligation predicate never addresses: `collect_unauthored_field` recurses and warns per leaf.

## Why expansion is the intended output

Issue #1328 leaves the intended behavior open as step 1. It is already settled everywhere else in the tree — `blank`, `resolve_value_sourced`, `collect_unauthored_field`, `seed_field` and `build_transform_schema` all recurse into a container-typed variant cell, `a_variant_field_holds_a_container` pins that a cell may hold one, and `BLUEPRINT.md`'s marker table already reads *"per-field recursion in the live world"*. The blueprint was the sole surface that didn't.

Now:

```
classification: # enum<UNCLASSIFIED | CUI>
  value: CUI
  # Controlling office.
  controlled_by: # object
    # Office symbol.
    office: !must_fill # string
    phone: "" # string
  citations: # array<object>
    - src: !must_fill # string
```

## The merge

The issue proposes a `position_offset: usize` parameter on `build_property_mapping`. That puts "positions may be shifted by any amount" in the signature to express one fact. Instead the function takes the mapping it fills and reads each property's slot off `map.len()` — the position *is* where the property lands. Plain callers hand over an empty map and get the old numbering; `append_variant` hands over a map already holding the discriminant, and the live world seats itself one past it. No offset parameter, no cell-strategy flag, and the duplicated loop is gone (27 insertions, 49 deletions in `blueprint.rs`).

## Verification

- New `the_blueprint_expands_a_container_cell_per_property` in `variant_tests.rs` pins the expansion, that the container carries no marker while its leaves do, that the marked cells are exactly the paths `Quill::validate` warns at (`…controlled_by.office`, `…citations[0].src`), and that the result round-trips. Confirmed it fails against the pre-fix code.
- `cargo test --workspace` passes; no new clippy warnings.
- Scalar variant cells are byte-identical, so no real quill's blueprint changes — `usaf_memo`'s `classification` variant carries only string cells.


---
_Generated by [Claude Code](https://claude.ai/code/session_019d9LRJezFdjRg8hUrvMf1B)_