### PR TITLE
fix(core): match .quillignore patterns holding more than one wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+- fix(core): **a `.quillignore` pattern holding more than one `*` ignores what
+  it names.** The matcher handled exactly one wildcard and returned no match
+  for the rest, so `**/*.tmp` and `*.sublime-*` were dead lines. Patterns now
+  compile once through `glob::Pattern`, matched against the whole path and the
+  basename. Two readings tighten to gitignore's: `*` stops at `/`, and a
+  pattern spelling out a `/` anchors at the bundle root rather than matching
+  any path that opens and closes with its halves. A pattern free of `*`, `?`
+  and `[` stays a literal name, so a file named `Cinzel[wght].ttf` is still
+  ignored by writing it out.
+
 ## v0.108.3 - 2026-08-21
 
 - fix(typst): **a paragraph holding one bare `/` renders instead of failing the

--- a/crates/core/src/quill/ignore.rs
+++ b/crates/core/src/quill/ignore.rs
@@ -1,10 +1,33 @@
 //! .quillignore parsing and path matching.
 use std::path::Path;
 
-/// Simple gitignore-style pattern matcher for .quillignore
+use glob::{MatchOptions, Pattern};
+
+/// `*` stops at a path separator, so a pattern spans one path segment unless it
+/// spells the separators out — the gitignore reading of a `.quillignore` line.
+const MATCH: MatchOptions = MatchOptions {
+    case_sensitive: true,
+    require_literal_separator: true,
+    require_literal_leading_dot: false,
+};
+
+/// Gitignore-style pattern matcher for .quillignore
 #[derive(Debug, Clone)]
 pub struct QuillIgnore {
-    pub(crate) patterns: Vec<String>,
+    rules: Vec<Rule>,
+}
+
+/// One `.quillignore` line, parsed once at construction.
+#[derive(Debug, Clone)]
+enum Rule {
+    /// `dir/`: the entry itself and everything beneath it.
+    Dir(String),
+    /// A literal name: the whole path, or the basename at any depth.
+    Name(String),
+    /// A glob, matched against the whole path and against the basename, so a
+    /// slash-free pattern applies at any depth and a slashed one is anchored
+    /// at the bundle root. As in gitignore, `*` does not cross `/`.
+    Glob(Pattern),
 }
 
 impl Default for QuillIgnore {
@@ -24,65 +47,60 @@ impl Default for QuillIgnore {
 impl QuillIgnore {
     /// Create a new QuillIgnore from pattern strings
     pub fn new(patterns: Vec<String>) -> Self {
-        Self { patterns }
+        Self {
+            rules: patterns.into_iter().map(Rule::parse).collect(),
+        }
     }
 
     /// Parse .quillignore content into patterns
     pub fn from_content(content: &str) -> Self {
-        let patterns = content
-            .lines()
-            .map(|line| line.trim())
-            .filter(|line| !line.is_empty() && !line.starts_with('#'))
-            .map(|line| line.to_string())
-            .collect();
-        Self::new(patterns)
+        Self::new(
+            content
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty() && !line.starts_with('#'))
+                .map(str::to_string)
+                .collect(),
+        )
     }
 
     /// Check if a path should be ignored
     pub fn is_ignored<P: AsRef<Path>>(&self, path: P) -> bool {
-        let path = path.as_ref();
-        let path_str = path.to_string_lossy();
+        let path = path
+            .as_ref()
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
+        let basename = path.rsplit_once('/').map_or(path.as_str(), |(_, name)| name);
+        self.rules.iter().any(|rule| rule.matches(&path, basename))
+    }
+}
 
-        for pattern in &self.patterns {
-            if self.matches_pattern(pattern, &path_str) {
-                return true;
-            }
+impl Rule {
+    fn parse(pattern: String) -> Self {
+        if let Some(prefix) = pattern.strip_suffix('/') {
+            return Rule::Dir(prefix.to_string());
         }
-        false
+        if !pattern.contains(['*', '?', '[']) {
+            return Rule::Name(pattern);
+        }
+        match Pattern::new(&pattern) {
+            Ok(glob) => Rule::Glob(glob),
+            // An unparseable glob still matches the name it spells out.
+            Err(_) => Rule::Name(pattern),
+        }
     }
 
-    /// Simple pattern matching (supports * wildcard and directory patterns)
-    fn matches_pattern(&self, pattern: &str, path: &str) -> bool {
-        // Handle directory patterns
-        if let Some(pattern_prefix) = pattern.strip_suffix('/') {
-            return path.starts_with(pattern_prefix)
-                && (path.len() == pattern_prefix.len()
-                    || path.chars().nth(pattern_prefix.len()) == Some('/'));
-        }
-
-        // Handle exact matches
-        if !pattern.contains('*') {
-            return path == pattern || path.ends_with(&format!("/{}", pattern));
-        }
-
-        // Simple wildcard matching
-        if pattern == "*" {
-            return true;
-        }
-
-        // Handle patterns with wildcards
-        let pattern_parts: Vec<&str> = pattern.split('*').collect();
-        if pattern_parts.len() == 2 {
-            let (prefix, suffix) = (pattern_parts[0], pattern_parts[1]);
-            if prefix.is_empty() {
-                return path.ends_with(suffix);
-            } else if suffix.is_empty() {
-                return path.starts_with(prefix);
-            } else {
-                return path.starts_with(prefix) && path.ends_with(suffix);
+    fn matches(&self, path: &str, basename: &str) -> bool {
+        match self {
+            Rule::Dir(prefix) => path
+                .strip_prefix(prefix.as_str())
+                .is_some_and(|rest| rest.is_empty() || rest.starts_with('/')),
+            Rule::Name(name) => path == name || basename == name,
+            Rule::Glob(glob) => {
+                glob.matches_with(path, MATCH) || glob.matches_with(basename, MATCH)
             }
         }
-
-        false
     }
 }

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -87,9 +87,39 @@ node_modules/
 .git/
 "#;
     let ignore = QuillIgnore::from_content(ignore_content);
-    assert_eq!(ignore.patterns.len(), 4);
-    assert!(ignore.patterns.contains(&"*.tmp".to_string()));
-    assert!(ignore.patterns.contains(&"target/".to_string()));
+    assert!(ignore.is_ignored("scratch.tmp"));
+    assert!(ignore.is_ignored("target/debug"));
+    assert!(!ignore.is_ignored("# This is a comment"));
+    // A blank line is not a rule that swallows everything.
+    assert!(!ignore.is_ignored("plate.typ"));
+}
+
+#[test]
+fn test_quillignore_multiple_wildcards() {
+    let ignore = QuillIgnore::new(vec![
+        "**/*.tmp".to_string(),
+        "*.sublime-*".to_string(),
+        "a*b*c".to_string(),
+    ]);
+
+    assert!(ignore.is_ignored("scratch.tmp"));
+    assert!(ignore.is_ignored("deep/nested/scratch.tmp"));
+    assert!(!ignore.is_ignored("scratch.txt"));
+
+    assert!(ignore.is_ignored("quill.sublime-project"));
+    assert!(ignore.is_ignored("editor/quill.sublime-workspace"));
+
+    assert!(ignore.is_ignored("axbxc"));
+    assert!(!ignore.is_ignored("axbx"));
+}
+
+#[test]
+fn test_quillignore_wildcard_does_not_cross_slash() {
+    let ignore = QuillIgnore::new(vec!["assets/*.png".to_string()]);
+
+    assert!(ignore.is_ignored("assets/logo.png"));
+    assert!(!ignore.is_ignored("assets/icons/logo.png"));
+    assert!(!ignore.is_ignored("vendor/assets/logo.png"));
 }
 
 #[test]

--- a/crates/quillmark/src/load.rs
+++ b/crates/quillmark/src/load.rs
@@ -142,4 +142,19 @@ mod tests {
         assert!(tree.get_file("leak.txt").is_none());
         assert_eq!(tree.get_file("real.txt"), Some(&b"ok"[..]));
     }
+
+    #[test]
+    fn load_dir_honours_multi_wildcard_ignore_patterns() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        std::fs::write(root.join(".quillignore"), "**/*.tmp\n").unwrap();
+        std::fs::create_dir(root.join("nested")).unwrap();
+        std::fs::write(root.join("nested/scratch.tmp"), b"drop").unwrap();
+        std::fs::write(root.join("nested/plate.typ"), b"keep").unwrap();
+
+        let tree = load_tree_from_path(root).unwrap();
+        assert!(tree.get_file("nested/scratch.tmp").is_none());
+        assert_eq!(tree.get_file("nested/plate.typ"), Some(&b"keep"[..]));
+    }
 }

--- a/prose/canon/QUILL.md
+++ b/prose/canon/QUILL.md
@@ -115,6 +115,8 @@ Errors flow through `RenderError` (a non-empty `Vec<Diagnostic>`) and surface to
 
 When loading from disk, `quillmark::quill_from_path` respects a `.quillignore` file at the bundle root. If absent, default patterns apply: `.git/`, `.gitignore`, `.quillignore`, `target/`, `node_modules/`.
 
+A line is one of three rules. `dir/` drops that directory and its subtree, anchored at the bundle root. A line free of `*`, `?` and `[` is a literal name, matching the whole path or the basename at any depth. Anything else is a glob (`glob::Pattern`), matched against both the whole path and the basename, so a slash-free pattern applies at any depth and a slashed one anchors at the root; `*` stops at `/`. A glob that fails to compile falls back to a literal name.
+
 ## API
 
 Construction:


### PR DESCRIPTION
Closes #1330.

## The bug

`QuillIgnore::matches_pattern` split a pattern on `*` and handled only the two-part case, returning `false` for anything with a second wildcard. `**/*.tmp` and `a*b*c` matched nothing, silently — as does `*.sublime-*`, a line the shipped `usaf_memo` fixture's own `.quillignore` has carried since it was written.

## One correction to the issue

The issue says "glob's `*` does not cross `/`". It does: `glob::Pattern::matches` uses `MatchOptions::default()`, where `require_literal_separator` is `false`. A drop-in `Pattern::new(…).matches(path)` would have shipped the looseness the issue meant to fix — the first test written here (`assets/*.png` must not match `assets/icons/logo.png`) failed until the matcher moved to `matches_with` with an explicit `MatchOptions`.

## The change

Each line parses once, at construction, into one of three rules — the old code re-derived the shape of the pattern on every path:

- `dir/` — a path prefix, as before.
- No `*`, `?` or `[` — a literal name, matched against the whole path or the basename at any depth. Keeping this branch matters: the `usaf_memo` fixture holds a font named `Cinzel[wght].ttf`, and folding literals into globs would turn its name into an unparseable character class.
- Anything else — a `glob::Pattern`, matched against the whole path and against the basename, so a slash-free pattern applies at any depth. A glob that fails to compile falls back to a literal name rather than matching nothing.

Two readings tighten to gitignore's, deliberately, as the issue anticipated:

- `*` stops at `/` (`require_literal_separator: true`).
- A pattern spelling out a `/` anchors at the bundle root, instead of the old `starts_with` + `ends_with` pair that let `src/*.typ` match `src/a/b/c.typ`.

One adjacent fix: `is_ignored` joins the path's components with `/` rather than reading `to_string_lossy` directly. On Windows the loader hands it `target\debug`, where the `dir/` branch's `starts_with("target")` succeeded but the following-character check for `/` failed — `target/` pruned nothing there.

Nothing in either fixture quill is newly ignored: no file matches `*.sublime-*`, and the remaining lines parse to the same rules they matched under before.

## Tests

- `test_quillignore_parsing` now asserts behavior; it reached into the removed `patterns` field.
- `test_quillignore_multiple_wildcards` — `**/*.tmp`, `*.sublime-*`, `a*b*c`.
- `test_quillignore_wildcard_does_not_cross_slash` — the re-pinned semantics.
- `load_dir_honours_multi_wildcard_ignore_patterns` in `quillmark::load` — the core tests walk their own loader double, so pruning through the real `quill_from_path` walker was otherwise uncovered.

`cargo test --workspace` is green (59 test binaries, 0 failures); clippy reports nothing on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6ZiHCwocvfMCaAsetGqtv

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6ZiHCwocvfMCaAsetGqtv)_