### PR TITLE
perf(content): stop rebuilding the canonical tree that was just encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+- perf(content): **canonical serialization stops rebuilding the tree it just
+  built.** `to_canonical_value` normalized a copy — which already recursively
+  key-sorts every opaque bag reachable from it (island `props`, an unknown's
+  `attrs`) — and then ran a whole-tree `sort_keys_owned` over the encoded
+  result, re-collecting and re-allocating every object and array in the document
+  to reorder the handful of fixed keys the encoders insert themselves. The
+  encoders now emit those keys in ascending order and the terminal pass is
+  `canonicalize_keys`, which scans and returns when the tree is already
+  canonical. Canonical bytes are unchanged, byte for byte; a tree that somehow
+  arrives unsorted is still repaired rather than shipped.
+
+  The public `container_to_value`, `island_to_value` and `mark_to_value` now
+  emit their own keys in a different order. An unknown's `attrs` bag is
+  untouched, as in 0.99, and nothing hashes the op wire.
+
 ## v0.108.3 - 2026-08-21
 
 - fix(typst): **a paragraph holding one bare `/` renders instead of failing the

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -18,7 +18,7 @@
 //! The seam encoding and the storage encoding are the *same* canonical form.
 
 use crate::model::{
-    sort_keys_owned, Container, Invariant, Island, Line, LineKind, Loss, Mark,
+    canonicalize_keys, Container, Invariant, Island, Line, LineKind, Loss, Mark,
     MarkKind, Content, Usv,
 };
 use serde_json::{Map, Value};
@@ -50,9 +50,10 @@ impl std::error::Error for ParseError {}
 
 impl Content {
     /// Serialize to canonical JSON bytes. Normalizes a copy first, so the output
-    /// is canonical regardless of the caller's mark/island order, and sorts every
-    /// object key recursively, so the bytes do **not** depend on `serde_json`'s
-    /// `preserve_order` feature in the consumer's crate graph.
+    /// is canonical regardless of the caller's mark/island order, and every
+    /// object key comes out in ascending order at every depth, so the bytes do
+    /// **not** depend on `serde_json`'s `preserve_order` feature in the
+    /// consumer's crate graph.
     pub fn to_canonical_json(&self) -> String {
         to_canonical_value(self).to_string()
     }
@@ -67,7 +68,10 @@ impl Content {
 
     fn to_value(&self) -> Value {
         let mut root = Map::new();
-        root.insert("text".into(), Value::String(self.text.clone()));
+        root.insert(
+            "islands".into(),
+            Value::Array(self.islands.iter().map(island_to_value).collect()),
+        );
         root.insert(
             "lines".into(),
             Value::Array(self.lines.iter().map(line_to_value).collect()),
@@ -76,10 +80,7 @@ impl Content {
             "marks".into(),
             Value::Array(self.marks.iter().map(mark_to_value).collect()),
         );
-        root.insert(
-            "islands".into(),
-            Value::Array(self.islands.iter().map(island_to_value).collect()),
-        );
+        root.insert("text".into(), Value::String(self.text.clone()));
         Value::Object(root)
     }
 
@@ -119,7 +120,22 @@ impl Content {
 pub fn to_canonical_value(rt: &Content) -> Value {
     let mut rt = rt.clone();
     rt.normalize();
-    sort_keys_owned(rt.to_value())
+    let mut v = rt.to_value();
+    // Scans and returns: the encoders emit their fixed keys in ascending order,
+    // and every opaque bag under them was canonicalized by `normalize`. A key
+    // inserted out of order is still repaired here, so the freeze holds without
+    // the encoders having to be trusted for it.
+    canonicalize_keys(&mut v);
+    v
+}
+
+/// One map's own keys in ascending order, its values untouched. Shallow because
+/// every value below is a scalar, an array of encoder objects that sorted
+/// themselves, or a bag [`Content::normalize`] already canonicalized.
+fn sort_own_keys(m: Map<String, Value>) -> Map<String, Value> {
+    let mut entries: Vec<(String, Value)> = m.into_iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries.into_iter().collect()
 }
 
 /// Parse the canonical content form from a structural [`Value`], normalize, and
@@ -300,7 +316,9 @@ fn line_to_value(line: &Line) -> Value {
     if line.continues {
         m.insert("continues".into(), Value::Bool(true));
     }
-    Value::Object(m)
+    // `line_kind_fields` is shared with the op wire, which flattens it beside
+    // keys of its own, so the canonical order is settled here.
+    Value::Object(sort_own_keys(m))
 }
 
 fn line_from_value(v: &Value) -> Result<Line, ParseError> {
@@ -333,15 +351,15 @@ pub fn container_to_value(c: &Container) -> Value {
         } => {
             m.insert("container".into(), "list_item".into());
             m.insert("ordered".into(), Value::Bool(*ordered));
-            m.insert("start".into(), Value::from(*start));
             m.insert("ordinal".into(), Value::from(*ordinal));
+            m.insert("start".into(), Value::from(*start));
         }
         Container::Quote => {
             m.insert("container".into(), "quote".into());
         }
         Container::Unknown { tag, attrs } => {
-            m.insert("container".into(), Value::String(tag.clone()));
             m.insert("attrs".into(), attrs.clone());
+            m.insert("container".into(), Value::String(tag.clone()));
         }
     }
     Value::Object(m)
@@ -371,9 +389,13 @@ pub fn container_from_value(v: &Value) -> Result<Container, ParseError> {
     }
 }
 
-/// Encode a [`Mark`] (`{start, end, type, …}`) into its canonical wire object.
+/// Encode a [`Mark`] (`start`, `end`, `type`, …) into its canonical wire object.
 pub fn mark_to_value(mark: &Mark) -> Value {
-    Value::Object(mark_fields(mark.start, mark.end, &mark.kind))
+    // As in `line_to_value`: `mark_fields` serves the op wire too, so the
+    // canonical order is settled here.
+    Value::Object(sort_own_keys(mark_fields(
+        mark.start, mark.end, &mark.kind,
+    )))
 }
 
 /// The same fields unwrapped and over a mark's parts, for the op wire
@@ -654,15 +676,14 @@ pub fn parse_cell(v: &Value) -> (String, Vec<Mark>) {
     (text, marks)
 }
 
-/// Build a table-cell object `{text, marks}`. Key order is fixed by the
-/// recursive key-sort in [`Content::normalize`], not here.
+/// Build a table-cell object `{marks, text}`.
 pub(crate) fn cell_to_value(text: &str, marks: &[Mark]) -> Value {
     let mut m = Map::new();
-    m.insert("text".into(), Value::String(text.to_string()));
     m.insert(
         "marks".into(),
         Value::Array(marks.iter().map(mark_to_value).collect()),
     );
+    m.insert("text".into(), Value::String(text.to_string()));
     Value::Object(m)
 }
 
@@ -830,9 +851,9 @@ pub(crate) fn island_to_value(island: &Island) -> Value {
 pub(crate) fn island_fields(island: &Island) -> Map<String, Value> {
     let mut m = Map::new();
     m.insert("id".into(), Value::String(island.id.clone()));
-    m.insert("type".into(), Value::String(island.island_type.clone()));
-    m.insert("props".into(), island.props.clone());
     m.insert("loss".into(), island.loss.as_str().into());
+    m.insert("props".into(), island.props.clone());
+    m.insert("type".into(), Value::String(island.island_type.clone()));
     m
 }
 
@@ -1060,6 +1081,133 @@ mod tests {
         let mut two = one.clone();
         two.islands[0].props = serde_json::json!({"a": 2, "b": 1}); // keys reversed
         assert_eq!(one.to_canonical_json(), two.to_canonical_json());
+    }
+
+    /// Every encoder emits its own keys in ascending order, so
+    /// [`to_canonical_value`]'s backstop scans and returns instead of rebuilding
+    /// the tree. A key inserted out of order still serializes canonically — the
+    /// backstop repairs it — so nothing else notices the regression.
+    #[test]
+    fn encoders_emit_keys_in_ascending_order() {
+        use crate::model::is_value_key_sorted;
+        let bag = || serde_json::json!({"a": 1, "b": 2});
+        let sorted = |v: &Value| is_value_key_sorted(v);
+
+        let kinds = [
+            MarkKind::Strong,
+            MarkKind::Emph,
+            MarkKind::Underline,
+            MarkKind::Strike,
+            MarkKind::Code,
+            MarkKind::Link { url: "u".into() },
+            MarkKind::Anchor { id: "a".into() },
+            MarkKind::Unknown {
+                tag: "kbd".into(),
+                attrs: bag(),
+            },
+        ];
+        let marks: Vec<Mark> = kinds
+            .iter()
+            .map(|kind| Mark {
+                start: 0,
+                end: 1,
+                kind: kind.clone(),
+            })
+            .collect();
+        for m in &marks {
+            assert!(sorted(&mark_to_value(m)), "mark {:?}", m.kind);
+        }
+        assert!(sorted(&cell_to_value("t", &marks)));
+
+        let containers = vec![
+            Container::ListItem {
+                ordered: true,
+                start: 3,
+                ordinal: 1,
+            },
+            Container::Quote,
+            Container::Unknown {
+                tag: "indent".into(),
+                attrs: bag(),
+            },
+        ];
+        for c in &containers {
+            assert!(sorted(&container_to_value(c)), "container {c:?}");
+        }
+
+        let line_kinds = [
+            LineKind::Para,
+            LineKind::Heading { level: 2 },
+            LineKind::Code {
+                lang: Some("rust".into()),
+            },
+            LineKind::Code { lang: None },
+            LineKind::Island,
+            LineKind::Rule,
+            LineKind::Unknown {
+                tag: "callout".into(),
+                attrs: bag(),
+            },
+        ];
+        for kind in line_kinds {
+            for continues in [false, true] {
+                let line = Line {
+                    kind: kind.clone(),
+                    containers: containers.clone(),
+                    continues,
+                };
+                assert!(sorted(&line_to_value(&line)), "line {:?}", line.kind);
+            }
+        }
+
+        for island_type in ["table", "image", "widget"] {
+            let island = Island {
+                id: "i1".into(),
+                island_type: island_type.into(),
+                props: bag(),
+                loss: Loss::LOSSLESS,
+            };
+            assert!(sorted(&island_to_value(&island)), "island {island_type}");
+        }
+    }
+
+    /// The whole assembled tree, table cells and all: what the backstop actually
+    /// scans.
+    #[test]
+    fn the_canonical_tree_needs_no_repair() {
+        use crate::model::is_value_key_sorted;
+        let mut rt = Content::empty();
+        rt.text = "hi\n\u{FFFC}".into();
+        rt.lines = vec![
+            Line {
+                kind: LineKind::Heading { level: 2 },
+                containers: vec![Container::Quote],
+                continues: false,
+            },
+            Line {
+                kind: LineKind::Island,
+                containers: vec![],
+                continues: false,
+            },
+        ];
+        rt.marks = vec![Mark {
+            start: 0,
+            end: 2,
+            kind: MarkKind::Link { url: "u".into() },
+        }];
+        rt.islands = vec![Island {
+            id: "i1".into(),
+            island_type: "table".into(),
+            props: serde_json::json!({
+                "header": [{"text": "h", "marks": [{"start": 0, "end": 1, "type": "emph"}]}],
+                "rows": [[{"text": "r", "marks": []}]],
+                "aligns": ["none"],
+            }),
+            loss: Loss::LOSSLESS,
+        }];
+        rt.normalize();
+        assert_eq!(rt.validate(), Ok(()));
+        assert!(is_value_key_sorted(&rt.to_value()));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1334.

## The waste

`to_canonical_value` normalized a copy of the content — which recursively key-sorts every opaque bag reachable from it (island `props`, an unknown's `attrs`) — and then ran `sort_keys_owned` over the whole encoded tree: every object's entries collected into a `Vec`, sorted, and moved into a fresh `Map`; a fresh `Vec` per array. The only keys ever out of order were the fixed ones the encoders insert themselves.

## Where the issue's proposal needed adjusting

Two points from #1334 didn't survive a look at the code:

- **The "~40 lines" isn't there to delete.** `sort_keys_owned` still has two callers — `canonicalize_keys` and `canonical_json_string` (mark `attrs_key`). The deletion is one line.
- **Deleting the terminal pass outright trades a structural guarantee for a convention.** Today `to_canonical_value` guarantees sortedness in one place, unconditionally. Without it, six encoders have to keep an unwritten rule, and the pinning is thinner than it looks: the proptests check fixed-point and order-insensitivity, both of which hold for *any* deterministic order. Four hand-written literals pin actual bytes; `ListItem`'s `ordinal`/`start`, `Code`'s `lang`, a link's `url`, an anchor's `id`, cell `{marks,text}` and `continues` are pinned by nothing. On a storage freeze a silent key-order change moves every consumer's content hash.

Two encoders also can't emit sorted without contortion: `mark_fields` needs `attrs`/`id` interleaved among `end`/`start`/`type`, and `line_to_value` needs `containers`/`continues` interleaved with `line_kind_fields`' output. Restructuring either costs the exhaustive `match` that makes a new variant a compile error.

## What this does instead

- Four encoders settle order at the insert, for free: `Content::to_value`, `container_to_value`, `island_fields`, `cell_to_value`.
- `line_to_value` and `mark_to_value` shallow-sort their own top level via `sort_own_keys` — the same per-object cost those two already paid, but the opaque bags below them are no longer touched. Exhaustive matches and the op wire are unchanged.
- The terminal pass stays, as `canonicalize_keys`: an allocation-free scan that rebuilds only a tree that is not already canonical.

Net effect: all array reallocations and all bag rebuilds are gone, the expected-case cost drops to the scan, and the freeze remains a property of `to_canonical_value` rather than a convention.

## Bytes

Unchanged by construction, not just by test: `canonicalize_keys` *is* `sort_keys_owned` behind a correct sortedness predicate, so either branch yields the identical fully-sorted tree.

Visible only to a Rust caller encoding an op through the public `container_to_value` / `island_to_value` / `mark_to_value` and comparing the JSON as bytes: those emit their own keys in a different order now. An unknown's `attrs` bag is untouched, as in the 0.99 note, and nothing hashes the op wire.

## Tests

`encoders_emit_keys_in_ascending_order` pins the fast path over every line kind, container, mark type and island shape, and `the_canonical_tree_needs_no_repair` over an assembled tree with table cells. An out-of-order key still serializes canonically — the backstop repairs it — so these are what would notice the regression.

`cargo test --workspace` passes (29 suites, 0 failures), `golden_bytes_are_feature_independent` and the canonical-JSON proptests included. Clippy reports nothing new in `serial.rs`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENe3f2aC9FcGXGG5e6sVtP)_