### PR TITLE
perf(pdf): index the base's object offsets once instead of scanning per read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- perf(pdf): **filling a PDF form no longer slows down with the size of its
+  background or its page count.** Reading one object from the base walks every
+  byte of it — the live copy is the last revision, so a scan cannot stop early
+  — and nothing memoized that, so a stamp or flatten pass paid O(pages) whole-
+  file scans and the live-edit path repaid them on every keystroke. The base's
+  object offsets are now collected in one pass and each read is a lookup: a
+  20-page 300 KB form stamps in 0.7 ms rather than 37 ms, flat in page count.
+
 ## v0.108.3 - 2026-08-21
 
 - fix(typst): **a paragraph holding one bare `/` renders instead of failing the

--- a/crates/backends/pdfform/src/flatten.rs
+++ b/crates/backends/pdfform/src/flatten.rs
@@ -10,7 +10,7 @@
 //! SVG/PNG raster outputs only; the AcroForm PDF deliverable is stamped.
 
 use quillmark_pdf::{
-    reader::{extract_outer_dict, find_dict_value, object_dict, splice_dict_value, UpdatedObject},
+    reader::{extract_outer_dict, find_dict_value, splice_dict_value, ObjectIndex, UpdatedObject},
     writer::{
         alloc_id, append_refs_to_array_key, dict_object, pdf_escape, winansi_encode, OnNonArray,
     },
@@ -32,9 +32,10 @@ pub fn flatten(base: Vec<u8>, fields: &[FieldSpec]) -> Result<Vec<u8>, PdfError>
     }
 
     let pdf = base;
-    let mut up = PdfUpdate::begin(&pdf, None)?;
+    let idx = ObjectIndex::new(&pdf);
+    let mut up = PdfUpdate::begin(&idx, None)?;
 
-    let page_ids = up.resolve_pages(&pdf, fields)?;
+    let page_ids = up.resolve_pages(&idx, fields)?;
     let page_count = page_ids.len();
 
     // Helvetica and ZapfDingbats are among the 14 standard PDF fonts every
@@ -67,7 +68,7 @@ pub fn flatten(base: Vec<u8>, fields: &[FieldSpec]) -> Result<Vec<u8>, PdfError>
 
         let page_obj_id = page_ids[page_idx];
         let what = format!("page object {page_obj_id}");
-        let pg_dict = object_dict(&pdf, page_obj_id, CODE_PARSE, &what)?;
+        let pg_dict = idx.dict(page_obj_id, CODE_PARSE, &what)?;
 
         let new_pg = rewrite_page_for_flatten(pg_dict, helv_id, zadb_id, stream_id)?;
         up.objects.push(dict_object(page_obj_id, &new_pg));

--- a/crates/fuzz/src/pdf_fuzz.rs
+++ b/crates/fuzz/src/pdf_fuzz.rs
@@ -14,7 +14,9 @@
 use std::sync::LazyLock;
 
 use proptest::prelude::*;
-use quillmark_pdf::{page_media_boxes, stamp, FieldSpec, FieldType, PdfUpdate, StampOptions};
+use quillmark_pdf::{
+    page_media_boxes, reader::ObjectIndex, stamp, FieldSpec, FieldType, PdfUpdate, StampOptions,
+};
 
 /// A real AcroForm the spine accepts, so a mutant of it exercises parse paths a
 /// random buffer never reaches. Read once: thousands of cases mutate a copy.
@@ -44,8 +46,9 @@ fn every_field_kind() -> Vec<FieldSpec> {
 /// Drive every byte-taking entry point once; completing at all is the property.
 fn exercise(pdf: &[u8]) {
     let _ = page_media_boxes(pdf);
-    let _ = PdfUpdate::begin(pdf, None);
-    let _ = PdfUpdate::begin(pdf, Some("quillmark-fuzz"));
+    let idx = ObjectIndex::new(pdf);
+    let _ = PdfUpdate::begin(&idx, None);
+    let _ = PdfUpdate::begin(&idx, Some("quillmark-fuzz"));
     let _ = stamp(pdf.to_vec(), &[], &StampOptions::default());
     let _ = stamp(
         pdf.to_vec(),

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -12,7 +12,7 @@
 //! branches. `hayro-syntax` is read-only and exposes no byte spans, so it cannot
 //! drive a byte-splice append; hence this bespoke scanner.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::error::PdfError;
 
@@ -163,29 +163,108 @@ pub(crate) fn append_incremental_update(
     Ok(pdf)
 }
 
-/// Locate object `id` and return `(obj_start, endobj_end)`.
+/// A base PDF and the offset of every indirect object header in it, collected in
+/// one forward pass. Every read of an object goes through this.
 ///
-/// Matches `<id> <generation> obj` at a token boundary, so `19 0 obj` is not
+/// A per-object scan cannot stop early — a base carrying prior incremental
+/// updates serializes an id more than once and the live copy is the last — so
+/// reading one object without an index walks the whole buffer, and a stamp or
+/// flatten pass reads O(pages) objects.
+///
+/// A header is `<id> <generation> obj` at a token boundary, so `19 0 obj` is not
 /// found inside `519 0 obj`, at any generation (re-saved PDFs carry non-zero
-/// ones). A base with prior incremental updates can serialize an id more than
-/// once; the live copy is the last, so this returns the last match.
-pub fn find_object_bytes(pdf: &[u8], id: u32) -> Option<(usize, usize)> {
-    let prefix = format!("{id} ");
-    let p = prefix.as_bytes();
-    let mut last_start = None;
-    let mut i = 0;
-    while i + p.len() <= pdf.len() {
-        if (i == 0 || matches!(pdf[i - 1], b'\n' | b'\r' | b' '))
-            && pdf[i..].starts_with(p)
-            && is_obj_header_tail(&pdf[i + p.len()..])
-        {
-            last_start = Some(i);
+/// ones). A later occurrence overwrites an earlier one, so a lookup answers with
+/// the live copy.
+pub struct ObjectIndex<'a> {
+    pdf: &'a [u8],
+    starts: HashMap<u32, usize>,
+}
+
+impl<'a> ObjectIndex<'a> {
+    pub fn new(pdf: &'a [u8]) -> Self {
+        let mut starts = HashMap::new();
+        for i in 0..pdf.len() {
+            if !pdf[i].is_ascii_digit() || !(i == 0 || matches!(pdf[i - 1], b'\n' | b'\r' | b' ')) {
+                continue;
+            }
+            if let Some(id) = obj_header_id(&pdf[i..]) {
+                starts.insert(id, i);
+            }
         }
-        i += 1;
+        Self { pdf, starts }
     }
-    let start = last_start?;
-    let end = find_endobj_end(pdf, start + p.len())?;
-    Some((start, end))
+
+    /// The indexed bytes, for the scans that read no object.
+    pub fn bytes(&self) -> &'a [u8] {
+        self.pdf
+    }
+
+    /// `(obj_start, endobj_end)` of object `id`.
+    pub fn object_bytes(&self, id: u32) -> Option<(usize, usize)> {
+        let start = *self.starts.get(&id)?;
+        Some((start, find_endobj_end(self.pdf, start)?))
+    }
+
+    /// The inner dict bytes of object `id`. `what` names the object in both
+    /// failure messages — `"{what} not found"` and `"{what} dict not
+    /// parseable"` — under the caller's error `code`; an Option-returning caller
+    /// calls `.ok()`.
+    pub fn dict(&self, id: u32, code: &'static str, what: &str) -> Result<&'a [u8], PdfError> {
+        let (s, e) = self
+            .object_bytes(id)
+            .ok_or_else(|| err(code, format!("{what} not found")))?;
+        extract_outer_dict(&self.pdf[s..e])
+            .ok_or_else(|| err(code, format!("{what} dict not parseable")))
+    }
+
+    /// The generation in object `id`'s header, or `None` when the object is
+    /// absent or its generation malformed.
+    fn generation(&self, id: u32) -> Option<u16> {
+        let start = *self.starts.get(&id)?;
+        let header = &self.pdf[start..];
+        let id_digits = header.iter().take_while(|b| b.is_ascii_digit()).count();
+        // Past the id and the one space a header writes after it.
+        let rest = &header[id_digits + 1..];
+        let n = rest.iter().take_while(|b| b.is_ascii_digit()).count();
+        std::str::from_utf8(&rest[..n]).ok()?.parse().ok()
+    }
+
+    /// Reject overwriting a base object that lives at a non-zero generation.
+    ///
+    /// The update writer re-emits overwritten objects at generation 0 and
+    /// references them as generation 0, while the reader accepts a header at any
+    /// generation. A base whose catalog / page / `/Info` sits at a non-zero
+    /// generation therefore parses fine yet would produce a malformed update: the
+    /// new `/Root` points at generation 0 while the prior xref resolves the true
+    /// generation.
+    ///
+    /// `None` (object absent) is left for the caller's not-found error path.
+    pub(crate) fn assert_overwrite_gen_zero(&self, id: u32, what: &str) -> Result<(), PdfError> {
+        match self.generation(id) {
+            Some(0) | None => Ok(()),
+            Some(generation) => Err(err(
+                "pdf::nonzero_generation",
+                format!(
+                    "{what} object {id} is at generation {generation}; the stamp spine re-emits \
+                     overwritten objects at generation 0 and cannot preserve a non-zero generation"
+                ),
+            )),
+        }
+    }
+}
+
+/// The object id of the `<id> <generation> obj` header at the start of `rest`,
+/// when there is one. An id written with a leading zero is not one: the index
+/// matches the exact decimal form a reference to the object is written in.
+fn obj_header_id(rest: &[u8]) -> Option<u32> {
+    let digits = rest.iter().take_while(|b| b.is_ascii_digit()).count();
+    if (digits > 1 && rest[0] == b'0')
+        || rest.get(digits) != Some(&b' ')
+        || !is_obj_header_tail(&rest[digits + 1..])
+    {
+        return None;
+    }
+    std::str::from_utf8(&rest[..digits]).ok()?.parse().ok()
 }
 
 /// The index just past the `endobj` closing the body at `from`. Literal
@@ -205,38 +284,6 @@ fn find_endobj_end(pdf: &[u8], from: usize) -> Option<usize> {
         i += 1;
     }
     None
-}
-
-/// The generation in object `id`'s header, or `None` when it is absent or
-/// malformed. Reads the live copy, matching [`find_object_bytes`].
-pub(crate) fn object_generation(pdf: &[u8], id: u32) -> Option<u16> {
-    let (start, _) = find_object_bytes(pdf, id)?;
-    let after_id = start + format!("{id} ").len();
-    let rest = &pdf[after_id..];
-    let n = rest.iter().take_while(|b| b.is_ascii_digit()).count();
-    std::str::from_utf8(&rest[..n]).ok()?.parse().ok()
-}
-
-/// Reject overwriting a base object that lives at a non-zero generation.
-///
-/// The update writer re-emits overwritten objects at generation 0 and references
-/// them as generation 0, while the reader accepts a header at any generation. A
-/// base whose catalog / page / `/Info` sits at a non-zero generation therefore
-/// parses fine yet would produce a malformed update: the new `/Root` points at
-/// generation 0 while the prior xref resolves the true generation.
-///
-/// `None` (object absent) is left for the caller's not-found error path.
-pub(crate) fn assert_overwrite_gen_zero(pdf: &[u8], id: u32, what: &str) -> Result<(), PdfError> {
-    match object_generation(pdf, id) {
-        Some(0) | None => Ok(()),
-        Some(generation) => Err(err(
-            "pdf::nonzero_generation",
-            format!(
-                "{what} object {id} is at generation {generation}; the stamp spine re-emits \
-                 overwritten objects at generation 0 and cannot preserve a non-zero generation"
-            ),
-        )),
-    }
 }
 
 /// Whether the bytes after an `<id> ` prefix continue as `<generation> obj`.
@@ -538,19 +585,6 @@ fn skip_ws(s: &[u8]) -> &[u8] {
     &s[ws_end(s, 0)..]
 }
 
-/// The inner dict bytes of object `id`. `what` names the object in both failure
-/// messages — `"{what} not found"` and `"{what} dict not parseable"` — under
-/// the caller's error `code`; an Option-returning caller calls `.ok()`.
-pub fn object_dict<'a>(
-    pdf: &'a [u8],
-    id: u32,
-    code: &'static str,
-    what: &str,
-) -> Result<&'a [u8], PdfError> {
-    let (s, e) = find_object_bytes(pdf, id).ok_or_else(|| err(code, format!("{what} not found")))?;
-    extract_outer_dict(&pdf[s..e]).ok_or_else(|| err(code, format!("{what} dict not parseable")))
-}
-
 /// Open the base's trailer: the xref offset, the trailer dict, and the catalog
 /// (`/Root`) object id, after refusing an xref stream. `code` carries the
 /// caller's error code for a missing or malformed `/Root`.
@@ -569,15 +603,14 @@ pub(crate) fn open_trailer<'a>(
 
 /// Flatten the catalog's `/Pages` tree into page object ids in document order.
 /// The walk is capped to prevent runaway on a pathological PDF.
-pub(crate) fn resolve_page_ids(pdf: &[u8], catalog_id: u32) -> Result<Vec<u32>, PdfError> {
-    let root_pages_id = root_pages_id(pdf, catalog_id)?;
+pub(crate) fn resolve_page_ids(idx: &ObjectIndex, catalog_id: u32) -> Result<Vec<u32>, PdfError> {
+    let root_pages_id = root_pages_id(idx, catalog_id)?;
 
     const MAX_NODES: usize = 100_000;
     let mut out = Vec::new();
     let mut stack = vec![root_pages_id];
-    // A node reached twice is a cyclic or shared-node `/Pages` tree, and an
-    // amplification vector: every visit re-scans the whole file, so a tiny
-    // `/Kids` self-cycle would drive MAX_NODES full-file scans without this.
+    // A node reached twice is a cyclic or shared-node `/Pages` tree: a `/Kids`
+    // self-cycle would otherwise walk until MAX_NODES.
     let mut seen: HashSet<u32> = HashSet::new();
     while let Some(node_id) = stack.pop() {
         if !seen.insert(node_id) {
@@ -589,7 +622,7 @@ pub(crate) fn resolve_page_ids(pdf: &[u8], catalog_id: u32) -> Result<Vec<u32>, 
         if seen.len() > MAX_NODES {
             return Err(err(CODE_PARSE, "page tree exceeds 100 000 nodes"));
         }
-        let dict = object_dict(pdf, node_id, CODE_PARSE, &format!("page node {node_id}"))?;
+        let dict = idx.dict(node_id, CODE_PARSE, &format!("page node {node_id}"))?;
         let typ = find_dict_value(dict, "Type")
             .map(|b| String::from_utf8_lossy(b.trim_ascii()).into_owned())
             .unwrap_or_default();
@@ -610,8 +643,8 @@ pub(crate) fn resolve_page_ids(pdf: &[u8], catalog_id: u32) -> Result<Vec<u32>, 
 }
 
 /// The catalog's root `/Pages` node id.
-fn root_pages_id(pdf: &[u8], catalog_id: u32) -> Result<u32, PdfError> {
-    let cat_dict = object_dict(pdf, catalog_id, CODE_PARSE, "catalog")?;
+fn root_pages_id(idx: &ObjectIndex, catalog_id: u32) -> Result<u32, PdfError> {
+    let cat_dict = idx.dict(catalog_id, CODE_PARSE, "catalog")?;
     find_dict_value(cat_dict, "Pages")
         .and_then(parse_indirect_ref)
         .map(|(id, _)| id)
@@ -622,16 +655,13 @@ fn root_pages_id(pdf: &[u8], catalog_id: u32) -> Result<u32, PdfError> {
 /// from the root `/Pages`. The stamp and flatten paths write geometry in
 /// unrotated user space and do not compensate, so a rotated base page would
 /// display every widget away from its intended box.
-///
-/// The inherited value is resolved once for the whole batch: reading it costs a
-/// full-file scan per page otherwise.
 pub(crate) fn assert_unrotated_pages(
-    pdf: &[u8],
+    idx: &ObjectIndex,
     catalog_id: u32,
     page_ids: &[u32],
 ) -> Result<(), PdfError> {
     let read_rotate = |id: u32| -> Option<i64> {
-        let dict = object_dict(pdf, id, CODE_PARSE, "page").ok()?;
+        let dict = idx.dict(id, CODE_PARSE, "page").ok()?;
         let raw = find_dict_value(dict, "Rotate")?;
         std::str::from_utf8(raw.trim_ascii())
             .ok()?
@@ -639,7 +669,7 @@ pub(crate) fn assert_unrotated_pages(
             .parse::<i64>()
             .ok()
     };
-    let inherited = root_pages_id(pdf, catalog_id).ok().and_then(read_rotate);
+    let inherited = root_pages_id(idx, catalog_id).ok().and_then(read_rotate);
     for &page_id in page_ids {
         let rotate = read_rotate(page_id).or(inherited).unwrap_or(0);
         if rotate.rem_euclid(360) != 0 {
@@ -719,11 +749,12 @@ fn normalize_rect(mb: [f32; 4]) -> [f32; 4] {
 pub(crate) fn page_media_boxes(pdf: &[u8]) -> Result<Vec<[f32; 4]>, PdfError> {
     let (_, _, catalog_id) = open_trailer(pdf, CODE_PARSE)?;
 
-    let inherited = root_pages_media_box(pdf, catalog_id);
-    let page_ids = resolve_page_ids(pdf, catalog_id)?;
+    let idx = ObjectIndex::new(pdf);
+    let inherited = root_pages_media_box(&idx, catalog_id);
+    let page_ids = resolve_page_ids(&idx, catalog_id)?;
     let mut out = Vec::with_capacity(page_ids.len());
     for id in page_ids {
-        let dict = object_dict(pdf, id, CODE_PARSE, &format!("page node {id}"))?;
+        let dict = idx.dict(id, CODE_PARSE, &format!("page node {id}"))?;
         let mb = find_dict_value(dict, "MediaBox")
             .and_then(parse_rect_array)
             .or(inherited)
@@ -734,9 +765,9 @@ pub(crate) fn page_media_boxes(pdf: &[u8]) -> Result<Vec<[f32; 4]>, PdfError> {
 }
 
 /// The root `/Pages` node's `/MediaBox`, if present: the value pages inherit.
-fn root_pages_media_box(pdf: &[u8], catalog_id: u32) -> Option<[f32; 4]> {
-    let pages_id = root_pages_id(pdf, catalog_id).ok()?;
-    let dict = object_dict(pdf, pages_id, CODE_PARSE, "root /Pages node").ok()?;
+fn root_pages_media_box(idx: &ObjectIndex, catalog_id: u32) -> Option<[f32; 4]> {
+    let pages_id = root_pages_id(idx, catalog_id).ok()?;
+    let dict = idx.dict(pages_id, CODE_PARSE, "root /Pages node").ok()?;
     find_dict_value(dict, "MediaBox").and_then(parse_rect_array)
 }
 
@@ -776,7 +807,8 @@ mod tests {
     #[test]
     fn endobj_inside_comment_does_not_truncate_object() {
         let pdf = b"%PDF\n3 0 obj\n<< /A 1 >> %endobj in a comment\n/B 2 >>\nendobj\n";
-        let (s, e) = find_object_bytes(pdf, 3).expect("found object 3");
+        let idx = ObjectIndex::new(pdf);
+        let (s, e) = idx.object_bytes(3).expect("found object 3");
         assert_eq!(&pdf[e - 6..e], b"endobj");
         assert!(&pdf[s..e].ends_with(b"/B 2 >>\nendobj"));
     }
@@ -846,25 +878,50 @@ mod tests {
     #[test]
     fn find_object_at_token_boundary() {
         let pdf = b"%PDF\n519 0 obj\n<< /A 1 >>\nendobj\n19 0 obj\n<< /B 2 >>\nendobj\n";
-        let (s, e) = find_object_bytes(pdf, 19).expect("found object 19");
+        let idx = ObjectIndex::new(pdf);
+        let (s, e) = idx.object_bytes(19).expect("found object 19");
         assert_eq!(&pdf[s..e], b"19 0 obj\n<< /B 2 >>\nendobj");
+    }
+
+    #[test]
+    fn index_resolves_every_object_from_one_pass() {
+        let pdf = b"%PDF\n1 0 obj\n<< /A 1 >>\nendobj\n2 0 obj\n<< /B 2 >>\nendobj\n\
+                    3 0 obj\n<< /C 3 >>\nendobj\n";
+        let idx = ObjectIndex::new(pdf);
+        for (id, body) in [(1u32, &b"/A 1"[..]), (2, b"/B 2"), (3, b"/C 3")] {
+            assert_eq!(idx.dict(id, CODE_PARSE, "obj").unwrap().trim_ascii(), body);
+        }
+        assert!(idx.object_bytes(4).is_none());
+    }
+
+    #[test]
+    fn index_ignores_a_leading_zero_id_header() {
+        // `019` is not how a `19 0 R` reference writes the id, so it is not
+        // object 19 and does not supersede the real one.
+        let pdf = b"%PDF\n19 0 obj\n<< /V (real) >>\nendobj\n019 0 obj\n<< /V (decoy) >>\nendobj\n";
+        let dict = ObjectIndex::new(pdf).dict(19, CODE_PARSE, "obj").unwrap();
+        assert_eq!(find_dict_value(dict, "V").unwrap().trim_ascii(), b"(real)");
     }
 
     #[test]
     fn object_generation_reads_header_gen() {
         let pdf = b"%PDF\n7 2 obj\n<< /C 3 >>\nendobj\n4 0 obj\n<< /D 1 >>\nendobj\n";
-        assert_eq!(object_generation(pdf, 7), Some(2));
-        assert_eq!(object_generation(pdf, 4), Some(0));
-        assert_eq!(object_generation(pdf, 99), None);
+        let idx = ObjectIndex::new(pdf);
+        assert_eq!(idx.generation(7), Some(2));
+        assert_eq!(idx.generation(4), Some(0));
+        assert_eq!(idx.generation(99), None);
     }
 
     #[test]
     fn assert_overwrite_gen_zero_rejects_nonzero() {
         let pdf = b"%PDF\n7 2 obj\n<< /C 3 >>\nendobj\n4 0 obj\n<< /D 1 >>\nendobj\n";
-        assert!(assert_overwrite_gen_zero(pdf, 4, "x").is_ok());
+        let idx = ObjectIndex::new(pdf);
+        assert!(idx.assert_overwrite_gen_zero(4, "x").is_ok());
         // Absent is accepted: the caller owns the not-found path.
-        assert!(assert_overwrite_gen_zero(pdf, 99, "x").is_ok());
-        let e = assert_overwrite_gen_zero(pdf, 7, "catalog").expect_err("generation 2 rejected");
+        assert!(idx.assert_overwrite_gen_zero(99, "x").is_ok());
+        let e = idx
+            .assert_overwrite_gen_zero(7, "catalog")
+            .expect_err("generation 2 rejected");
         assert_eq!(e.code, "pdf::nonzero_generation");
         assert!(e.message.contains("generation 2"), "{}", e.message);
     }
@@ -873,14 +930,16 @@ mod tests {
     fn find_object_returns_last_revision() {
         // Same id serialized twice, as an incremental update writes it.
         let pdf = b"%PDF\n4 0 obj\n<< /V (old) >>\nendobj\n4 0 obj\n<< /V (new) >>\nendobj\n";
-        let (s, e) = find_object_bytes(pdf, 4).expect("found object 4");
+        let idx = ObjectIndex::new(pdf);
+        let (s, e) = idx.object_bytes(4).expect("found object 4");
         assert_eq!(&pdf[s..e], b"4 0 obj\n<< /V (new) >>\nendobj");
     }
 
     #[test]
     fn endobj_inside_string_does_not_truncate_object() {
         let pdf = b"%PDF\n3 0 obj\n<< /Title (My endobj report) /Author (X) >>\nendobj\n";
-        let (s, e) = find_object_bytes(pdf, 3).expect("found object 3");
+        let idx = ObjectIndex::new(pdf);
+        let (s, e) = idx.object_bytes(3).expect("found object 3");
         assert_eq!(
             &pdf[s..e],
             b"3 0 obj\n<< /Title (My endobj report) /Author (X) >>\nendobj"
@@ -894,7 +953,7 @@ mod tests {
     fn page_tree_cycle_is_rejected() {
         let pdf = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
                     2 0 obj\n<< /Type /Pages /Kids [2 0 R] /Count 1 >>\nendobj\n";
-        let e = resolve_page_ids(pdf, 1).expect_err("cycle rejected");
+        let e = resolve_page_ids(&ObjectIndex::new(pdf), 1).expect_err("cycle rejected");
         assert_eq!(e.code, CODE_PARSE);
         assert!(e.message.contains("revisits"), "{}", e.message);
     }
@@ -905,11 +964,12 @@ mod tests {
         let pdf = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
                     2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 /Rotate 90 >>\nendobj\n\
                     3 0 obj\n<< /Type /Page /Parent 2 0 R >>\nendobj\n";
-        let e = assert_unrotated_pages(pdf, 1, &[3]).expect_err("rotated page rejected");
+        let e = assert_unrotated_pages(&ObjectIndex::new(pdf), 1, &[3])
+            .expect_err("rotated page rejected");
         assert_eq!(e.code, "pdf::rotated_page");
         let flat = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
                      2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\
                      3 0 obj\n<< /Type /Page /Parent 2 0 R >>\nendobj\n";
-        assert!(assert_unrotated_pages(flat, 1, &[3]).is_ok());
+        assert!(assert_unrotated_pages(&ObjectIndex::new(flat), 1, &[3]).is_ok());
     }
 }

--- a/crates/quillmark-pdf/src/stamp.rs
+++ b/crates/quillmark-pdf/src/stamp.rs
@@ -21,7 +21,7 @@ use pdf_writer::{Chunk, Finish, Name, Rect, Ref, Str, TextStr};
 use quillmark_core::RenderedRegion;
 
 use crate::error::PdfError;
-use crate::reader::{err, object_dict, parse_indirect_ref, UpdatedObject};
+use crate::reader::{err, parse_indirect_ref, ObjectIndex, UpdatedObject};
 use crate::update::PdfUpdate;
 use crate::writer::{alloc_id, append_refs_to_array_key, dict_object, OnNonArray};
 use crate::{FieldSpec, FieldType, FormFont, TextAlign};
@@ -103,10 +103,11 @@ pub fn stamp(
     }
 
     let pdf = base;
-    let mut up = PdfUpdate::begin(&pdf, opts.producer.as_deref())?;
+    let idx = ObjectIndex::new(&pdf);
+    let mut up = PdfUpdate::begin(&idx, opts.producer.as_deref())?;
 
     if !fields.is_empty() {
-        let page_ids = up.resolve_pages(&pdf, fields)?;
+        let page_ids = up.resolve_pages(&idx, fields)?;
         let page_count = page_ids.len();
 
         let fonts = fonts_used(fields);
@@ -173,7 +174,7 @@ pub fn stamp(
 
         // A widget is fillable only if reachable both ways: the catalog's
         // `/AcroForm /Fields` (added here) and the page's `/Annots` (below).
-        let cat_dict = object_dict(&pdf, up.catalog_id, CODE_PARSE, "catalog")?;
+        let cat_dict = idx.dict(up.catalog_id, CODE_PARSE, "catalog")?;
         let mut cat_inner = cat_dict.to_vec();
         cat_inner.extend_from_slice(format!(" /AcroForm {acroform_id} 0 R").as_bytes());
         up.objects.push(dict_object(up.catalog_id, &cat_inner));
@@ -184,7 +185,7 @@ pub fn stamp(
             }
             let page_obj_id = page_ids[page_idx];
             let what = format!("page node {page_obj_id}");
-            let pg_dict = object_dict(&pdf, page_obj_id, CODE_PARSE, &what)?;
+            let pg_dict = idx.dict(page_obj_id, CODE_PARSE, &what)?;
             up.objects.push(dict_object(
                 page_obj_id,
                 &rewrite_page_with_annots(pg_dict, widget_refs)?,

--- a/crates/quillmark-pdf/src/update.rs
+++ b/crates/quillmark-pdf/src/update.rs
@@ -5,8 +5,8 @@
 
 use crate::error::PdfError;
 use crate::reader::{
-    append_incremental_update, assert_overwrite_gen_zero, assert_unrotated_pages, err,
-    find_dict_value, open_trailer, parse_indirect_ref, resolve_page_ids, UpdatedObject,
+    append_incremental_update, assert_unrotated_pages, err, find_dict_value, open_trailer,
+    parse_indirect_ref, resolve_page_ids, ObjectIndex, UpdatedObject,
 };
 use crate::writer::apply_producer_stamp;
 use crate::FieldSpec;
@@ -30,10 +30,11 @@ pub struct PdfUpdate {
 }
 
 impl PdfUpdate {
-    /// Open `pdf` for an incremental update. The caller then pushes its objects
-    /// onto [`objects`](Self::objects) and calls [`finish`](Self::finish).
-    pub fn begin(pdf: &[u8], producer: Option<&str>) -> Result<Self, PdfError> {
-        let (xref_offset, trailer, catalog_id) = open_trailer(pdf, CODE_PARSE)?;
+    /// Open the indexed base for an incremental update. The caller then pushes
+    /// its objects onto [`objects`](Self::objects) and calls
+    /// [`finish`](Self::finish) with the base's bytes.
+    pub fn begin(idx: &ObjectIndex, producer: Option<&str>) -> Result<Self, PdfError> {
+        let (xref_offset, trailer, catalog_id) = open_trailer(idx.bytes(), CODE_PARSE)?;
         if find_dict_value(trailer, "Encrypt").is_some() {
             return Err(err(
                 "pdf::encrypted",
@@ -43,7 +44,7 @@ impl PdfUpdate {
         // The new trailer re-references the catalog as `/Root <id> 0 R`, so a
         // non-zero-generation catalog would be silently corrupted even when only
         // the producer is stamped (catalog not itself overwritten).
-        assert_overwrite_gen_zero(pdf, catalog_id, "catalog (/Root)")?;
+        idx.assert_overwrite_gen_zero(catalog_id, "catalog (/Root)")?;
         let size = find_dict_value(trailer, "Size")
             .and_then(|v| std::str::from_utf8(v.trim_ascii()).ok())
             .and_then(|s| s.parse::<u32>().ok())
@@ -58,7 +59,7 @@ impl PdfUpdate {
         let mut extra_info_ref = None;
         if let Some(producer) = producer {
             extra_info_ref =
-                apply_producer_stamp(pdf, info_ref, producer, &mut next_id, &mut objects)?;
+                apply_producer_stamp(idx, info_ref, producer, &mut next_id, &mut objects)?;
         }
 
         Ok(Self {
@@ -72,11 +73,13 @@ impl PdfUpdate {
 
     /// Resolve the base's page object ids, bounds-checking every field's `page`
     /// so a spec targeting a non-existent page errors rather than panicking later.
-    pub fn resolve_pages(&self, pdf: &[u8], fields: &[FieldSpec]) -> Result<Vec<u32>, PdfError> {
-        let page_ids = resolve_page_ids(pdf, self.catalog_id)?;
+    pub fn resolve_pages(
+        &self,
+        idx: &ObjectIndex,
+        fields: &[FieldSpec],
+    ) -> Result<Vec<u32>, PdfError> {
+        let page_ids = resolve_page_ids(idx, self.catalog_id)?;
         let page_count = page_ids.len();
-        // Both assertions below re-scan the whole byte buffer, so validate each
-        // distinct page once rather than pay O(fields × file_size).
         let mut checked = vec![false; page_count];
         let mut targeted = Vec::new();
         for spec in fields {
@@ -94,13 +97,13 @@ impl PdfUpdate {
             }
             // A targeted page is overwritten and referenced as gen 0, so a
             // non-zero-generation page would be silently corrupted.
-            assert_overwrite_gen_zero(pdf, page_ids[spec.page], "page")?;
+            idx.assert_overwrite_gen_zero(page_ids[spec.page], "page")?;
             checked[spec.page] = true;
             targeted.push(page_ids[spec.page]);
         }
         // Geometry is written in unrotated user space, so a rotated target page
         // would mis-place every field.
-        assert_unrotated_pages(pdf, self.catalog_id, &targeted)?;
+        assert_unrotated_pages(idx, self.catalog_id, &targeted)?;
         Ok(page_ids)
     }
 

--- a/crates/quillmark-pdf/src/writer.rs
+++ b/crates/quillmark-pdf/src/writer.rs
@@ -3,9 +3,7 @@
 //! `/Producer` stamp.
 
 use crate::error::PdfError;
-use crate::reader::{
-    assert_overwrite_gen_zero, err, find_dict_value, object_dict, splice_dict_value, UpdatedObject,
-};
+use crate::reader::{err, find_dict_value, splice_dict_value, ObjectIndex, UpdatedObject};
 
 const CODE_PARSE: &str = "pdf::write";
 
@@ -133,7 +131,7 @@ pub(crate) fn upsert_producer(info_dict: &[u8], literal: &[u8]) -> Vec<u8> {
 /// `/Info` onto `objects`. Returns `Some(info_id)` when a new `/Info` was
 /// allocated, which the caller threads into the trailer.
 pub(crate) fn apply_producer_stamp(
-    pdf: &[u8],
+    idx: &ObjectIndex,
     info_ref: Option<(u32, u16)>,
     producer: &str,
     next_id: &mut u32,
@@ -144,9 +142,9 @@ pub(crate) fn apply_producer_stamp(
         Some((info_id, _)) => {
             // Overwritten in place at generation 0; a non-zero-generation
             // `/Info` would be silently corrupted.
-            assert_overwrite_gen_zero(pdf, info_id, "/Info")?;
+            idx.assert_overwrite_gen_zero(info_id, "/Info")?;
             let what = format!("/Info object {info_id}");
-            let info_dict = object_dict(pdf, info_id, CODE_PARSE, &what)?;
+            let info_dict = idx.dict(info_id, CODE_PARSE, &what)?;
             objects.push(dict_object(info_id, &upsert_producer(info_dict, &literal)));
             Ok(None)
         }


### PR DESCRIPTION
Closes #1335.

## The problem

`find_object_bytes` walked every byte of the base to find one object — the live copy is the *last* revision, so the scan has no early exit — and it was the only way any code read an object, with nothing memoizing it. A `P`-page form cost `page_media_boxes` ≈ 2P+5 whole-file scans, `flatten` ≈ 5P+6 more, `stamp` about as many again, and `PdfformSession::update` re-runs the whole flatten arm on every edit.

Measured before the change, release build, ~300 KB base:

| base | `page_media_boxes` | `stamp` |
|---|---|---|
| 1 page | 2.9 ms | 4.8 ms |
| 5 pages | 6.6 ms | 11.9 ms |
| 20 pages | 19.2 ms | 37.4 ms |

Linear in pages × file size, as the issue predicted. The live-edit path is what makes it matter: ~37 ms of byte-comparison per keystroke on a 20-page form.

## The change

`ObjectIndex` collects `id -> header offset` in one forward pass and answers each read from the map.

- **It carries the base's bytes with it**, so a caller passes one thing where it previously passed a buffer and re-scanned it — no `(pdf, index)` pair to keep in sync, and no way to pair the wrong index with the wrong buffer. `object_dict`, `object_generation` and `assert_overwrite_gen_zero` become methods on it.
- **It stores only header offsets**, not `(start, end)`. `endobj` is located on lookup from the known start, which keeps the build a single trivial pass.
- **It is not stored on `PdfUpdate`**, as the issue proposed: that would give `PdfUpdate` a lifetime and make `up.finish(pdf)` — which moves the `Vec` — a borrowck error. Callers build it locally instead, and NLL ends the borrow before the move.

The header predicate is the old scan's, moved verbatim: `<id> <generation> obj` at a token boundary, later occurrence winning, and an id written with a leading zero matching nothing (`019 0 obj` was not object 19 to a `"19 "` prefix search either). That last rule is pinned by a new test, alongside one for multi-object resolution; the four existing object-lookup tests were rewritten against the index.

`reader` and `writer` are `#[doc(hidden)]` and documented as outside this crate's semver, so the signature churn carries no external cost.

## Result

Same 300 KB base, after:

| base | `page_media_boxes` | `stamp` |
|---|---|---|
| 1 page | 0.64 ms | 0.74 ms |
| 5 pages | 0.62 ms | 0.70 ms |
| 20 pages | 0.62 ms | 0.72 ms |

Flat in page count; the residual is the single index pass.

## Testing

- `cargo test --workspace` green, including the PDF fuzz target (its `exercise` was updated for the new `PdfUpdate::begin` signature).
- `cargo clippy --workspace --all-targets` clean on the touched crates.
- The probe used for the numbers above was temporary and is not part of the diff.

## Out of scope

`PdfformSession::update` still does `self.base_pdf.clone()` per edit — a ~300 KB memcpy, now the dominant remaining per-keystroke cost at roughly 20 µs. Left alone; worth a look only if it shows up in a profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhVw7gp6ZjN33PcvvaMFWg

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhVw7gp6ZjN33PcvvaMFWg)_