### PR TITLE
refactor(core): one home for the richtext import contract

### DIFF
--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -59,6 +59,36 @@ pub(crate) fn decode_richtext_value(
     }
 }
 
+/// Why a richtext value did not become stored content, classified so each layer
+/// words the failure in its own error vocabulary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RichtextValueError {
+    /// An accepted encoding that failed to decode.
+    Decode(RichtextDecodeError),
+    /// Neither a canonical content object nor a markdown string.
+    Unshaped,
+    /// `inline` is declared and the content spans more than one paragraph.
+    NotInline,
+}
+
+/// The contract for a richtext value that must *become* stored content: decode
+/// either accepted encoding, enforce `inline`, canonicalize. The strict typed
+/// write and the schema-literal companion cache share it and differ only in the
+/// diagnostic they render from the error.
+pub(crate) fn canonical_richtext_value(
+    value: &serde_json::Value,
+    inline: bool,
+) -> Result<serde_json::Value, RichtextValueError> {
+    let content = match decode_richtext_value(value) {
+        Some(result) => result.map_err(RichtextValueError::Decode)?,
+        None => return Err(RichtextValueError::Unshaped),
+    };
+    if inline && !content.is_inline() {
+        return Err(RichtextValueError::NotInline);
+    }
+    Ok(quillmark_content::serial::to_canonical_value(&content))
+}
+
 /// The plaintext twin of [`decode_richtext_value`]: a string imports verbatim
 /// (never as markdown, so `*hi*` stays four plain characters), so only the
 /// object branch can fail.

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -596,37 +596,40 @@ impl QuillConfig {
                 // literal / validation sites): the string branch below reduces a
                 // bare scalar or length-1 array to text before importing, which
                 // the strict decoder must not do, so it stays open-coded here.
+                let inline_err = || {
+                    CoercionError::uncoercible(
+                        path,
+                        "<richtext>",
+                        "richtext(inline)",
+                        "richtext(inline) requires a single paragraph line \
+                             with no list/quote container and no islands",
+                    )
+                };
                 let inline_check =
                     |rt: &quillmark_content::Content| -> Result<(), CoercionError> {
                         if inline && !rt.is_inline() {
-                            return Err(CoercionError::uncoercible(
-                                path,
-                                "<richtext>",
-                                "richtext(inline)",
-                                "richtext(inline) requires a single paragraph line \
-                                     with no list/quote container and no islands",
-                            ));
+                            return Err(inline_err());
                         }
                         Ok(())
                     };
-                // A strict write uses `decode_richtext_value` semantics: a
+                // A strict write is `document::canonical_richtext_value`: a
                 // canonical content object or a markdown string, nothing else. No
                 // scalar→string reduction (the render floor's lenient cascade
                 // below): a bare scalar for a richtext field fails the write. The
                 // messages mirror `Card::commit_field`'s richtext error variants,
                 // which the bindings key on.
                 if mode == Leniency::Write {
-                    let content = match crate::document::decode_richtext_value(json_value) {
-                        Some(result) => result.map_err(|e| {
-                            CoercionError::uncoercible(
+                    use crate::document::RichtextValueError as E;
+                    return crate::document::canonical_richtext_value(json_value, inline)
+                        .map(QuillValue::from_json)
+                        .map_err(|e| match e {
+                            E::Decode(e) => CoercionError::uncoercible(
                                 path,
                                 "<richtext>",
                                 "richtext",
                                 e.into_message(),
-                            )
-                        })?,
-                        None => {
-                            return Err(CoercionError::uncoercible(
+                            ),
+                            E::Unshaped => CoercionError::uncoercible(
                                 path,
                                 json_value,
                                 "richtext",
@@ -639,13 +642,9 @@ impl QuillConfig {
                                         _ => "an unsupported value",
                                     }
                                 ),
-                            ));
-                        }
-                    };
-                    inline_check(&content)?;
-                    return Ok(QuillValue::from_json(
-                        quillmark_content::serial::to_canonical_value(&content),
-                    ));
+                            ),
+                            E::NotInline => inline_err(),
+                        });
                 }
                 if json_value.is_object() {
                     let rt = quillmark_content::serial::from_canonical_value(json_value).map_err(
@@ -2282,32 +2281,22 @@ fn literal_content(
     }
     match &field.r#type {
         FieldType::RichText { inline } => {
-            let rt = match crate::document::decode_richtext_value(json) {
-                Some(Ok(rt)) => rt,
-                Some(Err(e)) => {
-                    let reason = match e {
-                        crate::document::RichtextDecodeError::BadMarkdown(m) => {
-                            format!("markdown import failed: {m}")
-                        }
-                        crate::document::RichtextDecodeError::NotContent(m) => {
-                            format!("not a valid richtext content: {m}")
-                        }
-                    };
-                    return Err(richtext_literal_error(label, &reason));
-                }
-                None => {
-                    return Err(richtext_literal_error(
+            use crate::document::{RichtextDecodeError as D, RichtextValueError as E};
+            crate::document::canonical_richtext_value(json, *inline)
+                .map(|content| Some(QuillValue::from_json(content)))
+                .map_err(|e| match e {
+                    E::Decode(D::BadMarkdown(m)) => {
+                        richtext_literal_error(label, &format!("markdown import failed: {m}"))
+                    }
+                    E::Decode(D::NotContent(m)) => {
+                        richtext_literal_error(label, &format!("not a valid richtext content: {m}"))
+                    }
+                    E::Unshaped => richtext_literal_error(
                         label,
                         "expected a markdown string (richtext literals are authored as markdown)",
-                    ));
-                }
-            };
-            if *inline && !rt.is_inline() {
-                return Err(richtext_inline_error(label));
-            }
-            Ok(Some(QuillValue::from_json(
-                quillmark_content::serial::to_canonical_value(&rt),
-            )))
+                    ),
+                    E::NotInline => richtext_inline_error(label),
+                })
         }
         FieldType::PlainText { inline } => {
             // Plaintext literals are authored as literal strings and imported

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2358,6 +2358,21 @@ fn inline_richtext_example_over_one_para_is_a_load_error() {
     );
 }
 
+/// A richtext literal is authored as markdown or as a canonical content object;
+/// a bare scalar is neither, and the load error says so rather than importing
+/// the scalar's text.
+#[test]
+fn a_bare_scalar_richtext_example_is_a_load_error() {
+    let err = quill_with_field("    tag:\n      type: richtext\n      example: 47\n").unwrap_err();
+    assert!(
+        err.iter().any(|d| {
+            d.code.as_deref() == Some("quill::richtext_example_import")
+                && d.message.contains("expected a markdown string")
+        }),
+        "a numeric richtext example should fail load naming the encoding, got: {err:?}"
+    );
+}
+
 #[test]
 fn inline_richtext_single_line_example_loads_and_caches_content() {
     let config = quill_with_field(


### PR DESCRIPTION
Closes #1329.

## The issue's diagnosis, reviewed

Half right. `literal_content`'s richtext arm and `conform_value`'s `Leniency::Write` richtext arm do share a skeleton: `decode_richtext_value` → classify the failure → inline check → `to_canonical_value`. But most of the ~30 lines the issue counts are error *rendering*, and that part has to differ. `literal_content` addresses a quill author ("richtext literals are authored as markdown") and emits a `Diagnostic` carrying the `validation::not_inline` code plus a hint; `conform_value` addresses a document writer and emits a `CoercionError`. The genuinely shared logic is three lines.

## Why not the proposed fix

Calling `conform_value(value, field, label, Leniency::Write)` and mapping the `CoercionError` back means telling an inline violation from an import failure by string-matching `target == "richtext(inline)"` — `CoercionError` is a single opaque variant with four `String` fields. `document/edit.rs:366` already does that sniffing at its own seam; routing the load path through `conform_value` would make the literal `"richtext(inline)"` a load-bearing string at a second site, trading a visible duplicate for an invisible coupling to another layer's message text. It would also drop the per-variant prefixes (`markdown import failed:` / `not a valid richtext content:`), since the Write arm discards the variant via `into_message()`.

## What this does instead

Extracts the actual kernel into `document::canonical_richtext_value(value, inline) -> Result<Value, RichtextValueError>`, next to `decode_richtext_value`. The error is a *typed* three-way classification (`Decode` / `Unshaped` / `NotInline`), so each layer renders its own vocabulary from a match rather than a string comparison. Both call sites route through it and keep only their diagnostic.

- `crates/core/src/document/mod.rs` — the shared contract
- `crates/core/src/quill/config.rs` — both arms, −25 lines net

Every error text is byte-identical to before; the `PlainText` arms are untouched, since the issue is right that they diverge (the write path there reduces via `lenient_string` and rests as a string, not content).

## Testing

`cargo test --workspace`: 59 suites, all ok. `cargo clippy --workspace --all-targets` output is byte-identical before and after.

Added `a_bare_scalar_richtext_example_is_a_load_error` — the `Unshaped` branch (a numeric richtext `example:`) had no coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hs6iPPj7vA1NyHS75qevUf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hs6iPPj7vA1NyHS75qevUf)_