### PR TITLE
content: the op wire is a reading direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- **breaking** content: the op wire is a reading direction. `mark_op_to_value`,
+  `line_op_to_value` and `island_op_to_value` are removed from
+  `quillmark-content` — an op bundle is authored on the JS/Python side and
+  reaches Rust through `change_bundle_from_value`, so nothing in the workspace
+  ever emitted one and every wire change was made twice, once in code no product
+  path executes. The decoders are unchanged. Their round-trip tests become
+  decoder tests over literal JSON, which is what the wire actually is: an
+  encoder agreeing with its own reader never proved the shape a binding sends.
+
 ## v0.108.3 - 2026-08-21
 
 - fix(typst): **a paragraph holding one bare `/` renders instead of failing the

--- a/crates/content/src/lib.rs
+++ b/crates/content/src/lib.rs
@@ -28,9 +28,8 @@ pub use model::{
 };
 pub use normalize::normalize_markdown;
 pub use ops::{
-    change_bundle_from_value, island_op_from_value, island_op_to_value, line_op_from_value,
-    line_op_to_value, mark_op_from_value, mark_op_to_value, ApplyError, ChangeBundle, IslandOp,
-    LineOp, MarkOp,
+    change_bundle_from_value, island_op_from_value, line_op_from_value, mark_op_from_value,
+    ApplyError, ChangeBundle, IslandOp, LineOp, MarkOp,
 };
 pub use serial::ParseError;
 

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -157,40 +157,20 @@ impl ChangeBundle {
     }
 }
 
-// The op converters below reuse `serial`'s hand-written encoding for
-// `MarkKind` / `LineKind` / `Container`, so an `applyChange` bundle speaks the
-// same shapes the content read surface does rather than a second serde-derived
-// dialect.
+// The op readers below reuse `serial`'s hand-written readers for `MarkKind` /
+// `LineKind` / `Container`, so an `applyChange` bundle speaks the same shapes
+// the content read surface does rather than a second serde-derived dialect.
+// The wire is a reading direction: bundles are authored on the JS/Python side,
+// and no encoder answers these.
 
 use crate::serial::{
-    container_from_authored_value, container_to_value, island_fields, island_from_value,
-    line_kind_fields, line_kind_from_authored_value, mark_fields, mark_from_authored_value,
-    usv_from, ParseError,
+    container_from_authored_value, island_from_value, line_kind_from_authored_value,
+    mark_from_authored_value, usv_from, ParseError,
 };
-use serde_json::{Map, Value};
+use serde_json::Value;
 
-/// Encode a [`MarkOp`] to its wire object. `Add`/`Remove` carry the mark
-/// vocabulary (`{op, start, end, type, …}`); `RemoveAnchor` is `{op, id}`.
-pub fn mark_op_to_value(op: &MarkOp) -> Value {
-    let mut m = Map::new();
-    match op {
-        MarkOp::Add { start, end, kind } => {
-            m.insert("op".into(), "add".into());
-            m.extend(mark_fields(*start, *end, kind));
-        }
-        MarkOp::Remove { start, end, kind } => {
-            m.insert("op".into(), "remove".into());
-            m.extend(mark_fields(*start, *end, kind));
-        }
-        MarkOp::RemoveAnchor { id } => {
-            m.insert("op".into(), "removeAnchor".into());
-            m.insert("id".into(), Value::String(id.clone()));
-        }
-    }
-    Value::Object(m)
-}
-
-/// Decode a [`MarkOp`] from its wire object. `add`/`remove` read the mark
+/// Decode a [`MarkOp`] from its wire object (`{op, start, end, type, …}` for
+/// `add`/`remove`, `{op, id}` for `removeAnchor`). `add`/`remove` read the mark
 /// vocabulary on the authored lane, which refuses `attrs` beside a built-in
 /// `type` rather than resolving to the built-in and dropping them.
 pub fn mark_op_from_value(v: &Value) -> Result<MarkOp, ParseError> {
@@ -223,42 +203,8 @@ pub fn mark_op_from_value(v: &Value) -> Result<MarkOp, ParseError> {
     }
 }
 
-/// Encode a [`LineOp`] to its wire object. `SetKind` flattens the line-kind
-/// discriminant (`kind`/`level`/`lang`) alongside `op`/`line`.
-pub fn line_op_to_value(op: &LineOp) -> Value {
-    let mut m = Map::new();
-    match op {
-        LineOp::Split { at } => {
-            m.insert("op".into(), "split".into());
-            m.insert("at".into(), Value::from(*at));
-        }
-        LineOp::Join { line } => {
-            m.insert("op".into(), "join".into());
-            m.insert("line".into(), Value::from(*line));
-        }
-        LineOp::SetKind { line, kind } => {
-            m.insert("op".into(), "setKind".into());
-            m.insert("line".into(), Value::from(*line));
-            m.extend(line_kind_fields(kind));
-        }
-        LineOp::SetContainers { line, containers } => {
-            m.insert("op".into(), "setContainers".into());
-            m.insert("line".into(), Value::from(*line));
-            m.insert(
-                "containers".into(),
-                Value::Array(containers.iter().map(container_to_value).collect()),
-            );
-        }
-        LineOp::SetContinues { line, continues } => {
-            m.insert("op".into(), "setContinues".into());
-            m.insert("line".into(), Value::from(*line));
-            m.insert("continues".into(), Value::Bool(*continues));
-        }
-    }
-    Value::Object(m)
-}
-
-/// Decode a [`LineOp`] from its wire object.
+/// Decode a [`LineOp`] from its wire object. `setKind` carries the line-kind
+/// discriminant (`kind`/`level`/`lang`) flattened alongside `op`/`line`.
 pub fn line_op_from_value(v: &Value) -> Result<LineOp, ParseError> {
     let o = v.as_object().ok_or(ParseError::Shape("line op"))?;
     let line = || usv_from(o.get("line"), "line op line");
@@ -292,23 +238,8 @@ pub fn line_op_from_value(v: &Value) -> Result<LineOp, ParseError> {
     }
 }
 
-/// Encode an [`IslandOp`] to its wire object. Both arms flatten the island
-/// vocabulary (`{id, type, props, loss}`) alongside `op`.
-pub fn island_op_to_value(op: &IslandOp) -> Value {
-    let (verb, at, island) = match op {
-        IslandOp::Set { island } => ("set", None, island),
-        IslandOp::Insert { at, island } => ("insert", Some(*at), island),
-    };
-    let mut m = Map::new();
-    m.insert("op".into(), verb.into());
-    if let Some(at) = at {
-        m.insert("at".into(), Value::from(at));
-    }
-    m.extend(island_fields(island));
-    Value::Object(m)
-}
-
-/// Decode an [`IslandOp`] from its wire object.
+/// Decode an [`IslandOp`] from its wire object. Both arms carry the island
+/// vocabulary (`{id, type, props, loss}`) flattened alongside `op`.
 pub fn island_op_from_value(v: &Value) -> Result<IslandOp, ParseError> {
     let o = v.as_object().ok_or(ParseError::Shape("island op"))?;
     let island = || island_from_value(v);
@@ -998,72 +929,117 @@ mod tests {
     use crate::import::from_markdown;
 
     #[test]
-    fn mark_op_wire_round_trips_each_variant() {
-        let ops = vec![
-            MarkOp::Add {
-                start: 0,
-                end: 3,
-                kind: MarkKind::Strong,
-            },
-            MarkOp::Add {
-                start: 1,
-                end: 2,
-                kind: MarkKind::Link {
-                    url: "https://x".into(),
+    fn mark_op_wire_decodes_each_variant() {
+        let cases = vec![
+            (
+                serde_json::json!({"op": "add", "start": 0, "end": 3, "type": "strong"}),
+                MarkOp::Add {
+                    start: 0,
+                    end: 3,
+                    kind: MarkKind::Strong,
                 },
-            },
-            MarkOp::Remove {
-                start: 4,
-                end: 6,
-                kind: MarkKind::Anchor { id: "c1".into() },
-            },
-            MarkOp::RemoveAnchor { id: "c2".into() },
+            ),
+            (
+                serde_json::json!({
+                    "op": "add", "start": 1, "end": 2, "type": "link", "url": "https://x",
+                }),
+                MarkOp::Add {
+                    start: 1,
+                    end: 2,
+                    kind: MarkKind::Link {
+                        url: "https://x".into(),
+                    },
+                },
+            ),
+            (
+                serde_json::json!({
+                    "op": "remove", "start": 4, "end": 6, "type": "anchor", "id": "c1",
+                }),
+                MarkOp::Remove {
+                    start: 4,
+                    end: 6,
+                    kind: MarkKind::Anchor { id: "c1".into() },
+                },
+            ),
+            (
+                serde_json::json!({"op": "removeAnchor", "id": "c2"}),
+                MarkOp::RemoveAnchor { id: "c2".into() },
+            ),
         ];
-        for op in ops {
-            let v = mark_op_to_value(&op);
-            assert_eq!(mark_op_from_value(&v).unwrap(), op, "round-trip: {v}");
+        for (v, op) in cases {
+            assert_eq!(mark_op_from_value(&v).unwrap(), op, "decode: {v}");
         }
     }
 
     #[test]
-    fn line_op_wire_round_trips_each_variant() {
-        let ops = vec![
-            LineOp::Split { at: 5 },
-            LineOp::Join { line: 1 },
-            LineOp::SetKind {
-                line: 0,
-                kind: LineKind::Heading { level: 2 },
-            },
-            LineOp::SetContainers {
-                line: 2,
-                containers: vec![Container::Quote],
-            },
-            LineOp::SetKind {
-                line: 0,
-                kind: LineKind::Unknown {
-                    tag: "callout".into(),
-                    attrs: serde_json::json!({"variant": "warn"}),
+    fn line_op_wire_decodes_each_variant() {
+        let cases = vec![
+            (
+                serde_json::json!({"op": "split", "at": 5}),
+                LineOp::Split { at: 5 },
+            ),
+            (
+                serde_json::json!({"op": "join", "line": 1}),
+                LineOp::Join { line: 1 },
+            ),
+            (
+                serde_json::json!({"op": "setKind", "line": 0, "kind": "heading", "level": 2}),
+                LineOp::SetKind {
+                    line: 0,
+                    kind: LineKind::Heading { level: 2 },
                 },
-            },
-            LineOp::SetContainers {
-                line: 2,
-                containers: vec![Container::Unknown {
-                    tag: "indent".into(),
-                    attrs: serde_json::json!({"depth": 2}),
-                }],
-            },
-            LineOp::SetContinues {
-                line: 1,
-                continues: true,
-            },
-            LineOp::SetContinues {
-                line: 3,
-                continues: false,
-            },
+            ),
+            (
+                serde_json::json!({
+                    "op": "setContainers", "line": 2, "containers": [{"container": "quote"}],
+                }),
+                LineOp::SetContainers {
+                    line: 2,
+                    containers: vec![Container::Quote],
+                },
+            ),
+            (
+                serde_json::json!({
+                    "op": "setKind", "line": 0, "kind": "callout", "attrs": {"variant": "warn"},
+                }),
+                LineOp::SetKind {
+                    line: 0,
+                    kind: LineKind::Unknown {
+                        tag: "callout".into(),
+                        attrs: serde_json::json!({"variant": "warn"}),
+                    },
+                },
+            ),
+            (
+                serde_json::json!({
+                    "op": "setContainers", "line": 2,
+                    "containers": [{"container": "indent", "attrs": {"depth": 2}}],
+                }),
+                LineOp::SetContainers {
+                    line: 2,
+                    containers: vec![Container::Unknown {
+                        tag: "indent".into(),
+                        attrs: serde_json::json!({"depth": 2}),
+                    }],
+                },
+            ),
+            (
+                serde_json::json!({"op": "setContinues", "line": 1, "continues": true}),
+                LineOp::SetContinues {
+                    line: 1,
+                    continues: true,
+                },
+            ),
+            (
+                serde_json::json!({"op": "setContinues", "line": 3, "continues": false}),
+                LineOp::SetContinues {
+                    line: 3,
+                    continues: false,
+                },
+            ),
         ];
-        for op in ops {
-            let v = line_op_to_value(&op);
-            assert_eq!(line_op_from_value(&v).unwrap(), op, "round-trip: {v}");
+        for (v, op) in cases {
+            assert_eq!(line_op_from_value(&v).unwrap(), op, "decode: {v}");
         }
     }
 
@@ -1480,19 +1456,30 @@ mod tests {
     }
 
     #[test]
-    fn island_op_wire_round_trips_each_variant() {
+    fn island_op_wire_decodes_each_variant() {
         let island = Island::new("isl-0".into(), "table".into())
             .with_props(table_props("H", "a"))
             .with_loss(crate::model::Loss::DEGRADED);
-        let ops = vec![
-            IslandOp::Set {
-                island: island.clone(),
-            },
-            IslandOp::Insert { at: 7, island },
+        let cases = vec![
+            (
+                serde_json::json!({
+                    "op": "set", "id": "isl-0", "type": "table",
+                    "props": table_props("H", "a"), "loss": "degraded",
+                }),
+                IslandOp::Set {
+                    island: island.clone(),
+                },
+            ),
+            (
+                serde_json::json!({
+                    "op": "insert", "at": 7, "id": "isl-0", "type": "table",
+                    "props": table_props("H", "a"), "loss": "degraded",
+                }),
+                IslandOp::Insert { at: 7, island },
+            ),
         ];
-        for op in ops {
-            let v = island_op_to_value(&op);
-            assert_eq!(island_op_from_value(&v).unwrap(), op, "round-trip: {v}");
+        for (v, op) in cases {
+            assert_eq!(island_op_from_value(&v).unwrap(), op, "decode: {v}");
         }
     }
 

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -218,10 +218,9 @@ pub fn line_kind_to_value(kind: &LineKind) -> Value {
     Value::Object(line_kind_fields(kind))
 }
 
-/// The same fields unwrapped, for the op wire ([`crate::ops`]), which flattens
-/// them beside its own keys and so carries the exact discriminant a
-/// `ContentLine` does.
-pub(crate) fn line_kind_fields(kind: &LineKind) -> Map<String, Value> {
+/// The same fields unwrapped, for [`line_to_value`], which flattens them beside
+/// a line's own keys.
+fn line_kind_fields(kind: &LineKind) -> Map<String, Value> {
     let mut m = Map::new();
     match kind {
         LineKind::Para => {
@@ -321,8 +320,7 @@ fn line_from_value(v: &Value) -> Result<Line, ParseError> {
     })
 }
 
-/// Encode a [`Container`] into its canonical wire object. Public so the op wire
-/// ([`crate::ops`]) reuses the same container shape a `ContentLine` carries.
+/// Encode a [`Container`] into its canonical wire object.
 pub fn container_to_value(c: &Container) -> Value {
     let mut m = Map::new();
     match c {
@@ -373,17 +371,10 @@ pub fn container_from_value(v: &Value) -> Result<Container, ParseError> {
 
 /// Encode a [`Mark`] (`{start, end, type, …}`) into its canonical wire object.
 pub fn mark_to_value(mark: &Mark) -> Value {
-    Value::Object(mark_fields(mark.start, mark.end, &mark.kind))
-}
-
-/// The same fields unwrapped and over a mark's parts, for the op wire
-/// ([`crate::ops`]), which flattens them beside its own keys, carries the exact
-/// `type` discriminant a `ContentMark` does, and holds no [`Mark`].
-pub(crate) fn mark_fields(start: Usv, end: Usv, kind: &MarkKind) -> Map<String, Value> {
     let mut m = Map::new();
-    m.insert("start".into(), Value::from(start));
-    m.insert("end".into(), Value::from(end));
-    match kind {
+    m.insert("start".into(), Value::from(mark.start));
+    m.insert("end".into(), Value::from(mark.end));
+    match &mark.kind {
         MarkKind::Strong => {
             m.insert("type".into(), "strong".into());
         }
@@ -412,7 +403,7 @@ pub(crate) fn mark_fields(start: Usv, end: Usv, kind: &MarkKind) -> Map<String, 
             m.insert("attrs".into(), attrs.clone());
         }
     }
-    m
+    Value::Object(m)
 }
 
 /// What every mark carries whatever its type.
@@ -822,18 +813,12 @@ pub(crate) fn table_shape_error(props: &Value) -> Option<Invariant> {
 }
 
 pub(crate) fn island_to_value(island: &Island) -> Value {
-    Value::Object(island_fields(island))
-}
-
-/// The same fields unwrapped, for the op wire ([`crate::ops`]), which flattens
-/// them beside its own keys.
-pub(crate) fn island_fields(island: &Island) -> Map<String, Value> {
     let mut m = Map::new();
     m.insert("id".into(), Value::String(island.id.clone()));
     m.insert("type".into(), Value::String(island.island_type.clone()));
     m.insert("props".into(), island.props.clone());
     m.insert("loss".into(), island.loss.as_str().into());
-    m
+    Value::Object(m)
 }
 
 pub(crate) fn island_from_value(v: &Value) -> Result<Island, ParseError> {


### PR DESCRIPTION
Closes #1332.

`mark_op_to_value`, `line_op_to_value` and `island_op_to_value` had no caller in the workspace outside their own round-trip tests. An op bundle is authored on the JS/Python side and enters Rust through `change_bundle_from_value`, so nothing ever emitted one from here and every wire change was made twice — once in code no product path executes. The decoders stay: `change_bundle_from_value` from the wasm surface, `line_op_from_value` / `mark_op_from_value` from `crates/fuzz`.

The three encoders and their `lib.rs` re-exports are gone.

## Tests

The round-trip tests become decoder tests over literal JSON. An encoder agreeing with its own reader never proved the shape a binding sends; the literals are the `MarkOp` / `LineOp` / `IslandOp` unions the wasm surface declares in `crates/bindings/wasm/src/engine.rs`. Same variant coverage as before, plus the existing `op_wire_rejects_attrs_beside_a_built_in_name` untouched.

## The residue in `serial.rs`

`mark_fields` and `island_fields` existed only to hand the encoders their fields unwrapped — their rustdoc said so — so they fold back into `mark_to_value` / `island_to_value` rather than stay as indirection with stale docs. `line_kind_fields` keeps its second caller in the line encoder and is retargeted and demoted to private. `container_to_value`'s "public so the op wire reuses it" rationale also went stale; its visibility is untouched, its `from` twin and two siblings being `pub` with no external caller either — a pre-existing surface question, not this one's.

## Release

Per the issue, this is a public-API removal on a published crate and is not a release. It lands as a `**breaking** content:` entry under a new `## Unreleased` heading, so the next minor carries it. No migration guide: this repo writes those at release-prep time (474881d for 0.107 → 0.108).

## Checks

`cargo test --workspace` green. `cargo build --workspace --all-targets` and `cargo doc -p quillmark-content` clean; no new clippy warnings. Net −162 lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DL6mmn9CyxEgm4EggmG8Bg)_