### PR TITLE
refactor(pdfform): parse the flattened PDF where it is built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+- refactor(pdfform): **a session holds its flattened PDF parsed, not as bytes
+  each render path reparses.** Flatten and parse now happen together in `open`
+  and `update`, the two places `field_specs` are set, so the derived flat PDF
+  moves only with the specs it comes from and `render_svg`/`render_png`/
+  `render_rgba` paint parsed pages. A malformed flatten now surfaces from the
+  call that produced it under one code, `pdfform::flat_parse_failed`, replacing
+  the per-format `pdfform::svg_parse_failed` and `pdfform::png_parse_failed`
+  raised at render time (neither documented, and both reachable only through a
+  bug in this crate's own flatten).
+
 ## v0.108.3 - 2026-08-21
 
 - fix(typst): **a paragraph holding one bare `/` renders instead of failing the

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -90,8 +90,7 @@ impl Backend for PdfformBackend {
 
         let field_specs = resolve_field_specs(&bound, json_data);
 
-        // Pre-flatten once so the raster paths need not re-flatten per paint.
-        let flat_pdf = Arc::new(flatten_to_pdf(base_pdf.clone(), &field_specs)?);
+        let flat = flatten_and_parse(&base_pdf, &field_specs)?;
 
         Ok(LiveSession::new(
             Box::new(PdfformSession {
@@ -99,7 +98,7 @@ impl Backend for PdfformBackend {
                 bound,
                 field_specs,
                 page_boxes,
-                flat_pdf,
+                flat,
             }),
             source.config().clone(),
         ))
@@ -123,17 +122,29 @@ fn resolve_field_specs(bound: &[BoundWidget], json_data: &serde_json::Value) -> 
         .collect()
 }
 
-#[derive(Debug)]
+/// Values baked as content-stream operators, then parsed for hayro. Both halves
+/// live here so the render paths hold parsed pages rather than bytes to reparse:
+/// the flat PDF is derived from `field_specs` alone and moves only with them.
+///
+/// A parse failure is this crate flattening to something malformed, never a
+/// property of the output format asking for it.
+fn flatten_and_parse(base_pdf: &[u8], field_specs: &[FieldSpec]) -> Result<HayroPdf, RenderError> {
+    let flat = flatten_to_pdf(base_pdf.to_vec(), field_specs)?;
+    HayroPdf::new(flat).map_err(|_| {
+        engine_err(
+            "pdfform::flat_parse_failed",
+            "failed to parse the flattened PDF for rasterisation",
+        )
+    })
+}
+
 struct PdfformSession {
     base_pdf: Vec<u8>,
     bound: Vec<BoundWidget>,
     field_specs: Vec<FieldSpec>,
     /// Cached so `page_size_pt` need not reparse.
     page_boxes: Vec<[f32; 4]>,
-    /// Values baked as content-stream operators, ready for hayro rasterisation.
-    /// An `Arc` because hayro takes its bytes as one: a render pass shares them
-    /// rather than copying the whole flattened PDF.
-    flat_pdf: Arc<Vec<u8>>,
+    flat: HayroPdf,
 }
 
 impl SessionHandle for PdfformSession {
@@ -177,8 +188,7 @@ impl SessionHandle for PdfformSession {
     }
 
     fn render_rgba(&self, page: usize, scale: f32) -> Option<(u32, u32, Vec<u8>)> {
-        let pdf = HayroPdf::new(Arc::clone(&self.flat_pdf)).ok()?;
-        let p = pdf.pages().get(page)?;
+        let p = self.flat.pages().get(page)?;
         let cache = RenderCache::new();
         let interp = standard_font_settings();
         let render_settings = scaled_render_settings(scale);
@@ -201,7 +211,7 @@ impl SessionHandle for PdfformSession {
     /// never changes, so field deltas are the only visible delta.
     fn update(&mut self, json_data: &serde_json::Value) -> Result<ChangeSet, RenderError> {
         let field_specs = resolve_field_specs(&self.bound, json_data);
-        let flat_pdf = Arc::new(flatten_to_pdf(self.base_pdf.clone(), &field_specs)?);
+        let flat = flatten_and_parse(&self.base_pdf, &field_specs)?;
 
         let mut dirty_pages: Vec<usize> = self
             .field_specs
@@ -214,31 +224,20 @@ impl SessionHandle for PdfformSession {
         dirty_pages.dedup();
 
         self.field_specs = field_specs;
-        self.flat_pdf = flat_pdf;
+        self.flat = flat;
 
         Ok(ChangeSet::new(self.page_boxes.len(), dirty_pages))
     }
 }
 
 impl PdfformSession {
-    /// The pre-flattened PDF parsed for a render pass, refused under the
-    /// caller's own per-format error code.
-    fn open_flat(&self, code: &'static str, label: &str) -> Result<HayroPdf, RenderError> {
-        HayroPdf::new(Arc::clone(&self.flat_pdf)).map_err(|_| {
-            engine_err(
-                code,
-                format!("failed to parse pre-flattened PDF for {label} render"),
-            )
-        })
-    }
-
     fn render_svg(&self) -> Result<RenderResult, RenderError> {
-        let pdf = self.open_flat("pdfform::svg_parse_failed", "SVG")?;
         let interp = standard_font_settings();
         let svg_settings = SvgRenderSettings {
             bg_color: [255, 255, 255, 255],
         };
-        let artifacts: Vec<Artifact> = pdf
+        let artifacts: Vec<Artifact> = self
+            .flat
             .pages()
             .iter()
             .map(|page| {
@@ -253,12 +252,11 @@ impl PdfformSession {
 
     /// `scale` is device pixels per PDF point (`ppi / 72`).
     fn render_png(&self, scale: f32) -> Result<RenderResult, RenderError> {
-        let pdf = self.open_flat("pdfform::png_parse_failed", "PNG")?;
         let interp = standard_font_settings();
         let render_settings = scaled_render_settings(scale);
 
-        let mut artifacts = Vec::with_capacity(pdf.pages().len());
-        for page in pdf.pages().iter() {
+        let mut artifacts = Vec::with_capacity(self.flat.pages().len());
+        for page in self.flat.pages().iter() {
             let cache = RenderCache::new();
             let pixmap = hayro_render(page, &cache, &interp, &render_settings);
             let png = pixmap.into_png().map_err(|e| {


### PR DESCRIPTION
Closes #1336.

## The issue's perf claim does not hold

#1336 proposed caching the parsed `hayro::Pdf` as an optimisation, on the reasoning that `render_rgba` is called once per page by the canvas seam, so an N-page preview parses the identical flattened bytes N times.

The mechanics are right — `crates/bindings/wasm/src/engine.rs:2751` does call `render_rgba` a page at a time, and all three render paths did construct a fresh `Pdf`. What does not hold is the premise that the parse is "the remaining, larger half". Measured on the `sample_form` fixture, release build:

| | |
|---|---|
| `hayro::Pdf::new` on the flattened PDF (3.9 KB) | **6.5 µs** |
| `render_rgba` for that page | **18.8 ms** |

The parse is ~0.03% of the paint that follows it. `Pdf::new` only walks the xref and page tree — hayro parses objects lazily — so its cost tracks object count, not the rasterisation. End-to-end `render_rgba` before vs. after this change: 18.45 ms → 18.59 ms, unchanged within noise.

**As a performance fix this is not worth doing.** It lands on the simplification alone.

## What the change does

The flat PDF was derived state assembled in two places: flattened in `open`/`update`, parsed again at each of three render sites. Both halves now sit in `flatten_and_parse`, called from the two places `field_specs` are set, and the session holds the parsed `Pdf` — so the derived value moves only with the specs it comes from, and `render_svg` / `render_png` / `render_rgba` paint parsed pages.

`update` keeps its transactional swap: specs and flat PDF still move together only after both succeed.

`open_flat` and its two parse-and-check sites are gone. Net −2 lines, not the ~25 the issue estimated, since this is a move rather than an addition.

## Error-code change

A parse failure here means this crate's own flatten emitted something malformed — a bug in `flatten`, not a property of the output format that asked for it, so attributing it per-format was misleading. The per-format codes collapse into one raised from the call that produced the bytes:

- removed: `pdfform::svg_parse_failed`, `pdfform::png_parse_failed`
- added: `pdfform::flat_parse_failed`

Neither retired code was documented or referenced by a test.

`#[derive(Debug)]` leaves the session, `hayro::Pdf` having no `Debug` impl. `SessionHandle` does not require one and `TypstSession` carries none.

## Testing

- `cargo test --workspace` — green, no failures.
- `cargo clippy -p quillmark-pdfform --all-targets` — no warnings for the crate.
- The `Send + Sync` prediction in the issue held; the compiler accepted it through the existing `SessionHandle` bound.

## Note for the epic

#1336 came out of the batch simplify review in #1339. If its sibling issues carry similar unmeasured perf claims, they are worth timing before implementing rather than after.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QY2dSfjZgRUCiZhc2sodGp)_