### PR TITLE
refactor: one constructor for a single-error-diagnostic RenderError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- refactor: **`RenderError::coded(code, message)` is the one constructor for a
+  single-error-diagnostic failure.** Nine sites across five crates spelled
+  `from_diag(Diagnostic::new(Severity::Error, msg).with_code(code))` by hand,
+  two of them as a per-crate `engine_err` helper the backends each carried
+  their own copy of. Additive to `quillmark-core`'s public API; no code, message
+  or shape changes.
+
 ## v0.108.3 - 2026-08-21
 
 - fix(typst): **a paragraph holding one bare `/` renders instead of failing the

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -18,8 +18,8 @@ use form::FormSpec;
 use quillmark_core::quill::QuillConfig;
 use quillmark_core::session::SessionHandle;
 use quillmark_core::{
-    Artifact, Backend, ChangeSet, Diagnostic, LiveSession, OutputFormat, Quill, RenderError,
-    RenderOptions, RenderResult, RenderedRegion, Severity,
+    Artifact, Backend, ChangeSet, LiveSession, OutputFormat, Quill, RenderError, RenderOptions,
+    RenderResult, RenderedRegion,
 };
 use quillmark_pdf::regions_of;
 use quillmark_pdf::{stamp, FieldSpec, StampOptions};
@@ -65,28 +65,28 @@ impl Backend for PdfformBackend {
         let base_pdf = files
             .get_file(FORM_PDF)
             .ok_or_else(|| {
-                engine_err(
+                RenderError::coded(
                     "pdfform::missing_form_pdf",
                     format!("pdfform quill is missing its `{FORM_PDF}` background"),
                 )
             })?
             .to_vec();
         let form_json = files.get_file(FORM_JSON).ok_or_else(|| {
-            engine_err(
+            RenderError::coded(
                 "pdfform::missing_form_json",
                 format!("pdfform quill is missing its `{FORM_JSON}` field spec"),
             )
         })?;
 
-        let spec =
-            FormSpec::parse(form_json).map_err(|e| engine_err(e.code(), e.to_string()))?;
+        let spec = FormSpec::parse(form_json)
+            .map_err(|e| RenderError::coded(e.code(), e.to_string()))?;
 
         // Page boxes drive the top-left → bottom-left flip (honouring a
         // non-zero page origin), and reading them surfaces a malformed base early.
         let page_boxes = quillmark_pdf::page_media_boxes(&base_pdf)?;
 
         let bound = bind::bind_widgets(&spec, source.config(), &page_boxes)
-            .map_err(|e| engine_err(e.code(), e.to_string()))?;
+            .map_err(|e| RenderError::coded(e.code(), e.to_string()))?;
 
         let field_specs = resolve_field_specs(&bound, json_data);
 
@@ -225,7 +225,7 @@ impl PdfformSession {
     /// caller's own per-format error code.
     fn open_flat(&self, code: &'static str, label: &str) -> Result<HayroPdf, RenderError> {
         HayroPdf::new(Arc::clone(&self.flat_pdf)).map_err(|_| {
-            engine_err(
+            RenderError::coded(
                 code,
                 format!("failed to parse pre-flattened PDF for {label} render"),
             )
@@ -262,7 +262,7 @@ impl PdfformSession {
             let cache = RenderCache::new();
             let pixmap = hayro_render(page, &cache, &interp, &render_settings);
             let png = pixmap.into_png().map_err(|e| {
-                engine_err(
+                RenderError::coded(
                     "pdfform::png_encoding",
                     format!("failed to encode page as PNG: {e}"),
                 )
@@ -301,10 +301,4 @@ fn standard_font_settings() -> InterpreterSettings {
 /// Owned by the backend, never defaulted from the leaf spine's version.
 fn default_producer() -> String {
     format!("Quillmark {}", env!("CARGO_PKG_VERSION"))
-}
-
-fn engine_err(code: &str, message: impl Into<String>) -> RenderError {
-    RenderError::from_diag(
-        Diagnostic::new(Severity::Error, message.into()).with_code(code.to_string()),
-    )
 }

--- a/crates/backends/typst/src/compile.rs
+++ b/crates/backends/typst/src/compile.rs
@@ -11,7 +11,7 @@ use typst_svg::SvgOptions;
 use crate::error_mapping::map_typst_errors;
 use crate::overlay;
 use crate::world::QuillWorld;
-use quillmark_core::{Artifact, Diagnostic, OutputFormat, RenderError, RenderResult, Severity};
+use quillmark_core::{Artifact, Diagnostic, OutputFormat, RenderError, RenderResult};
 use quillmark_pdf::{stamp, StampOptions};
 
 pub(crate) fn render_options(pixel_per_pt: f32) -> RenderOptions {
@@ -54,12 +54,9 @@ pub(crate) fn render_document_pages(
     producer: Option<&str>,
 ) -> Result<RenderResult, RenderError> {
     if format == OutputFormat::Pdf && pages.is_some() {
-        return Err(RenderError::from_diag(
-            Diagnostic::new(
-                Severity::Error,
-                "PDF does not support page selection; pass null/None to render the full document, or use PNG/SVG".to_string(),
-            )
-            .with_code("typst::pdf_page_selection_not_supported".to_string()),
+        return Err(RenderError::coded(
+            "typst::pdf_page_selection_not_supported",
+            "PDF does not support page selection; pass null/None to render the full document, or use PNG/SVG",
         ));
     }
 
@@ -69,15 +66,11 @@ pub(crate) fn render_document_pages(
             let out_of_bounds: Vec<usize> =
                 slice.iter().copied().filter(|&i| i >= page_count).collect();
             if !out_of_bounds.is_empty() {
-                return Err(RenderError::from_diag(
-                    Diagnostic::new(
-                        Severity::Error,
-                        format!(
-                            "Page index out of bounds (page_count={}); offending indices: {:?}. Check `LiveSession.pageCount` before requesting pages.",
-                            page_count, out_of_bounds
-                        ),
-                    )
-                    .with_code("typst::page_index_out_of_bounds".to_string()),
+                return Err(RenderError::coded(
+                    "typst::page_index_out_of_bounds",
+                    format!(
+                        "Page index out of bounds (page_count={page_count}); offending indices: {out_of_bounds:?}. Check `LiveSession.pageCount` before requesting pages."
+                    ),
                 ));
             }
             slice.to_vec()
@@ -106,10 +99,7 @@ pub(crate) fn render_document_pages(
             for idx in selected_indices {
                 let pixmap = typst_render::render(&document.pages()[idx], &opts);
                 let png_data = pixmap.encode_png().map_err(|e| {
-                    RenderError::from_diag(
-                        Diagnostic::new(Severity::Error, format!("PNG encoding failed: {}", e))
-                            .with_code("typst::png_encoding".to_string()),
-                    )
+                    RenderError::coded("typst::png_encoding", format!("PNG encoding failed: {e}"))
                 })?;
                 artifacts.push(Artifact::new(png_data, OutputFormat::Png));
             }
@@ -117,9 +107,9 @@ pub(crate) fn render_document_pages(
         }
         OutputFormat::Pdf => {
             let pdf = typst_pdf::pdf(document, &PdfOptions::default()).map_err(|e| {
-                RenderError::from_diag(
-                    Diagnostic::new(Severity::Error, format!("PDF generation failed: {:?}", e))
-                        .with_code("typst::pdf_generation".to_string()),
+                RenderError::coded(
+                    "typst::pdf_generation",
+                    format!("PDF generation failed: {e:?}"),
                 )
             })?;
             let field_specs = overlay::build_field_specs(document, field_placements)?;

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -93,7 +93,7 @@ fn recompile(
 ) -> Result<Compiled, RenderError> {
     let mut windows = world
         .inject_helper_package(data, schema_meta)
-        .map_err(|e| engine_err(e.code(), e.to_string()))?;
+        .map_err(|e| RenderError::coded(e.code(), e.to_string()))?;
     windows.extend(scalar_windows.iter().cloned());
 
     let (document, compile_warnings) = compile::compile_document(world)?;
@@ -369,7 +369,7 @@ fn helper_source(world: &world::QuillWorld) -> Result<typst::syntax::Source, Ren
     world
         .source(world::QuillWorld::helper_fid("lib.typ"))
         .map_err(|e| {
-            engine_err(
+            RenderError::coded(
                 "typst::helper_source",
                 format!("helper lib.typ unreadable: {e}"),
             )
@@ -465,25 +465,18 @@ fn read_plate(source: &Quill) -> Result<String, RenderError> {
     };
 
     let bytes = source.files().get_file(plate_file).ok_or_else(|| {
-        engine_err(
+        RenderError::coded(
             "typst::plate_missing",
             format!("plate file '{plate_file}' not found in the quill's file tree"),
         )
     })?;
 
     String::from_utf8(bytes.to_vec()).map_err(|e| {
-        engine_err(
+        RenderError::coded(
             "typst::invalid_utf8",
             format!("plate file '{plate_file}' is not valid UTF-8: {e}"),
         )
     })
-}
-
-/// A single-diagnostic [`RenderError`] carrying `code`.
-pub(crate) fn engine_err(code: &str, message: impl Into<String>) -> RenderError {
-    RenderError::from_diag(
-        Diagnostic::new(Severity::Error, message.into()).with_code(code.to_string()),
-    )
 }
 
 /// The steps a schema address may take out of one node, and nothing else: the

--- a/crates/backends/typst/src/overlay/extract.rs
+++ b/crates/backends/typst/src/overlay/extract.rs
@@ -14,7 +14,7 @@ use quillmark_core::{Diagnostic, RenderError, Severity};
 
 use quillmark_pdf::{FormFont, TextAlign};
 
-use super::{engine_err, FieldKind, FieldPlacement};
+use super::{FieldKind, FieldPlacement};
 
 const FIELD_LABEL: &str = "__qm_field__";
 const CODE_INTERNAL: &str = "typst::overlay_internal";
@@ -22,7 +22,7 @@ const CODE_INTERNAL: &str = "typst::overlay_internal";
 pub(crate) fn extract(doc: &PagedDocument) -> Result<Vec<FieldPlacement>, RenderError> {
     let intro = doc.introspector();
     let label = Label::new(PicoStr::intern(FIELD_LABEL)).ok_or_else(|| {
-        engine_err(
+        RenderError::coded(
             CODE_INTERNAL,
             "FIELD_LABEL must be a non-empty interned string",
         )
@@ -39,12 +39,17 @@ pub(crate) fn extract(doc: &PagedDocument) -> Result<Vec<FieldPlacement>, Render
         let dict = match c.get_by_name("value") {
             Ok(Value::Dict(d)) => d,
             Ok(other) => {
-                return Err(engine_err(
+                return Err(RenderError::coded(
                     CODE_INTERNAL,
                     format!("expected metadata value to be a dict, got {}", other.ty()),
                 ))
             }
-            Err(e) => return Err(engine_err(CODE_INTERNAL, format!("metadata.value missing: {e:?}"))),
+            Err(e) => {
+                return Err(RenderError::coded(
+                    CODE_INTERNAL,
+                    format!("metadata.value missing: {e:?}"),
+                ))
+            }
         };
         if read_str(&dict, "kind")? != FIELD_LABEL {
             // User attached <__qm_field__> to unrelated metadata; ignore it.
@@ -61,7 +66,9 @@ pub(crate) fn extract(doc: &PagedDocument) -> Result<Vec<FieldPlacement>, Render
         let align = read_align(&dict)?;
         let loc = c
             .location()
-            .ok_or_else(|| engine_err(CODE_INTERNAL, "form-field metadata is not located"))?;
+            .ok_or_else(|| {
+                RenderError::coded(CODE_INTERNAL, "form-field metadata is not located")
+            })?;
 
         if let Some(&prior) = by_name.get(&name) {
             return Err(duplicate_field_error(&name, prior, loc));
@@ -70,7 +77,9 @@ pub(crate) fn extract(doc: &PagedDocument) -> Result<Vec<FieldPlacement>, Render
 
         let pos = intro
             .position(loc)
-            .ok_or_else(|| engine_err(CODE_INTERNAL, "form-field metadata has no position"))?;
+            .ok_or_else(|| {
+                RenderError::coded(CODE_INTERNAL, "form-field metadata has no position")
+            })?;
         placements.push(FieldPlacement {
             name,
             schema_field,
@@ -111,7 +120,7 @@ fn read_field_kind(
             value: read_value_str(d, "value")?,
         }),
         "signature" => Ok(FieldKind::Signature),
-        other => Err(engine_err(
+        other => Err(RenderError::coded(
             CODE_INTERNAL,
             format!("unknown form-field type {other:?}"),
         )),
@@ -125,7 +134,7 @@ fn read_font(d: &typst::foundations::Dict) -> Result<FormFont, RenderError> {
         "helvetica" => Ok(FormFont::Helvetica),
         "times" => Ok(FormFont::Times),
         "courier" => Ok(FormFont::Courier),
-        other => Err(engine_err(
+        other => Err(RenderError::coded(
             CODE_INTERNAL,
             format!("unknown form-field font {other:?}"),
         )),
@@ -137,7 +146,7 @@ fn read_align(d: &typst::foundations::Dict) -> Result<TextAlign, RenderError> {
         "left" => Ok(TextAlign::Left),
         "center" => Ok(TextAlign::Center),
         "right" => Ok(TextAlign::Right),
-        other => Err(engine_err(
+        other => Err(RenderError::coded(
             CODE_INTERNAL,
             format!("unknown form-field align {other:?}"),
         )),
@@ -154,11 +163,11 @@ fn read_opt_f64(d: &typst::foundations::Dict, key: &str) -> Result<Option<f64>, 
 fn read_str(d: &typst::foundations::Dict, key: &str) -> Result<String, RenderError> {
     match d.get(key) {
         Ok(Value::Str(s)) => Ok(s.to_string()),
-        Ok(other) => Err(engine_err(
+        Ok(other) => Err(RenderError::coded(
             CODE_INTERNAL,
             format!("expected metadata.{key} to be str, got {}", other.ty()),
         )),
-        Err(_) => Err(engine_err(CODE_INTERNAL, format!("metadata.{key} missing"))),
+        Err(_) => Err(RenderError::coded(CODE_INTERNAL, format!("metadata.{key} missing"))),
     }
 }
 
@@ -166,11 +175,11 @@ fn read_f64(d: &typst::foundations::Dict, key: &str) -> Result<f64, RenderError>
     match d.get(key) {
         Ok(Value::Float(f)) => Ok(*f),
         Ok(Value::Int(i)) => Ok(*i as f64),
-        Ok(other) => Err(engine_err(
+        Ok(other) => Err(RenderError::coded(
             CODE_INTERNAL,
             format!("expected metadata.{key} to be float, got {}", other.ty()),
         )),
-        Err(_) => Err(engine_err(CODE_INTERNAL, format!("metadata.{key} missing"))),
+        Err(_) => Err(RenderError::coded(CODE_INTERNAL, format!("metadata.{key} missing"))),
     }
 }
 
@@ -178,7 +187,7 @@ fn read_opt_str(d: &typst::foundations::Dict, key: &str) -> Result<Option<String
     match d.get(key) {
         Ok(Value::Str(s)) => Ok(Some(s.to_string())),
         Ok(Value::None) => Ok(None),
-        Ok(other) => Err(engine_err(
+        Ok(other) => Err(RenderError::coded(
             CODE_INTERNAL,
             format!(
                 "expected metadata.{key} to be str or none, got {}",
@@ -195,7 +204,7 @@ fn read_str_array(d: &typst::foundations::Dict, key: &str) -> Result<Vec<String>
             .iter()
             .map(|v| match v {
                 Value::Str(s) => Ok(s.to_string()),
-                other => Err(engine_err(
+                other => Err(RenderError::coded(
                     CODE_INTERNAL,
                     format!(
                         "expected metadata.{key} elements to be str, got {}",
@@ -205,7 +214,7 @@ fn read_str_array(d: &typst::foundations::Dict, key: &str) -> Result<Vec<String>
             })
             .collect(),
         Ok(Value::None) => Ok(Vec::new()),
-        Ok(other) => Err(engine_err(
+        Ok(other) => Err(RenderError::coded(
             CODE_INTERNAL,
             format!("expected metadata.{key} to be an array, got {}", other.ty()),
         )),
@@ -223,7 +232,7 @@ fn read_value_str(d: &typst::foundations::Dict, key: &str) -> Result<Option<Stri
         Ok(Value::Bool(b)) => b.to_string(),
         Ok(Value::None) | Err(_) => return Ok(None),
         Ok(other) => {
-            return Err(engine_err(
+            return Err(RenderError::coded(
                 CODE_INTERNAL,
                 format!(
                     "expected metadata.{key} to be str/int/float/bool/none, got {}",
@@ -239,7 +248,7 @@ fn read_value_bool(d: &typst::foundations::Dict, key: &str) -> Result<Option<boo
     match d.get(key) {
         Ok(Value::Bool(b)) => Ok(Some(*b)),
         Ok(Value::None) | Err(_) => Ok(None),
-        Ok(other) => Err(engine_err(
+        Ok(other) => Err(RenderError::coded(
             CODE_INTERNAL,
             format!(
                 "expected metadata.{key} to be bool or none, got {}",

--- a/crates/backends/typst/src/overlay/mod.rs
+++ b/crates/backends/typst/src/overlay/mod.rs
@@ -6,8 +6,6 @@ use quillmark_core::RenderError;
 use quillmark_pdf::{FieldSpec, FieldType, FormFont, TextAlign, CHECKBOX_ON_STATE};
 use typst_layout::PagedDocument;
 
-use crate::engine_err;
-
 mod extract;
 mod span_scan;
 
@@ -68,7 +66,7 @@ pub(crate) fn build_field_specs(
         .iter()
         .map(|p| {
             let page_h = *page_heights.get(p.page).ok_or_else(|| {
-                engine_err(
+                RenderError::coded(
                     "typst::form_field_page_out_of_range",
                     format!(
                         "form-field {:?} targets page {} but the document has {} page(s)",

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -454,6 +454,15 @@ impl RenderError {
         Self { diags: vec![diag] }
     }
 
+    /// A failure carrying one error diagnostic under `code`, the shape most
+    /// engine-side refusals take. A diagnostic needing a hint, a path or args
+    /// builds one and goes through [`from_diag`](Self::from_diag).
+    pub fn coded(code: &str, message: impl Into<String>) -> Self {
+        Self::from_diag(
+            Diagnostic::new(Severity::Error, message.into()).with_code(code.to_string()),
+        )
+    }
+
     pub fn diagnostics(&self) -> &[Diagnostic] {
         &self.diags
     }

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -1,7 +1,6 @@
 use crate::quill::QuillConfig;
 use crate::{
     ContentHit, Diagnostic, Document, RenderError, RenderOptions, RenderResult, RenderedRegion,
-    Severity,
 };
 pub use quillmark_content::{ApplyError, Assoc, ChangeBundle, Delta, IslandOp, LineOp, MarkOp, Op};
 use std::sync::OnceLock;
@@ -40,12 +39,9 @@ pub trait SessionHandle: Send + Sync + 'static {
     /// keeps serving it. The returned [`ChangeSet`] reports the pages the edit
     /// visibly changed. Default: update is unsupported.
     fn update(&mut self, _json_data: &serde_json::Value) -> Result<ChangeSet, RenderError> {
-        Err(RenderError::from_diag(
-            Diagnostic::new(
-                Severity::Error,
-                "this backend's session does not support update".to_string(),
-            )
-            .with_code("backend::update_unsupported".to_string()),
+        Err(RenderError::coded(
+            "backend::update_unsupported",
+            "this backend's session does not support update",
         ))
     }
 
@@ -315,6 +311,7 @@ impl LiveSession {
 mod tests {
     use super::*;
     use crate::version::QuillReference;
+    use crate::Severity;
     use std::str::FromStr;
 
     const QUILL_YAML: &str = "\

--- a/crates/quillmark-pdf/src/error.rs
+++ b/crates/quillmark-pdf/src/error.rs
@@ -21,9 +21,6 @@ impl PdfError {
 
 impl From<PdfError> for quillmark_core::RenderError {
     fn from(e: PdfError) -> Self {
-        quillmark_core::RenderError::from_diag(
-            quillmark_core::Diagnostic::new(quillmark_core::Severity::Error, e.message)
-                .with_code(e.code.to_string()),
-        )
+        quillmark_core::RenderError::coded(e.code, e.message)
     }
 }

--- a/crates/quillmark/src/load.rs
+++ b/crates/quillmark/src/load.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::path::{Path, PathBuf};
 
-use quillmark_core::{Diagnostic, FileTreeNode, Quill, QuillIgnore, RenderError, Severity};
+use quillmark_core::{Diagnostic, FileTreeNode, Quill, QuillIgnore, RenderError};
 
 /// Load a quill from a filesystem directory. Honours a root `.quillignore`,
 /// else a default ignore set.
@@ -22,10 +22,7 @@ pub fn quill_from_path_with_warnings<P: AsRef<Path>>(
     path: P,
 ) -> Result<(Quill, Vec<Diagnostic>), RenderError> {
     let tree = load_tree_from_path(path.as_ref()).map_err(|e| {
-        RenderError::from_diag(
-            Diagnostic::new(Severity::Error, format!("Failed to load quill: {}", e))
-                .with_code("quill::load_failed".to_string()),
-        )
+        RenderError::coded("quill::load_failed", format!("Failed to load quill: {e}"))
     })?;
     Quill::from_tree_with_warnings(tree).map_err(RenderError::new)
 }

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -31,7 +31,9 @@ It exists so no public signature names `serde-saphyr`. A third-party error type 
 Two surfaces return one directly (`QuillValue::from_yaml_str`, `QuillConfig::schema_yaml`); `QuillConfig::from_yaml_with_warnings` converts through it to `quill::yaml_parse_error`. The card-yaml path does not travel this way: it becomes `ParseError::YamlErrorWithLocation`, which additionally knows the enclosing block.
 
 **`RenderError`**: the main rendering error, a struct carrying a non-empty
-`Vec<Diagnostic>` (`RenderError::new` / `from_diag`; `diagnostics()` borrows,
+`Vec<Diagnostic>` (`RenderError::new` / `from_diag` / `coded(code, message)`
+for the one-error-diagnostic case every engine-side refusal takes;
+`diagnostics()` borrows,
 `into_diagnostics()` consumes). There is no failure taxonomy beyond the
 diagnostics themselves: the machine-routable identity of a failure is each
 diagnostic's namespaced `code` (`parse::*`, `validation::*`, `quill::*`,


### PR DESCRIPTION
Closes #1337.

## What

`RenderError::coded(code, message)` lands beside `from_diag` in `quillmark-core`, and every site that spelled `from_diag(Diagnostic::new(Severity::Error, msg).with_code(code))` by hand now delegates to it.

Nine such sites across five crates:

| crate | sites |
| --- | --- |
| `quillmark-typst` | `engine_err` (lib.rs) + 4 in `compile.rs` that never used it |
| `quillmark-pdfform` | `engine_err` |
| `quillmark-core` | `session.rs` — `backend::update_unsupported` |
| `quillmark` | `load.rs` — `quill::load_failed` |
| `quillmark-pdf` | `error.rs` — `From<PdfError>` |

Both `engine_err` helpers are deleted rather than kept as delegating aliases, so one name spells one thing.

Additive to core's public API. No code, message, or error shape changes.

## Review of the issue

The issue frames this as two backends duplicating a three-line builder, which on its own is a wash — delete 8 lines, add 8, gain public API. The real count is nine sites in five crates, which makes it a cross-crate idiom rather than a two-copy nit.

Two deviations from the proposed design:

- **Home.** The issue proposes a free fn beside `unsupported_format` in `backend.rs`. Three of the nine sites are not backends; `load.rs` and `quillmark-pdf` would be importing from a backend module to build an error. It belongs as an inherent constructor on `RenderError` in `error.rs`, beside `from_diag`.
- **Name.** Not `engine(...)`: `engine::*` is already a live diagnostic-code namespace (`engine::backend_not_found`), so that name would falsely imply it. `coded` says what it makes.

The issue's second half — deduplicating the `quill:` preamble across ~63 tests in `crates/core/src/quill/tests.rs` — is **not** included, deliberately:

- Neither named helper does the job. `cfg(yaml)` (blueprint.rs, schema_yaml.rs) is just `from_yaml(yaml).expect(...)`; its own tests still spell the preamble inline, so lifting it removes nothing. Only `config_with` (validation.rs) injects a preamble.
- `config_with` hard-codes name/version/backend/description. Many of those tests assert on exactly those values (`test_quill_config_from_yaml` checks name, version, author, `backend_config`), and several *are* preamble tests (`missing_required_fields`, `missing_quill_section`, `rejects_non_snake_case_identifiers`) that cannot use it at all.
- The preambles are not duplicates — each carries a name and description tailored to its test. Literal fixture data in a test is legibility, not repetition.

It is also unrelated to the constructor change — different crate, different concern — so bundling it would only make the diff harder to read.

## Testing

- `cargo check --workspace --all-targets` — clean, zero warnings (imports left unused by the change were trimmed)
- `cargo test --workspace` — green

`prose/canon/ERROR.md` and `CHANGELOG.md` updated.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENv4GMgKsQpRERNrrdva3b)_