### PR TITLE
refactor(core): one `Codec` value behind every content read

### DIFF
--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -978,6 +978,7 @@ fn validate_dto_payload(payload: &Payload) -> Result<(), StorageError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::document::Codec;
 
     fn sample() -> Document {
         Document::parse(
@@ -1039,7 +1040,7 @@ This body and the metadata above are an indorsement card.
         let stored = serde_json::to_string(&doc).unwrap();
         let restored: Document = serde_json::from_str(&stored).unwrap();
         assert_eq!(doc, restored, "content field must survive storage round-trip");
-        let read = restored.main().field_richtext("intro").unwrap().unwrap();
+        let read = restored.main().field_content("intro", Codec::Richtext).unwrap().unwrap();
         assert!(
             read.marks.iter().any(|m| matches!(m.kind, MarkKind::Underline)),
             "underline (content-only) must survive the DTO carrier"

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -18,7 +18,7 @@ use quillmark_content::{ApplyError, ChangeBundle, Content, Delta};
 use crate::document::meta::{validate_composable_kind, CardKindError};
 use crate::error::diag_args;
 use crate::document::payload::MetaKey;
-use crate::document::{Card, Document, Payload, RichtextDecodeError};
+use crate::document::{Card, Codec, ContentDecodeError, Document, Payload};
 use crate::quill::{CoercionError, FieldSchema, FieldType, Leniency, QuillConfig};
 use crate::value::{PathSegment, QuillValue};
 use crate::version::QuillReference;
@@ -313,12 +313,19 @@ fn check_kind(kind: &str) -> Result<(), EditError> {
     })
 }
 
-/// A decode failure on the field itself, under the codec that ran.
-fn field_decode(name: &str, codec: &str, e: RichtextDecodeError) -> EditError {
+/// A decode failure at an address, under the codec that ran. The one
+/// [`EditError::FieldDecode`] constructor for a codec outcome, shared with the
+/// schema-bound reads in [`reader`](crate::reader).
+pub(crate) fn field_decode(
+    name: &str,
+    at: &[PathSegment],
+    codec: Codec,
+    e: ContentDecodeError,
+) -> EditError {
     EditError::FieldDecode {
         field: name.to_string(),
-        at: Vec::new(),
-        codec: codec.to_string(),
+        at: at.to_vec(),
+        codec: codec.name().to_string(),
         message: e.into_message(),
     }
 }
@@ -786,9 +793,9 @@ impl Card {
         if !is_valid_field_name(name) {
             return Err(EditError::InvalidFieldName(name.to_string()));
         }
-        let base = match self.field_richtext(name) {
+        let base = match self.field_content(name, Codec::Richtext) {
             Some(Ok(rt)) => rt,
-            Some(Err(e)) => return Err(field_decode(name, CODEC_RICHTEXT, e)),
+            Some(Err(e)) => return Err(field_decode(name, &[], Codec::Richtext, e)),
             None => Content::empty(),
         };
         diff_import(&base, &body.into()).map_err(EditError::Import)
@@ -871,9 +878,9 @@ impl Card {
         if !is_valid_field_name(name) {
             return Err(EditError::InvalidFieldName(name.to_string()));
         }
-        let base = match self.field_plaintext_content(name) {
-            Some(Ok(rt)) => quillmark_content::export::to_plaintext(&rt),
-            Some(Err(e)) => return Err(field_decode(name, CODEC_PLAINTEXT, e)),
+        let base = match self.field_text(name, Codec::Plaintext) {
+            Some(Ok(text)) => text,
+            Some(Err(e)) => return Err(field_decode(name, &[], Codec::Plaintext, e)),
             None => String::new(),
         };
         // The strict write is the codec: it runs the `from_plaintext` boundary
@@ -923,9 +930,9 @@ impl Card {
         name: &str,
         bundle: &ChangeBundle,
     ) -> Result<(), EditError> {
-        let mut content = match self.field_richtext(name) {
+        let mut content = match self.field_content(name, Codec::Richtext) {
             Some(Ok(rt)) => rt,
-            Some(Err(e)) => return Err(field_decode(name, CODEC_RICHTEXT, e)),
+            Some(Err(e)) => return Err(field_decode(name, &[], Codec::Richtext, e)),
             // Only this arm creates; the `Some` arms resolved an existing field.
             None => {
                 if !is_valid_field_name(name) {

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -23,82 +23,104 @@ pub(crate) fn import_body(md: &str) -> Result<Content, ImportError> {
     }
 }
 
-/// Which encoding a `decode_richtext_value` failure came from, so a call site
+/// Which encoding a [`Codec::decode_value`] failure came from, so a call site
 /// can prefix its diagnostic per encoding.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-pub(crate) enum RichtextDecodeError {
+pub(crate) enum ContentDecodeError {
     NotContent(String),
     BadMarkdown(String),
 }
 
-impl RichtextDecodeError {
+impl ContentDecodeError {
     pub(crate) fn into_message(self) -> String {
         match self {
-            RichtextDecodeError::NotContent(m) | RichtextDecodeError::BadMarkdown(m) => m,
+            ContentDecodeError::NotContent(m) | ContentDecodeError::BadMarkdown(m) => m,
         }
     }
 }
 
-/// Decode a JSON value in either accepted richtext encoding: a canonical content
-/// object, or an authored markdown string. `None` when the value is neither an
-/// object nor a string; the call site handles those shapes and maps the error
-/// into its own type.
-pub(crate) fn decode_richtext_value(
-    value: &serde_json::Value,
-) -> Option<Result<Content, RichtextDecodeError>> {
-    match value {
-        serde_json::Value::Object(_) => Some(
-            quillmark_content::serial::from_canonical_value(value)
-                .map_err(|e| RichtextDecodeError::NotContent(e.to_string())),
-        ),
-        serde_json::Value::String(md) => {
-            Some(import_body(md).map_err(|e| RichtextDecodeError::BadMarkdown(e.to_string())))
+/// A content codec: which authored string a [`Content`] field accepts, and which
+/// text a stored content projects back to. Both codecs also accept a canonical
+/// content object, so a codec is exactly the string end of the round trip. The
+/// declared type names one (`reader::content_codec`), and every schema-bound
+/// content read and projection runs the codec it names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Codec {
+    /// A string is markdown, and a content projects back to markdown — lossy,
+    /// content-only marks not surviving.
+    Richtext,
+    /// A string is literal text (`*hi*` stays four characters), and a content
+    /// projects back verbatim.
+    Plaintext,
+}
+
+impl Codec {
+    /// The schema keyword declaring this codec, carried verbatim on
+    /// [`EditError::FieldDecode`].
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Codec::Richtext => edit::CODEC_RICHTEXT,
+            Codec::Plaintext => edit::CODEC_PLAINTEXT,
         }
-        _ => None,
     }
-}
 
-/// The plaintext twin of [`decode_richtext_value`]: a string imports verbatim
-/// (never as markdown, so `*hi*` stays four plain characters), so only the
-/// object branch can fail.
-pub(crate) fn decode_plaintext_value(
-    value: &serde_json::Value,
-) -> Option<Result<Content, String>> {
-    match value {
-        serde_json::Value::Object(_) => {
-            Some(quillmark_content::serial::from_canonical_value(value).map_err(|e| e.to_string()))
+    /// How this codec reads a stored string, for the shape-mismatch message.
+    fn string_form(self) -> &'static str {
+        match self {
+            Codec::Richtext => "a markdown string",
+            Codec::Plaintext => "a string",
         }
-        serde_json::Value::String(s) => Some(Ok(quillmark_content::from_plaintext(s))),
-        _ => None,
     }
-}
 
-/// [`decode_richtext_value`] closed over the shapes a stored field can hold: a
-/// null is the empty content (null ≡ absent), and anything neither object nor
-/// string is a decode failure.
-pub(crate) fn decode_richtext_field(
-    value: &serde_json::Value,
-) -> Result<Content, RichtextDecodeError> {
-    match decode_richtext_value(value) {
-        Some(result) => result,
-        None if value.is_null() => Ok(Content::empty()),
-        None => Err(RichtextDecodeError::NotContent(
-            "expected a richtext content object or a markdown string".to_string(),
-        )),
+    /// Decode a JSON value in either accepted encoding: a canonical content
+    /// object, or an authored string read this codec's way. `None` when the value
+    /// is neither an object nor a string; the call site handles those shapes and
+    /// maps the error into its own type.
+    pub(crate) fn decode_value(
+        self,
+        value: &serde_json::Value,
+    ) -> Option<Result<Content, ContentDecodeError>> {
+        match value {
+            serde_json::Value::Object(_) => Some(
+                quillmark_content::serial::from_canonical_value(value)
+                    .map_err(|e| ContentDecodeError::NotContent(e.to_string())),
+            ),
+            serde_json::Value::String(s) => Some(match self {
+                Codec::Richtext => {
+                    import_body(s).map_err(|e| ContentDecodeError::BadMarkdown(e.to_string()))
+                }
+                Codec::Plaintext => Ok(quillmark_content::from_plaintext(s)),
+            }),
+            _ => None,
+        }
     }
-}
 
-/// The plaintext twin of [`decode_richtext_field`].
-pub(crate) fn decode_plaintext_field(
-    value: &serde_json::Value,
-) -> Result<Content, RichtextDecodeError> {
-    match decode_plaintext_value(value) {
-        Some(result) => result.map_err(RichtextDecodeError::NotContent),
-        None if value.is_null() => Ok(Content::empty()),
-        None => Err(RichtextDecodeError::NotContent(
-            "expected a plaintext content object or a string".to_string(),
-        )),
+    /// [`decode_value`](Self::decode_value) closed over the shapes a stored field
+    /// can hold: a null is the empty content (null ≡ absent), and anything
+    /// neither object nor string is a decode failure.
+    pub(crate) fn decode_field(
+        self,
+        value: &serde_json::Value,
+    ) -> Result<Content, ContentDecodeError> {
+        match self.decode_value(value) {
+            Some(result) => result,
+            None if value.is_null() => Ok(Content::empty()),
+            None => Err(ContentDecodeError::NotContent(format!(
+                "expected a {} content object or {}",
+                self.name(),
+                self.string_form()
+            ))),
+        }
+    }
+
+    /// Project a content back to this codec's text: the inverse of its string
+    /// encoding.
+    pub(crate) fn project(self, content: &Content) -> String {
+        match self {
+            Codec::Richtext => quillmark_content::export::to_markdown(content),
+            Codec::Plaintext => quillmark_content::export::to_plaintext(content),
+        }
     }
 }
 
@@ -222,61 +244,35 @@ impl Card {
         &mut self.body
     }
 
-    /// Read a richtext-valued user field back as a [`Content`]: the field-level
-    /// twin of [`Card::body`]. `None` when absent, `Some(Err(_))` when present
-    /// but neither a content object nor importable markdown. A `Document`
-    /// carries no schema, so the caller names a field it knows is richtext.
-    pub(crate) fn field_richtext(&self, name: &str) -> Option<Result<Content, RichtextDecodeError>> {
-        Some(crate::document::decode_richtext_field(
-            self.payload.get(name)?.as_json(),
-        ))
-    }
-
-    /// The markdown projection of a richtext-valued field (`export ∘ decode`),
-    /// carrying [`field_richtext`](Card::field_richtext)'s `None`/`Ok`/`Err`.
-    pub(crate) fn field_markdown(&self, name: &str) -> Option<Result<String, RichtextDecodeError>> {
-        Some(self.field_richtext(name)?.map(|rt| quillmark_content::export::to_markdown(&rt)))
-    }
-
-    /// Read a plaintext-valued user field back as a [`Content`] content: the
-    /// literal-codec twin of [`field_richtext`](Card::field_richtext). A stored
-    /// string imports verbatim (`*hi*` is four characters, not emphasis), an
-    /// already-canonical content decodes losslessly: the same dispatch coercion
-    /// and validation run for a `plaintext` field, so the read and the render
-    /// agree on the codec.
+    /// Read a content-valued user field back through `codec`: the field-level
+    /// twin of [`Card::body`].
     ///
     /// - `None`: the field is absent.
-    /// - `Some(Ok(rt))`: decoded content.
-    /// - `Some(Err(_))`: the field is present but neither a content object nor a
-    ///   string (e.g. a bare number a `store_field` wrote).
+    /// - `Some(Ok(content))`: decoded content, from either of the codec's
+    ///   encodings — a stored string and an already-canonical content object read
+    ///   back the same.
+    /// - `Some(Err(_))`: the field is present but decodes under neither (e.g. a
+    ///   bare number an opaque `store_field` wrote).
     ///
-    /// A `Document` carries no schema, so the caller names a field it knows is
-    /// plaintext; the schema-bound door is
+    /// A `Document` carries no schema, so the caller names the codec the field is
+    /// declared at; the schema-bound door is
     /// [`TypedReader::get_content`](crate::TypedReader::get_content).
-    pub(crate) fn field_plaintext_content(
+    pub(crate) fn field_content(
         &self,
         name: &str,
-    ) -> Option<Result<Content, RichtextDecodeError>> {
-        Some(crate::document::decode_plaintext_field(
-            self.payload.get(name)?.as_json(),
-        ))
+        codec: Codec,
+    ) -> Option<Result<Content, ContentDecodeError>> {
+        Some(codec.decode_field(self.payload.get(name)?.as_json()))
     }
 
-    /// The plaintext projection of a content-valued field (`to_plaintext ∘
-    /// decode`), the literal-codec twin of [`field_markdown`](Card::field_markdown),
-    /// for a `plaintext`-typed field: marks are never interpreted, so the text is
-    /// verbatim both ways. Carries
-    /// [`field_plaintext_content`](Card::field_plaintext_content)'s `Ok`/`Err`
-    /// decode outcome:
-    ///
-    /// - `None`: the field is absent.
-    /// - `Some(Ok(text))`: the projected literal text.
-    /// - `Some(Err(_))`: the field is present but does not decode as content.
-    pub(crate) fn field_plaintext(&self, name: &str) -> Option<Result<String, RichtextDecodeError>> {
-        Some(
-            self.field_plaintext_content(name)?
-                .map(|rt| quillmark_content::export::to_plaintext(&rt)),
-        )
+    /// The text projection of a content-valued field (`project ∘ decode`),
+    /// carrying [`field_content`](Card::field_content)'s `None`/`Ok`/`Err`.
+    pub(crate) fn field_text(
+        &self,
+        name: &str,
+        codec: Codec,
+    ) -> Option<Result<String, ContentDecodeError>> {
+        Some(self.field_content(name, codec)?.map(|c| codec.project(&c)))
     }
 }
 

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -1,7 +1,7 @@
 
 use crate::document::edit::{is_valid_field_name, EditError};
 use crate::document::meta::is_valid_kind_name;
-use crate::document::{Card, Document};
+use crate::document::{Card, Codec, Document};
 use crate::value::QuillValue;
 use crate::version::QuillReference;
 use std::str::FromStr;
@@ -338,7 +338,7 @@ fn test_overwrite_field_sets_directly() {
 
     let mut card = Card::new("note").unwrap();
     card.overwrite_field("intro", content.clone()).unwrap();
-    let read = card.field_richtext("intro").unwrap().unwrap();
+    let read = card.field_content("intro", Codec::Richtext).unwrap().unwrap();
     assert_eq!(read, content);
     assert!(read.marks.iter().any(|m| matches!(m.kind, MarkKind::Underline)));
 
@@ -358,14 +358,14 @@ fn test_revise_field_diff_imports_and_returns_delta() {
     let delta = card.revise_field("intro", "hello target world").unwrap();
     assert!(!delta.ops.is_empty());
 
-    let mut base = card.field_richtext("intro").unwrap().unwrap();
+    let mut base = card.field_content("intro", Codec::Richtext).unwrap().unwrap();
     // 6..12 is "target".
     base.marks
         .push(Mark::new(6, 12, MarkKind::Anchor { id: "c1".into() }));
     base.normalize();
     card.overwrite_field("intro", base).unwrap();
     card.revise_field("intro", "why keep the target here").unwrap();
-    let read = card.field_richtext("intro").unwrap().unwrap();
+    let read = card.field_content("intro", Codec::Richtext).unwrap().unwrap();
     assert!(read
         .marks
         .iter()
@@ -396,7 +396,7 @@ fn test_revise_field_checked_preserves_anchors_and_enforces_inline() {
         .unwrap();
     assert!(!delta.ops.is_empty());
 
-    let mut base = card.field_richtext("subject").unwrap().unwrap();
+    let mut base = card.field_content("subject", Codec::Richtext).unwrap().unwrap();
     // 6..12 is "target".
     base.marks
         .push(Mark::new(6, 12, MarkKind::Anchor { id: "c1".into() }));
@@ -404,7 +404,7 @@ fn test_revise_field_checked_preserves_anchors_and_enforces_inline() {
     card.overwrite_field("subject", base).unwrap();
     card.revise_field_checked("subject", "why keep the target here", &inline)
         .unwrap();
-    let read = card.field_richtext("subject").unwrap().unwrap();
+    let read = card.field_content("subject", Codec::Richtext).unwrap().unwrap();
     assert!(
         read.marks
             .iter()
@@ -412,19 +412,19 @@ fn test_revise_field_checked_preserves_anchors_and_enforces_inline() {
         "anchor should rebase onto surviving text, unlike the cold commit_field"
     );
 
-    let before = card.field_markdown("subject").unwrap().unwrap();
+    let before = card.field_text("subject", Codec::Richtext).unwrap().unwrap();
     let err = card
         .revise_field_checked("subject", "line one\n\nline two", &inline)
         .unwrap_err();
     assert_eq!(err.code(), "edit::field_not_inline");
-    assert_eq!(card.field_markdown("subject").unwrap().unwrap(), before);
+    assert_eq!(card.field_text("subject", Codec::Richtext).unwrap().unwrap(), before);
 
     let block = FieldSchema::new("body".to_string(), FieldType::RichText { inline: false }, None);
     let d = card
         .revise_field_checked("body", "para one\n\npara two", &block)
         .unwrap();
     assert!(!d.ops.is_empty());
-    assert!(card.field_markdown("body").unwrap().unwrap().contains("para two"));
+    assert!(card.field_text("body", Codec::Richtext).unwrap().unwrap().contains("para two"));
 }
 
 #[test]
@@ -440,7 +440,7 @@ fn test_commit_field_richtext_content_object_reads_back() {
     commit_richtext(&mut card, "intro", &json, false).unwrap();
 
     assert!(card.payload().get("intro").unwrap().as_json().is_object());
-    let read = card.field_richtext("intro").unwrap().unwrap();
+    let read = card.field_content("intro", Codec::Richtext).unwrap().unwrap();
     assert_eq!(read, content);
     assert!(read.marks.iter().any(|m| matches!(m.kind, MarkKind::Underline)));
 }
@@ -450,11 +450,11 @@ fn test_commit_field_richtext_markdown_null_and_rejects_bad() {
     let mut card = Card::new("note").unwrap();
 
     commit_richtext(&mut card, "intro", &serde_json::json!("**bold** intro"), false).unwrap();
-    assert_eq!(card.field_markdown("intro").unwrap().unwrap(), "**bold** intro");
+    assert_eq!(card.field_text("intro", Codec::Richtext).unwrap().unwrap(), "**bold** intro");
 
     commit_richtext(&mut card, "intro", &serde_json::Value::Null, false).unwrap();
     assert!(card.payload().get("intro").unwrap().as_json().is_null());
-    assert!(card.field_richtext("intro").unwrap().unwrap().is_blank());
+    assert!(card.field_content("intro", Codec::Richtext).unwrap().unwrap().is_blank());
 
     assert_eq!(
         commit_richtext(&mut card, "intro", &serde_json::json!({ "not": "a content" }), false)
@@ -475,7 +475,7 @@ fn test_commit_field_richtext_inline_enforced_at_write() {
     let mut card = Card::new("note").unwrap();
 
     commit_richtext(&mut card, "title", &serde_json::json!("A single line"), true).unwrap();
-    assert_eq!(card.field_markdown("title").unwrap().unwrap(), "A single line");
+    assert_eq!(card.field_text("title", Codec::Richtext).unwrap().unwrap(), "A single line");
 
     let err = commit_richtext(
         &mut card,
@@ -485,7 +485,7 @@ fn test_commit_field_richtext_inline_enforced_at_write() {
     )
     .unwrap_err();
     assert_eq!(err.code(), "edit::field_not_inline");
-    assert_eq!(card.field_markdown("title").unwrap().unwrap(), "A single line");
+    assert_eq!(card.field_text("title", Codec::Richtext).unwrap().unwrap(), "A single line");
 }
 
 #[test]
@@ -577,14 +577,14 @@ fn test_commit_field_rejects_bad_name() {
 }
 
 #[test]
-fn test_field_richtext_absent_and_non_richtext() {
+fn test_field_content_absent_and_non_content() {
     let mut card = Card::new("note").unwrap();
-    assert!(card.field_richtext("missing").is_none());
-    assert!(card.field_markdown("missing").is_none());
+    assert!(card.field_content("missing", Codec::Richtext).is_none());
+    assert!(card.field_text("missing", Codec::Richtext).is_none());
 
     card.store_field("count", 3).unwrap();
-    assert!(card.field_richtext("count").unwrap().is_err());
-    assert!(card.field_markdown("count").unwrap().is_err());
+    assert!(card.field_content("count", Codec::Richtext).unwrap().is_err());
+    assert!(card.field_text("count", Codec::Richtext).unwrap().is_err());
 }
 
 #[test]
@@ -764,7 +764,7 @@ fn test_apply_field_change_splices_and_persists() {
     .unwrap();
 
     assert!(card.payload().get("intro").unwrap().as_json().is_object());
-    let rt = card.field_richtext("intro").unwrap().unwrap();
+    let rt = card.field_content("intro", Codec::Richtext).unwrap().unwrap();
     assert_eq!(rt.text, "abXc");
     assert!(rt.marks.iter().any(|m| matches!(m.kind, MarkKind::Strong)));
 }
@@ -788,7 +788,7 @@ fn test_apply_field_change_treats_an_absent_field_as_empty() {
     let mut card = Card::new("note").unwrap();
     card.apply_field_change("intro", &ChangeBundle::default())
         .expect("a zero-base bundle lands on the empty content");
-    assert_eq!(card.field_markdown("intro").unwrap().unwrap(), "");
+    assert_eq!(card.field_text("intro", Codec::Richtext).unwrap().unwrap(), "");
 
     let stale = ChangeBundle {
         delta: quillmark_content::Delta {

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -295,7 +295,7 @@ fn body_from_wire(body: &JsonValue) -> Result<Content, WireError> {
         key: "$body".to_string(),
         reason,
     };
-    match super::decode_richtext_value(body) {
+    match super::Codec::Richtext.decode_value(body) {
         Some(result) => result.map_err(|e| invalid(e.into_message())),
         None => match body {
             JsonValue::Null => Ok(Content::empty()),
@@ -333,6 +333,7 @@ fn validate_wire_field(key: &str, value: &JsonValue) -> Result<(), WireError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::document::Codec;
     use serde_json::json;
 
     /// Nested `!must_fill` markers inside a field value survive Card → wire →
@@ -390,7 +391,7 @@ mod tests {
 
         let back = Card::try_from(wire).expect("wire → card");
         assert_eq!(back, card, "content field must survive Card → wire → Card");
-        let read = back.field_richtext("intro").unwrap().unwrap();
+        let read = back.field_content("intro", Codec::Richtext).unwrap().unwrap();
         assert!(read.marks.iter().any(|m| matches!(m.kind, MarkKind::Underline)));
     }
 

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -303,7 +303,7 @@ impl QuillConfig {
     ///
     /// Validation keeps its own read-only dispatch (`validation::validate_value`),
     /// synced with this via the shared helpers `scalar_as_string` /
-    /// `decode_richtext_value`.
+    /// `Codec::Richtext.decode_value`.
     pub(crate) fn conform_value(
         value: &QuillValue,
         field_schema: &super::FieldSchema,
@@ -592,7 +592,7 @@ impl QuillConfig {
                 // lockstep with the validation-layer `validation::not_inline` check.
                 //
                 // This is the deliberately-lenient sibling of
-                // `document::decode_richtext_value` (used by the strict wire /
+                // `document::Codec::Richtext.decode_value` (used by the strict wire /
                 // literal / validation sites): the string branch below reduces a
                 // bare scalar or length-1 array to text before importing, which
                 // the strict decoder must not do, so it stays open-coded here.
@@ -609,14 +609,14 @@ impl QuillConfig {
                         }
                         Ok(())
                     };
-                // A strict write uses `decode_richtext_value` semantics: a
+                // A strict write uses `Codec::Richtext.decode_value` semantics: a
                 // canonical content object or a markdown string, nothing else. No
                 // scalar→string reduction (the render floor's lenient cascade
                 // below): a bare scalar for a richtext field fails the write. The
                 // messages mirror `Card::commit_field`'s richtext error variants,
                 // which the bindings key on.
                 if mode == Leniency::Write {
-                    let content = match crate::document::decode_richtext_value(json_value) {
+                    let content = match crate::document::Codec::Richtext.decode_value(json_value) {
                         Some(result) => result.map_err(|e| {
                             CoercionError::uncoercible(
                                 path,
@@ -2282,14 +2282,14 @@ fn literal_content(
     }
     match &field.r#type {
         FieldType::RichText { inline } => {
-            let rt = match crate::document::decode_richtext_value(json) {
+            let rt = match crate::document::Codec::Richtext.decode_value(json) {
                 Some(Ok(rt)) => rt,
                 Some(Err(e)) => {
                     let reason = match e {
-                        crate::document::RichtextDecodeError::BadMarkdown(m) => {
+                        crate::document::ContentDecodeError::BadMarkdown(m) => {
                             format!("markdown import failed: {m}")
                         }
-                        crate::document::RichtextDecodeError::NotContent(m) => {
+                        crate::document::ContentDecodeError::NotContent(m) => {
                             format!("not a valid richtext content: {m}")
                         }
                     };
@@ -2314,12 +2314,12 @@ fn literal_content(
             // verbatim (never markdown), so the cached content is plain by
             // construction; a content-object literal is revalidated. Shares the
             // one object-vs-string dispatch with the validation shape check.
-            let rt = match crate::document::decode_plaintext_value(json) {
+            let rt = match crate::document::Codec::Plaintext.decode_value(json) {
                 Some(Ok(rt)) => rt,
                 Some(Err(e)) => {
                     return Err(richtext_literal_error(
                         label,
-                        &format!("not a valid richtext content: {e}"),
+                        &format!("not a valid richtext content: {}", e.into_message()),
                     ))
                 }
                 None => {

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -559,8 +559,9 @@ fn validate_value(
     if type_valid {
         match field.r#type {
             FieldType::RichText { inline: true } => {
-                let parsed =
-                    crate::document::decode_richtext_value(value.as_json()).and_then(Result::ok);
+                let parsed = crate::document::Codec::Richtext
+                    .decode_value(value.as_json())
+                    .and_then(Result::ok);
                 if let Some(rt) = parsed {
                     if !rt.is_inline() {
                         errors.push(ValidationError::NotInline {
@@ -575,7 +576,8 @@ fn validate_value(
                 // a canonical content object. The plain constraint is primary;
                 // the single-line constraint applies only when `inline`. A decode
                 // error is another layer's to report (swallowed via `.ok()`).
-                if let Some(rt) = crate::document::decode_plaintext_value(value.as_json())
+                if let Some(rt) = crate::document::Codec::Plaintext
+                    .decode_value(value.as_json())
                     .and_then(Result::ok)
                 {
                     if !rt.is_plain() {

--- a/crates/core/src/reader.rs
+++ b/crates/core/src/reader.rs
@@ -37,8 +37,8 @@
 use indexmap::IndexMap;
 use quillmark_content::Content;
 
-use crate::document::edit::{CODEC_PLAINTEXT, CODEC_RICHTEXT};
-use crate::document::{Card, Document, EditError, RichtextDecodeError};
+use crate::document::edit::field_decode;
+use crate::document::{Card, Codec, Document, EditError};
 use crate::quill::{CardSchema, FieldSchema, FieldType, QuillConfig};
 use crate::value::{PathSegment, QuillValue};
 
@@ -208,23 +208,16 @@ fn read_field(
     let schema = fields_schema
         .and_then(|m| m.get(name))
         .ok_or_else(|| EditError::unknown_field(name))?;
-    match schema.r#type {
-        FieldType::RichText { .. } => project(
-            card.field_markdown(name),
-            name,
-            CODEC_RICHTEXT,
-            ReadValue::Markdown,
-        ),
-        FieldType::PlainText { .. } => project(
-            card.field_plaintext(name),
-            name,
-            CODEC_PLAINTEXT,
-            ReadValue::Plaintext,
-        ),
-        _ => Ok(card
-            .payload()
-            .get(name)
-            .map(|v| ReadValue::Value(v.clone()))),
+    let Some(codec) = content_codec(&schema.r#type) else {
+        return Ok(card.payload().get(name).map(|v| ReadValue::Value(v.clone())));
+    };
+    match card.field_text(name, codec) {
+        None => Ok(None),
+        Some(Ok(text)) => Ok(Some(match codec {
+            Codec::Richtext => ReadValue::Markdown(text),
+            Codec::Plaintext => ReadValue::Plaintext(text),
+        })),
+        Some(Err(e)) => Err(field_decode(name, &[], codec, e)),
     }
 }
 
@@ -246,7 +239,7 @@ fn read_content(
     let leaf = schema_at(field, name, at)?;
     // The codec rides out of the dispatch: it is the declared type's, not the
     // stored shape's.
-    let (decode, codec) = content_codec(&leaf.r#type).ok_or_else(|| EditError::FieldNotContent {
+    let codec = content_codec(&leaf.r#type).ok_or_else(|| EditError::FieldNotContent {
         field: name.to_string(),
         at: at.to_vec(),
         declared: leaf.r#type.as_str().to_string(),
@@ -254,28 +247,20 @@ fn read_content(
     let Some(value) = card.payload().get(name).and_then(|v| value_at(v.as_json(), at)) else {
         return Ok(None);
     };
-    decode(value).map(Some).map_err(|e| EditError::FieldDecode {
-        field: name.to_string(),
-        at: at.to_vec(),
-        codec: codec.to_string(),
-        message: e.into_message(),
-    })
+    codec
+        .decode_field(value)
+        .map(Some)
+        .map_err(|e| field_decode(name, at, codec, e))
 }
 
-type ContentCodec = (
-    fn(&serde_json::Value) -> Result<Content, RichtextDecodeError>,
-    &'static str,
-);
-
 /// The one declared-type → codec dispatch: `None` for a type that is no content
-/// leaf. Every schema-bound [`Content`] read routes through this, so a codec
-/// change reaches the whole-field and the nested read by construction.
-fn content_codec(r#type: &FieldType) -> Option<ContentCodec> {
+/// leaf. Every schema-bound content read routes through this — the whole field,
+/// a nested leaf, and [`get`](TypedReader::get)'s text projection alike — so a
+/// codec change reaches all three by construction.
+fn content_codec(r#type: &FieldType) -> Option<Codec> {
     match r#type {
-        FieldType::RichText { .. } => Some((crate::document::decode_richtext_field, CODEC_RICHTEXT)),
-        FieldType::PlainText { .. } => {
-            Some((crate::document::decode_plaintext_field, CODEC_PLAINTEXT))
-        }
+        FieldType::RichText { .. } => Some(Codec::Richtext),
+        FieldType::PlainText { .. } => Some(Codec::Plaintext),
         _ => None,
     }
 }
@@ -336,28 +321,10 @@ fn value_at<'a>(value: &'a serde_json::Value, at: &[PathSegment]) -> Option<&'a 
     Some(cursor)
 }
 
-/// Lift a codec projection into a [`ReadValue`].
-fn project(
-    projection: Option<Result<String, RichtextDecodeError>>,
-    name: &str,
-    codec: &str,
-    wrap: fn(String) -> ReadValue,
-) -> Result<Option<ReadValue>, EditError> {
-    match projection {
-        None => Ok(None),
-        Some(Ok(text)) => Ok(Some(wrap(text))),
-        Some(Err(e)) => Err(EditError::FieldDecode {
-            field: name.to_string(),
-            at: Vec::new(),
-            codec: codec.to_string(),
-            message: e.into_message(),
-        }),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::document::edit::CODEC_RICHTEXT;
     use crate::document::Document;
     use crate::version::QuillReference;
     use std::str::FromStr;

--- a/crates/core/src/writer.rs
+++ b/crates/core/src/writer.rs
@@ -269,6 +269,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::document::Codec;
     use crate::document::{Card, Document};
     use crate::version::QuillReference;
     use std::str::FromStr;
@@ -313,7 +314,7 @@ card_kinds:
             doc.main().payload().get("qty").unwrap().as_json(),
             &serde_json::json!(3)
         );
-        assert_eq!(doc.main().field_markdown("subject").unwrap().unwrap(), "Hello");
+        assert_eq!(doc.main().field_text("subject", Codec::Richtext).unwrap().unwrap(), "Hello");
     }
 
     #[test]
@@ -355,7 +356,7 @@ card_kinds:
             .unwrap();
         assert_eq!(doc.cards().len(), 1);
         assert_eq!(doc.cards()[0].kind(), Some("note"));
-        assert_eq!(doc.cards()[0].field_markdown("body").unwrap().unwrap(), "**hi**");
+        assert_eq!(doc.cards()[0].field_text("body", Codec::Richtext).unwrap().unwrap(), "**hi**");
         assert_eq!(doc.cards()[0].body_markdown(), "card body");
     }
 
@@ -372,7 +373,7 @@ card_kinds:
         let bodies: Vec<String> = doc
             .cards()
             .iter()
-            .map(|c| c.field_markdown("body").unwrap().unwrap())
+            .map(|c| c.field_text("body", Codec::Richtext).unwrap().unwrap())
             .collect();
         assert_eq!(bodies, ["a", "b", "c"]);
 
@@ -389,7 +390,7 @@ card_kinds:
         {
             let mut ed = TypedWriter::new(&config, &mut doc);
             let removed = ed.remove_card(1).unwrap();
-            assert_eq!(removed.field_markdown("body").unwrap().unwrap(), "b");
+            assert_eq!(removed.field_text("body", Codec::Richtext).unwrap().unwrap(), "b");
             assert!(ed.remove_card(5).is_none());
         }
         assert_eq!(doc.cards().len(), 2);
@@ -420,7 +421,7 @@ card_kinds:
         let err = card_ed.set("stray", "v").unwrap_err();
         assert_eq!(err.code(), "edit::unknown_field");
 
-        assert_eq!(doc.cards()[0].field_markdown("body").unwrap().unwrap(), "**hi**");
+        assert_eq!(doc.cards()[0].field_text("body", Codec::Richtext).unwrap().unwrap(), "**hi**");
 
         let mut ed = TypedWriter::new(&config, &mut doc);
         assert!(matches!(
@@ -435,7 +436,7 @@ card_kinds:
         let mut doc = blank_doc();
         let mut ed = TypedWriter::new(&config, &mut doc);
         let _delta = ed.revise_field("subject", "Hello").unwrap();
-        assert_eq!(doc.main().field_markdown("subject").unwrap().unwrap(), "Hello");
+        assert_eq!(doc.main().field_text("subject", Codec::Richtext).unwrap().unwrap(), "Hello");
 
         let mut ed = TypedWriter::new(&config, &mut doc);
         assert_eq!(
@@ -445,7 +446,7 @@ card_kinds:
         // `richtext(inline)` rejects a multi-block result.
         let err = ed.revise_field("subject", "a\n\nb").unwrap_err();
         assert_eq!(err.code(), "edit::field_not_inline");
-        assert_eq!(doc.main().field_markdown("subject").unwrap().unwrap(), "Hello");
+        assert_eq!(doc.main().field_text("subject", Codec::Richtext).unwrap().unwrap(), "Hello");
     }
 
     #[test]
@@ -456,7 +457,7 @@ card_kinds:
 
         let mut ed = TypedWriter::new(&config, &mut doc);
         ed.card(0).unwrap().revise_field("body", "**hi**").unwrap();
-        assert_eq!(doc.cards()[0].field_markdown("body").unwrap().unwrap(), "**hi**");
+        assert_eq!(doc.cards()[0].field_text("body", Codec::Richtext).unwrap().unwrap(), "**hi**");
 
         let mut ed = TypedWriter::new(&config, &mut doc);
         assert_eq!(


### PR DESCRIPTION
Closes #1331.

## The lattice

The richtext/plaintext split was written out four times: two `decode_*_value`, two `decode_*_field`, two `Card::field_*` content accessors, two `Card::field_*` text projections. Two independent choices — which codec, which layer — spelled as eight functions.

`Codec` now carries the codec: `decode_value`, `decode_field`, `project`, `name`. `Card::field_content(name, codec)` and `field_text(name, codec)` replace the four accessors. `RichtextDecodeError` becomes `ContentDecodeError`, it having been the error of both codecs since plaintext landed — `pub(crate)` since 0.100→0.101, so no public surface moves and no migration note is due.

## The bypass

`content_codec` documented itself as "the one declared-type → codec dispatch … every schema-bound `Content` read routes through this", but `read_field` — behind `TypedReader::get` / `CardReader::get` — matched `FieldType` itself, respelled `CODEC_RICHTEXT` / `CODEC_PLAINTEXT`, and reached the codec through the two projections, whose only non-test callers were those two sites. It now resolves the codec through `content_codec` like `read_content` does, and both raise through one `field_decode` constructor.

## Divergences from the issue

- The issue offered a `Codec` enum **or** a 4-tuple `ContentCodec`. The enum: a tuple of function pointers cannot name its arms, and `ReadValue`'s constructor does not belong in a tuple living in `document`. The `Codec → ReadValue` wrap stays in `reader.rs` where `ReadValue` is defined, so `document` stays unaware of the reader's value type.
- `field_markdown` / `field_plaintext` do not become deletable as the issue says — they merge into `field_text(name, codec)`. Four accessors → two.

## Left alone

`QuillConfig::conform_value`'s open-coded richtext branch, whose own comment explains why: it is the render floor's *lenient* sibling (scalar→string reduction, length-1 array unwrap) that the strict decoder must not do. Folding it in would quietly loosen the strict-write path.

## Effect

Adding a third codec means adding one enum variant and letting the compiler point at the five genuinely per-codec facts (`name`, `string_form`, the string arm of `decode_value`, `project`, `content_codec`) plus the `ReadValue` wrap — instead of hunting eight functions across three files.

## Testing

`cargo test --workspace`: 1165 passed, 0 failed. Clippy and rustdoc clean on the touched files (the remaining warnings in those crates predate this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_012QN9TNQXkKiBT9fVyhBnMF)_