### PR TITLE
Bulk PR integration: #1347–#1356

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- **breaking** content: the op wire is a reading direction. `mark_op_to_value`,
+  `line_op_to_value` and `island_op_to_value` are removed from
+  `quillmark-content` — an op bundle is authored on the JS/Python side and
+  reaches Rust through `change_bundle_from_value`, so nothing in the workspace
+  ever emitted one and every wire change was made twice, once in code no product
+  path executes. The decoders are unchanged. Their round-trip tests become
+  decoder tests over literal JSON, which is what the wire actually is: an
+  encoder agreeing with its own reader never proved the shape a binding sends.
+
 ## v0.108.3 - 2026-08-21
 
 - fix(typst): **a paragraph holding one bare `/` renders instead of failing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+- perf(content): **canonical serialization stops rebuilding the tree it just
+  built.** `to_canonical_value` normalized a copy — which already recursively
+  key-sorts every opaque bag reachable from it (island `props`, an unknown's
+  `attrs`) — and then ran a whole-tree `sort_keys_owned` over the encoded
+  result, re-collecting and re-allocating every object and array in the document
+  to reorder the handful of fixed keys the encoders insert themselves. The
+  encoders now emit those keys in ascending order and the terminal pass is
+  `canonicalize_keys`, which scans and returns when the tree is already
+  canonical. Canonical bytes are unchanged, byte for byte; a tree that somehow
+  arrives unsorted is still repaired rather than shipped.
+
+  The public `container_to_value`, `island_to_value` and `mark_to_value` now
+  emit their own keys in a different order. An unknown's `attrs` bag is
+  untouched, as in 0.99, and nothing hashes the op wire.
+
 ## v0.108.3 - 2026-08-21
 
 - fix(typst): **a paragraph holding one bare `/` renders instead of failing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+- refactor(pdfform): **a session holds its flattened PDF parsed, not as bytes
+  each render path reparses.** Flatten and parse now happen together in `open`
+  and `update`, the two places `field_specs` are set, so the derived flat PDF
+  moves only with the specs it comes from and `render_svg`/`render_png`/
+  `render_rgba` paint parsed pages. A malformed flatten now surfaces from the
+  call that produced it under one code, `pdfform::flat_parse_failed`, replacing
+  the per-format `pdfform::svg_parse_failed` and `pdfform::png_parse_failed`
+  raised at render time (neither documented, and both reachable only through a
+  bug in this crate's own flatten).
+
 ## v0.108.3 - 2026-08-21
 
 - fix(typst): **a paragraph holding one bare `/` renders instead of failing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- fix(blueprint): **a variant's `object` or `array<object>` cell expands per
+  property.** The cell went through the scalar path, so it rendered as
+  `controlled_by: !must_fill # object` — a null where the schema wants a
+  mapping, with every property's description, `default:` and type annotation
+  dropped, and the marker on a path the obligation predicate never warns at.
+  A cell is a field of its container and now expands as one, like every other
+  surface already did.
 - fix(core): **a `.quillignore` pattern holding more than one `*` ignores what
   it names.** The matcher handled exactly one wildcard and returned no match
   for the rest, so `**/*.tmp` and `*.sublime-*` were dead lines. Patterns now
@@ -33,6 +40,11 @@
   file scans and the live-edit path repaid them on every keystroke. The base's
   object offsets are now collected in one pass and each read is a lookup: a
   20-page 300 KB form stamps in 0.7 ms rather than 37 ms, flat in page count.
+
+  **breaking** in `quillmark-pdf`: `PdfUpdate::begin` and
+  `PdfUpdate::resolve_pages` take the `&ObjectIndex` the caller builds over the
+  base rather than its bytes, and `reader::find_object_bytes` /
+  `reader::object_dict` become `ObjectIndex::object_bytes` / `ObjectIndex::dict`.
 - **breaking** content: the op wire is a reading direction. `mark_op_to_value`,
   `line_op_to_value` and `island_op_to_value` are removed from
   `quillmark-content` — an op bundle is authored on the JS/Python side and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+- fix(core): **a `.quillignore` pattern holding more than one `*` ignores what
+  it names.** The matcher handled exactly one wildcard and returned no match
+  for the rest, so `**/*.tmp` and `*.sublime-*` were dead lines. Patterns now
+  compile once through `glob::Pattern`, matched against the whole path and the
+  basename. Two readings tighten to gitignore's: `*` stops at `/`, and a
+  pattern spelling out a `/` anchors at the bundle root rather than matching
+  any path that opens and closes with its halves. A pattern free of `*`, `?`
+  and `[` stays a literal name, so a file named `Cinzel[wght].ttf` is still
+  ignored by writing it out.
+
 ## v0.108.3 - 2026-08-21
 
 - fix(typst): **a paragraph holding one bare `/` renders instead of failing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@
   compile once through `glob::Pattern`, matched against the whole path and the
   basename. Two readings tighten to gitignore's: `*` stops at `/`, and a
   pattern spelling out a `/` anchors at the bundle root rather than matching
-  any path that opens and closes with its halves. A pattern free of `*`, `?`
-  and `[` stays a literal name, so a file named `Cinzel[wght].ttf` is still
-  ignored by writing it out.
+  any path that opens and closes with its halves. A line always ignores the
+  name it spells out as well: `[` opens a character class and is an ordinary
+  character in a filename, so `Cinzel[wght].ttf` ignores both the variable font
+  of that name and the class it describes.
 - refactor: **`RenderError::coded(code, message)` is the one constructor for a
   single-error-diagnostic failure.** Nine sites across five crates spelled
   `from_diag(Diagnostic::new(Severity::Error, msg).with_code(code))` by hand,
@@ -32,7 +33,9 @@
   call that produced it under one code, `pdfform::flat_parse_failed`, replacing
   the per-format `pdfform::svg_parse_failed` and `pdfform::png_parse_failed`
   raised at render time (neither documented, and both reachable only through a
-  bug in this crate's own flatten).
+  bug in this crate's own flatten). Opening a session fails on that bug now,
+  including for a caller that only ever renders the AcroForm PDF, which is
+  stamped from the base and reads nothing flattened.
 - perf(pdf): **filling a PDF form no longer slows down with the size of its
   background or its page count.** Reading one object from the base walks every
   byte of it — the live copy is the last revision, so a scan cannot stop early
@@ -64,8 +67,8 @@
   canonical. Canonical bytes are unchanged, byte for byte; a tree that somehow
   arrives unsorted is still repaired rather than shipped.
 
-  The public `container_to_value`, `island_to_value` and `mark_to_value` now
-  emit their own keys in a different order. An unknown's `attrs` bag is
+  The public `container_to_value` and `mark_to_value`, and the crate-internal
+  `island_to_value`, now emit their own keys in a different order. An unknown's `attrs` bag is
   untouched, as in 0.99, and nothing hashes the op wire.
 
 ## v0.108.3 - 2026-08-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- perf(pdf): **filling a PDF form no longer slows down with the size of its
+  background or its page count.** Reading one object from the base walks every
+  byte of it — the live copy is the last revision, so a scan cannot stop early
+  — and nothing memoized that, so a stamp or flatten pass paid O(pages) whole-
+  file scans and the live-edit path repaid them on every keystroke. The base's
+  object offsets are now collected in one pass and each read is a lookup: a
+  20-page 300 KB form stamps in 0.7 ms rather than 37 ms, flat in page count.
+
 ## v0.108.3 - 2026-08-21
 
 - fix(typst): **a paragraph holding one bare `/` renders instead of failing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- refactor: **`RenderError::coded(code, message)` is the one constructor for a
+  single-error-diagnostic failure.** Nine sites across five crates spelled
+  `from_diag(Diagnostic::new(Severity::Error, msg).with_code(code))` by hand,
+  two of them as a per-crate `engine_err` helper the backends each carried
+  their own copy of. Additive to `quillmark-core`'s public API; no code, message
+  or shape changes.
+
 ## v0.108.3 - 2026-08-21
 
 - fix(typst): **a paragraph holding one bare `/` renders instead of failing the

--- a/crates/backends/pdfform/src/flatten.rs
+++ b/crates/backends/pdfform/src/flatten.rs
@@ -10,7 +10,7 @@
 //! SVG/PNG raster outputs only; the AcroForm PDF deliverable is stamped.
 
 use quillmark_pdf::{
-    reader::{extract_outer_dict, find_dict_value, object_dict, splice_dict_value, UpdatedObject},
+    reader::{extract_outer_dict, find_dict_value, splice_dict_value, ObjectIndex, UpdatedObject},
     writer::{
         alloc_id, append_refs_to_array_key, dict_object, pdf_escape, winansi_encode, OnNonArray,
     },
@@ -32,9 +32,10 @@ pub fn flatten(base: Vec<u8>, fields: &[FieldSpec]) -> Result<Vec<u8>, PdfError>
     }
 
     let pdf = base;
-    let mut up = PdfUpdate::begin(&pdf, None)?;
+    let idx = ObjectIndex::new(&pdf);
+    let mut up = PdfUpdate::begin(&idx, None)?;
 
-    let page_ids = up.resolve_pages(&pdf, fields)?;
+    let page_ids = up.resolve_pages(&idx, fields)?;
     let page_count = page_ids.len();
 
     // Helvetica and ZapfDingbats are among the 14 standard PDF fonts every
@@ -67,7 +68,7 @@ pub fn flatten(base: Vec<u8>, fields: &[FieldSpec]) -> Result<Vec<u8>, PdfError>
 
         let page_obj_id = page_ids[page_idx];
         let what = format!("page object {page_obj_id}");
-        let pg_dict = object_dict(&pdf, page_obj_id, CODE_PARSE, &what)?;
+        let pg_dict = idx.dict(page_obj_id, CODE_PARSE, &what)?;
 
         let new_pg = rewrite_page_for_flatten(pg_dict, helv_id, zadb_id, stream_id)?;
         up.objects.push(dict_object(page_obj_id, &new_pg));

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -90,8 +90,7 @@ impl Backend for PdfformBackend {
 
         let field_specs = resolve_field_specs(&bound, json_data);
 
-        // Pre-flatten once so the raster paths need not re-flatten per paint.
-        let flat_pdf = Arc::new(flatten_to_pdf(base_pdf.clone(), &field_specs)?);
+        let flat = flatten_and_parse(&base_pdf, &field_specs)?;
 
         Ok(LiveSession::new(
             Box::new(PdfformSession {
@@ -99,7 +98,7 @@ impl Backend for PdfformBackend {
                 bound,
                 field_specs,
                 page_boxes,
-                flat_pdf,
+                flat,
             }),
             source.config().clone(),
         ))
@@ -123,17 +122,29 @@ fn resolve_field_specs(bound: &[BoundWidget], json_data: &serde_json::Value) -> 
         .collect()
 }
 
-#[derive(Debug)]
+/// Values baked as content-stream operators, then parsed for hayro. Both halves
+/// live here so the render paths hold parsed pages rather than bytes to reparse:
+/// the flat PDF is derived from `field_specs` alone and moves only with them.
+///
+/// A parse failure is this crate flattening to something malformed, never a
+/// property of the output format asking for it.
+fn flatten_and_parse(base_pdf: &[u8], field_specs: &[FieldSpec]) -> Result<HayroPdf, RenderError> {
+    let flat = flatten_to_pdf(base_pdf.to_vec(), field_specs)?;
+    HayroPdf::new(flat).map_err(|_| {
+        engine_err(
+            "pdfform::flat_parse_failed",
+            "failed to parse the flattened PDF for rasterisation",
+        )
+    })
+}
+
 struct PdfformSession {
     base_pdf: Vec<u8>,
     bound: Vec<BoundWidget>,
     field_specs: Vec<FieldSpec>,
     /// Cached so `page_size_pt` need not reparse.
     page_boxes: Vec<[f32; 4]>,
-    /// Values baked as content-stream operators, ready for hayro rasterisation.
-    /// An `Arc` because hayro takes its bytes as one: a render pass shares them
-    /// rather than copying the whole flattened PDF.
-    flat_pdf: Arc<Vec<u8>>,
+    flat: HayroPdf,
 }
 
 impl SessionHandle for PdfformSession {
@@ -177,8 +188,7 @@ impl SessionHandle for PdfformSession {
     }
 
     fn render_rgba(&self, page: usize, scale: f32) -> Option<(u32, u32, Vec<u8>)> {
-        let pdf = HayroPdf::new(Arc::clone(&self.flat_pdf)).ok()?;
-        let p = pdf.pages().get(page)?;
+        let p = self.flat.pages().get(page)?;
         let cache = RenderCache::new();
         let interp = standard_font_settings();
         let render_settings = scaled_render_settings(scale);
@@ -201,7 +211,7 @@ impl SessionHandle for PdfformSession {
     /// never changes, so field deltas are the only visible delta.
     fn update(&mut self, json_data: &serde_json::Value) -> Result<ChangeSet, RenderError> {
         let field_specs = resolve_field_specs(&self.bound, json_data);
-        let flat_pdf = Arc::new(flatten_to_pdf(self.base_pdf.clone(), &field_specs)?);
+        let flat = flatten_and_parse(&self.base_pdf, &field_specs)?;
 
         let mut dirty_pages: Vec<usize> = self
             .field_specs
@@ -214,31 +224,20 @@ impl SessionHandle for PdfformSession {
         dirty_pages.dedup();
 
         self.field_specs = field_specs;
-        self.flat_pdf = flat_pdf;
+        self.flat = flat;
 
         Ok(ChangeSet::new(self.page_boxes.len(), dirty_pages))
     }
 }
 
 impl PdfformSession {
-    /// The pre-flattened PDF parsed for a render pass, refused under the
-    /// caller's own per-format error code.
-    fn open_flat(&self, code: &'static str, label: &str) -> Result<HayroPdf, RenderError> {
-        HayroPdf::new(Arc::clone(&self.flat_pdf)).map_err(|_| {
-            engine_err(
-                code,
-                format!("failed to parse pre-flattened PDF for {label} render"),
-            )
-        })
-    }
-
     fn render_svg(&self) -> Result<RenderResult, RenderError> {
-        let pdf = self.open_flat("pdfform::svg_parse_failed", "SVG")?;
         let interp = standard_font_settings();
         let svg_settings = SvgRenderSettings {
             bg_color: [255, 255, 255, 255],
         };
-        let artifacts: Vec<Artifact> = pdf
+        let artifacts: Vec<Artifact> = self
+            .flat
             .pages()
             .iter()
             .map(|page| {
@@ -253,12 +252,11 @@ impl PdfformSession {
 
     /// `scale` is device pixels per PDF point (`ppi / 72`).
     fn render_png(&self, scale: f32) -> Result<RenderResult, RenderError> {
-        let pdf = self.open_flat("pdfform::png_parse_failed", "PNG")?;
         let interp = standard_font_settings();
         let render_settings = scaled_render_settings(scale);
 
-        let mut artifacts = Vec::with_capacity(pdf.pages().len());
-        for page in pdf.pages().iter() {
+        let mut artifacts = Vec::with_capacity(self.flat.pages().len());
+        for page in self.flat.pages().iter() {
             let cache = RenderCache::new();
             let pixmap = hayro_render(page, &cache, &interp, &render_settings);
             let png = pixmap.into_png().map_err(|e| {

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -18,8 +18,8 @@ use form::FormSpec;
 use quillmark_core::quill::QuillConfig;
 use quillmark_core::session::SessionHandle;
 use quillmark_core::{
-    Artifact, Backend, ChangeSet, Diagnostic, LiveSession, OutputFormat, Quill, RenderError,
-    RenderOptions, RenderResult, RenderedRegion, Severity,
+    Artifact, Backend, ChangeSet, LiveSession, OutputFormat, Quill, RenderError, RenderOptions,
+    RenderResult, RenderedRegion,
 };
 use quillmark_pdf::regions_of;
 use quillmark_pdf::{stamp, FieldSpec, StampOptions};
@@ -65,28 +65,28 @@ impl Backend for PdfformBackend {
         let base_pdf = files
             .get_file(FORM_PDF)
             .ok_or_else(|| {
-                engine_err(
+                RenderError::coded(
                     "pdfform::missing_form_pdf",
                     format!("pdfform quill is missing its `{FORM_PDF}` background"),
                 )
             })?
             .to_vec();
         let form_json = files.get_file(FORM_JSON).ok_or_else(|| {
-            engine_err(
+            RenderError::coded(
                 "pdfform::missing_form_json",
                 format!("pdfform quill is missing its `{FORM_JSON}` field spec"),
             )
         })?;
 
-        let spec =
-            FormSpec::parse(form_json).map_err(|e| engine_err(e.code(), e.to_string()))?;
+        let spec = FormSpec::parse(form_json)
+            .map_err(|e| RenderError::coded(e.code(), e.to_string()))?;
 
         // Page boxes drive the top-left → bottom-left flip (honouring a
         // non-zero page origin), and reading them surfaces a malformed base early.
         let page_boxes = quillmark_pdf::page_media_boxes(&base_pdf)?;
 
         let bound = bind::bind_widgets(&spec, source.config(), &page_boxes)
-            .map_err(|e| engine_err(e.code(), e.to_string()))?;
+            .map_err(|e| RenderError::coded(e.code(), e.to_string()))?;
 
         let field_specs = resolve_field_specs(&bound, json_data);
 
@@ -225,7 +225,7 @@ impl PdfformSession {
     /// caller's own per-format error code.
     fn open_flat(&self, code: &'static str, label: &str) -> Result<HayroPdf, RenderError> {
         HayroPdf::new(Arc::clone(&self.flat_pdf)).map_err(|_| {
-            engine_err(
+            RenderError::coded(
                 code,
                 format!("failed to parse pre-flattened PDF for {label} render"),
             )
@@ -262,7 +262,7 @@ impl PdfformSession {
             let cache = RenderCache::new();
             let pixmap = hayro_render(page, &cache, &interp, &render_settings);
             let png = pixmap.into_png().map_err(|e| {
-                engine_err(
+                RenderError::coded(
                     "pdfform::png_encoding",
                     format!("failed to encode page as PNG: {e}"),
                 )
@@ -301,10 +301,4 @@ fn standard_font_settings() -> InterpreterSettings {
 /// Owned by the backend, never defaulted from the leaf spine's version.
 fn default_producer() -> String {
     format!("Quillmark {}", env!("CARGO_PKG_VERSION"))
-}
-
-fn engine_err(code: &str, message: impl Into<String>) -> RenderError {
-    RenderError::from_diag(
-        Diagnostic::new(Severity::Error, message.into()).with_code(code.to_string()),
-    )
 }

--- a/crates/backends/typst/src/compile.rs
+++ b/crates/backends/typst/src/compile.rs
@@ -11,7 +11,7 @@ use typst_svg::SvgOptions;
 use crate::error_mapping::map_typst_errors;
 use crate::overlay;
 use crate::world::QuillWorld;
-use quillmark_core::{Artifact, Diagnostic, OutputFormat, RenderError, RenderResult, Severity};
+use quillmark_core::{Artifact, Diagnostic, OutputFormat, RenderError, RenderResult};
 use quillmark_pdf::{stamp, StampOptions};
 
 pub(crate) fn render_options(pixel_per_pt: f32) -> RenderOptions {
@@ -54,12 +54,9 @@ pub(crate) fn render_document_pages(
     producer: Option<&str>,
 ) -> Result<RenderResult, RenderError> {
     if format == OutputFormat::Pdf && pages.is_some() {
-        return Err(RenderError::from_diag(
-            Diagnostic::new(
-                Severity::Error,
-                "PDF does not support page selection; pass null/None to render the full document, or use PNG/SVG".to_string(),
-            )
-            .with_code("typst::pdf_page_selection_not_supported".to_string()),
+        return Err(RenderError::coded(
+            "typst::pdf_page_selection_not_supported",
+            "PDF does not support page selection; pass null/None to render the full document, or use PNG/SVG",
         ));
     }
 
@@ -69,15 +66,11 @@ pub(crate) fn render_document_pages(
             let out_of_bounds: Vec<usize> =
                 slice.iter().copied().filter(|&i| i >= page_count).collect();
             if !out_of_bounds.is_empty() {
-                return Err(RenderError::from_diag(
-                    Diagnostic::new(
-                        Severity::Error,
-                        format!(
-                            "Page index out of bounds (page_count={}); offending indices: {:?}. Check `LiveSession.pageCount` before requesting pages.",
-                            page_count, out_of_bounds
-                        ),
-                    )
-                    .with_code("typst::page_index_out_of_bounds".to_string()),
+                return Err(RenderError::coded(
+                    "typst::page_index_out_of_bounds",
+                    format!(
+                        "Page index out of bounds (page_count={page_count}); offending indices: {out_of_bounds:?}. Check `LiveSession.pageCount` before requesting pages."
+                    ),
                 ));
             }
             slice.to_vec()
@@ -106,10 +99,7 @@ pub(crate) fn render_document_pages(
             for idx in selected_indices {
                 let pixmap = typst_render::render(&document.pages()[idx], &opts);
                 let png_data = pixmap.encode_png().map_err(|e| {
-                    RenderError::from_diag(
-                        Diagnostic::new(Severity::Error, format!("PNG encoding failed: {}", e))
-                            .with_code("typst::png_encoding".to_string()),
-                    )
+                    RenderError::coded("typst::png_encoding", format!("PNG encoding failed: {e}"))
                 })?;
                 artifacts.push(Artifact::new(png_data, OutputFormat::Png));
             }
@@ -117,9 +107,9 @@ pub(crate) fn render_document_pages(
         }
         OutputFormat::Pdf => {
             let pdf = typst_pdf::pdf(document, &PdfOptions::default()).map_err(|e| {
-                RenderError::from_diag(
-                    Diagnostic::new(Severity::Error, format!("PDF generation failed: {:?}", e))
-                        .with_code("typst::pdf_generation".to_string()),
+                RenderError::coded(
+                    "typst::pdf_generation",
+                    format!("PDF generation failed: {e:?}"),
                 )
             })?;
             let field_specs = overlay::build_field_specs(document, field_placements)?;

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -93,7 +93,7 @@ fn recompile(
 ) -> Result<Compiled, RenderError> {
     let mut windows = world
         .inject_helper_package(data, schema_meta)
-        .map_err(|e| engine_err(e.code(), e.to_string()))?;
+        .map_err(|e| RenderError::coded(e.code(), e.to_string()))?;
     windows.extend(scalar_windows.iter().cloned());
 
     let (document, compile_warnings) = compile::compile_document(world)?;
@@ -369,7 +369,7 @@ fn helper_source(world: &world::QuillWorld) -> Result<typst::syntax::Source, Ren
     world
         .source(world::QuillWorld::helper_fid("lib.typ"))
         .map_err(|e| {
-            engine_err(
+            RenderError::coded(
                 "typst::helper_source",
                 format!("helper lib.typ unreadable: {e}"),
             )
@@ -465,25 +465,18 @@ fn read_plate(source: &Quill) -> Result<String, RenderError> {
     };
 
     let bytes = source.files().get_file(plate_file).ok_or_else(|| {
-        engine_err(
+        RenderError::coded(
             "typst::plate_missing",
             format!("plate file '{plate_file}' not found in the quill's file tree"),
         )
     })?;
 
     String::from_utf8(bytes.to_vec()).map_err(|e| {
-        engine_err(
+        RenderError::coded(
             "typst::invalid_utf8",
             format!("plate file '{plate_file}' is not valid UTF-8: {e}"),
         )
     })
-}
-
-/// A single-diagnostic [`RenderError`] carrying `code`.
-pub(crate) fn engine_err(code: &str, message: impl Into<String>) -> RenderError {
-    RenderError::from_diag(
-        Diagnostic::new(Severity::Error, message.into()).with_code(code.to_string()),
-    )
 }
 
 /// The steps a schema address may take out of one node, and nothing else: the

--- a/crates/backends/typst/src/overlay/extract.rs
+++ b/crates/backends/typst/src/overlay/extract.rs
@@ -14,7 +14,7 @@ use quillmark_core::{Diagnostic, RenderError, Severity};
 
 use quillmark_pdf::{FormFont, TextAlign};
 
-use super::{engine_err, FieldKind, FieldPlacement};
+use super::{FieldKind, FieldPlacement};
 
 const FIELD_LABEL: &str = "__qm_field__";
 const CODE_INTERNAL: &str = "typst::overlay_internal";
@@ -22,7 +22,7 @@ const CODE_INTERNAL: &str = "typst::overlay_internal";
 pub(crate) fn extract(doc: &PagedDocument) -> Result<Vec<FieldPlacement>, RenderError> {
     let intro = doc.introspector();
     let label = Label::new(PicoStr::intern(FIELD_LABEL)).ok_or_else(|| {
-        engine_err(
+        RenderError::coded(
             CODE_INTERNAL,
             "FIELD_LABEL must be a non-empty interned string",
         )
@@ -39,12 +39,17 @@ pub(crate) fn extract(doc: &PagedDocument) -> Result<Vec<FieldPlacement>, Render
         let dict = match c.get_by_name("value") {
             Ok(Value::Dict(d)) => d,
             Ok(other) => {
-                return Err(engine_err(
+                return Err(RenderError::coded(
                     CODE_INTERNAL,
                     format!("expected metadata value to be a dict, got {}", other.ty()),
                 ))
             }
-            Err(e) => return Err(engine_err(CODE_INTERNAL, format!("metadata.value missing: {e:?}"))),
+            Err(e) => {
+                return Err(RenderError::coded(
+                    CODE_INTERNAL,
+                    format!("metadata.value missing: {e:?}"),
+                ))
+            }
         };
         if read_str(&dict, "kind")? != FIELD_LABEL {
             // User attached <__qm_field__> to unrelated metadata; ignore it.
@@ -61,7 +66,9 @@ pub(crate) fn extract(doc: &PagedDocument) -> Result<Vec<FieldPlacement>, Render
         let align = read_align(&dict)?;
         let loc = c
             .location()
-            .ok_or_else(|| engine_err(CODE_INTERNAL, "form-field metadata is not located"))?;
+            .ok_or_else(|| {
+                RenderError::coded(CODE_INTERNAL, "form-field metadata is not located")
+            })?;
 
         if let Some(&prior) = by_name.get(&name) {
             return Err(duplicate_field_error(&name, prior, loc));
@@ -70,7 +77,9 @@ pub(crate) fn extract(doc: &PagedDocument) -> Result<Vec<FieldPlacement>, Render
 
         let pos = intro
             .position(loc)
-            .ok_or_else(|| engine_err(CODE_INTERNAL, "form-field metadata has no position"))?;
+            .ok_or_else(|| {
+                RenderError::coded(CODE_INTERNAL, "form-field metadata has no position")
+            })?;
         placements.push(FieldPlacement {
             name,
             schema_field,
@@ -111,7 +120,7 @@ fn read_field_kind(
             value: read_value_str(d, "value")?,
         }),
         "signature" => Ok(FieldKind::Signature),
-        other => Err(engine_err(
+        other => Err(RenderError::coded(
             CODE_INTERNAL,
             format!("unknown form-field type {other:?}"),
         )),
@@ -125,7 +134,7 @@ fn read_font(d: &typst::foundations::Dict) -> Result<FormFont, RenderError> {
         "helvetica" => Ok(FormFont::Helvetica),
         "times" => Ok(FormFont::Times),
         "courier" => Ok(FormFont::Courier),
-        other => Err(engine_err(
+        other => Err(RenderError::coded(
             CODE_INTERNAL,
             format!("unknown form-field font {other:?}"),
         )),
@@ -137,7 +146,7 @@ fn read_align(d: &typst::foundations::Dict) -> Result<TextAlign, RenderError> {
         "left" => Ok(TextAlign::Left),
         "center" => Ok(TextAlign::Center),
         "right" => Ok(TextAlign::Right),
-        other => Err(engine_err(
+        other => Err(RenderError::coded(
             CODE_INTERNAL,
             format!("unknown form-field align {other:?}"),
         )),
@@ -154,11 +163,11 @@ fn read_opt_f64(d: &typst::foundations::Dict, key: &str) -> Result<Option<f64>, 
 fn read_str(d: &typst::foundations::Dict, key: &str) -> Result<String, RenderError> {
     match d.get(key) {
         Ok(Value::Str(s)) => Ok(s.to_string()),
-        Ok(other) => Err(engine_err(
+        Ok(other) => Err(RenderError::coded(
             CODE_INTERNAL,
             format!("expected metadata.{key} to be str, got {}", other.ty()),
         )),
-        Err(_) => Err(engine_err(CODE_INTERNAL, format!("metadata.{key} missing"))),
+        Err(_) => Err(RenderError::coded(CODE_INTERNAL, format!("metadata.{key} missing"))),
     }
 }
 
@@ -166,11 +175,11 @@ fn read_f64(d: &typst::foundations::Dict, key: &str) -> Result<f64, RenderError>
     match d.get(key) {
         Ok(Value::Float(f)) => Ok(*f),
         Ok(Value::Int(i)) => Ok(*i as f64),
-        Ok(other) => Err(engine_err(
+        Ok(other) => Err(RenderError::coded(
             CODE_INTERNAL,
             format!("expected metadata.{key} to be float, got {}", other.ty()),
         )),
-        Err(_) => Err(engine_err(CODE_INTERNAL, format!("metadata.{key} missing"))),
+        Err(_) => Err(RenderError::coded(CODE_INTERNAL, format!("metadata.{key} missing"))),
     }
 }
 
@@ -178,7 +187,7 @@ fn read_opt_str(d: &typst::foundations::Dict, key: &str) -> Result<Option<String
     match d.get(key) {
         Ok(Value::Str(s)) => Ok(Some(s.to_string())),
         Ok(Value::None) => Ok(None),
-        Ok(other) => Err(engine_err(
+        Ok(other) => Err(RenderError::coded(
             CODE_INTERNAL,
             format!(
                 "expected metadata.{key} to be str or none, got {}",
@@ -195,7 +204,7 @@ fn read_str_array(d: &typst::foundations::Dict, key: &str) -> Result<Vec<String>
             .iter()
             .map(|v| match v {
                 Value::Str(s) => Ok(s.to_string()),
-                other => Err(engine_err(
+                other => Err(RenderError::coded(
                     CODE_INTERNAL,
                     format!(
                         "expected metadata.{key} elements to be str, got {}",
@@ -205,7 +214,7 @@ fn read_str_array(d: &typst::foundations::Dict, key: &str) -> Result<Vec<String>
             })
             .collect(),
         Ok(Value::None) => Ok(Vec::new()),
-        Ok(other) => Err(engine_err(
+        Ok(other) => Err(RenderError::coded(
             CODE_INTERNAL,
             format!("expected metadata.{key} to be an array, got {}", other.ty()),
         )),
@@ -223,7 +232,7 @@ fn read_value_str(d: &typst::foundations::Dict, key: &str) -> Result<Option<Stri
         Ok(Value::Bool(b)) => b.to_string(),
         Ok(Value::None) | Err(_) => return Ok(None),
         Ok(other) => {
-            return Err(engine_err(
+            return Err(RenderError::coded(
                 CODE_INTERNAL,
                 format!(
                     "expected metadata.{key} to be str/int/float/bool/none, got {}",
@@ -239,7 +248,7 @@ fn read_value_bool(d: &typst::foundations::Dict, key: &str) -> Result<Option<boo
     match d.get(key) {
         Ok(Value::Bool(b)) => Ok(Some(*b)),
         Ok(Value::None) | Err(_) => Ok(None),
-        Ok(other) => Err(engine_err(
+        Ok(other) => Err(RenderError::coded(
             CODE_INTERNAL,
             format!(
                 "expected metadata.{key} to be bool or none, got {}",

--- a/crates/backends/typst/src/overlay/mod.rs
+++ b/crates/backends/typst/src/overlay/mod.rs
@@ -6,8 +6,6 @@ use quillmark_core::RenderError;
 use quillmark_pdf::{FieldSpec, FieldType, FormFont, TextAlign, CHECKBOX_ON_STATE};
 use typst_layout::PagedDocument;
 
-use crate::engine_err;
-
 mod extract;
 mod span_scan;
 
@@ -68,7 +66,7 @@ pub(crate) fn build_field_specs(
         .iter()
         .map(|p| {
             let page_h = *page_heights.get(p.page).ok_or_else(|| {
-                engine_err(
+                RenderError::coded(
                     "typst::form_field_page_out_of_range",
                     format!(
                         "form-field {:?} targets page {} but the document has {} page(s)",

--- a/crates/content/src/lib.rs
+++ b/crates/content/src/lib.rs
@@ -28,9 +28,8 @@ pub use model::{
 };
 pub use normalize::normalize_markdown;
 pub use ops::{
-    change_bundle_from_value, island_op_from_value, island_op_to_value, line_op_from_value,
-    line_op_to_value, mark_op_from_value, mark_op_to_value, ApplyError, ChangeBundle, IslandOp,
-    LineOp, MarkOp,
+    change_bundle_from_value, island_op_from_value, line_op_from_value, mark_op_from_value,
+    ApplyError, ChangeBundle, IslandOp, LineOp, MarkOp,
 };
 pub use serial::ParseError;
 

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -157,40 +157,20 @@ impl ChangeBundle {
     }
 }
 
-// The op converters below reuse `serial`'s hand-written encoding for
-// `MarkKind` / `LineKind` / `Container`, so an `applyChange` bundle speaks the
-// same shapes the content read surface does rather than a second serde-derived
-// dialect.
+// The op readers below reuse `serial`'s hand-written readers for `MarkKind` /
+// `LineKind` / `Container`, so an `applyChange` bundle speaks the same shapes
+// the content read surface does rather than a second serde-derived dialect.
+// The wire is a reading direction: bundles are authored on the JS/Python side,
+// and no encoder answers these.
 
 use crate::serial::{
-    container_from_authored_value, container_to_value, island_fields, island_from_value,
-    line_kind_fields, line_kind_from_authored_value, mark_fields, mark_from_authored_value,
-    usv_from, ParseError,
+    container_from_authored_value, island_from_value, line_kind_from_authored_value,
+    mark_from_authored_value, usv_from, ParseError,
 };
-use serde_json::{Map, Value};
+use serde_json::Value;
 
-/// Encode a [`MarkOp`] to its wire object. `Add`/`Remove` carry the mark
-/// vocabulary (`{op, start, end, type, …}`); `RemoveAnchor` is `{op, id}`.
-pub fn mark_op_to_value(op: &MarkOp) -> Value {
-    let mut m = Map::new();
-    match op {
-        MarkOp::Add { start, end, kind } => {
-            m.insert("op".into(), "add".into());
-            m.extend(mark_fields(*start, *end, kind));
-        }
-        MarkOp::Remove { start, end, kind } => {
-            m.insert("op".into(), "remove".into());
-            m.extend(mark_fields(*start, *end, kind));
-        }
-        MarkOp::RemoveAnchor { id } => {
-            m.insert("op".into(), "removeAnchor".into());
-            m.insert("id".into(), Value::String(id.clone()));
-        }
-    }
-    Value::Object(m)
-}
-
-/// Decode a [`MarkOp`] from its wire object. `add`/`remove` read the mark
+/// Decode a [`MarkOp`] from its wire object (`{op, start, end, type, …}` for
+/// `add`/`remove`, `{op, id}` for `removeAnchor`). `add`/`remove` read the mark
 /// vocabulary on the authored lane, which refuses `attrs` beside a built-in
 /// `type` rather than resolving to the built-in and dropping them.
 pub fn mark_op_from_value(v: &Value) -> Result<MarkOp, ParseError> {
@@ -223,42 +203,8 @@ pub fn mark_op_from_value(v: &Value) -> Result<MarkOp, ParseError> {
     }
 }
 
-/// Encode a [`LineOp`] to its wire object. `SetKind` flattens the line-kind
-/// discriminant (`kind`/`level`/`lang`) alongside `op`/`line`.
-pub fn line_op_to_value(op: &LineOp) -> Value {
-    let mut m = Map::new();
-    match op {
-        LineOp::Split { at } => {
-            m.insert("op".into(), "split".into());
-            m.insert("at".into(), Value::from(*at));
-        }
-        LineOp::Join { line } => {
-            m.insert("op".into(), "join".into());
-            m.insert("line".into(), Value::from(*line));
-        }
-        LineOp::SetKind { line, kind } => {
-            m.insert("op".into(), "setKind".into());
-            m.insert("line".into(), Value::from(*line));
-            m.extend(line_kind_fields(kind));
-        }
-        LineOp::SetContainers { line, containers } => {
-            m.insert("op".into(), "setContainers".into());
-            m.insert("line".into(), Value::from(*line));
-            m.insert(
-                "containers".into(),
-                Value::Array(containers.iter().map(container_to_value).collect()),
-            );
-        }
-        LineOp::SetContinues { line, continues } => {
-            m.insert("op".into(), "setContinues".into());
-            m.insert("line".into(), Value::from(*line));
-            m.insert("continues".into(), Value::Bool(*continues));
-        }
-    }
-    Value::Object(m)
-}
-
-/// Decode a [`LineOp`] from its wire object.
+/// Decode a [`LineOp`] from its wire object. `setKind` carries the line-kind
+/// discriminant (`kind`/`level`/`lang`) flattened alongside `op`/`line`.
 pub fn line_op_from_value(v: &Value) -> Result<LineOp, ParseError> {
     let o = v.as_object().ok_or(ParseError::Shape("line op"))?;
     let line = || usv_from(o.get("line"), "line op line");
@@ -292,23 +238,8 @@ pub fn line_op_from_value(v: &Value) -> Result<LineOp, ParseError> {
     }
 }
 
-/// Encode an [`IslandOp`] to its wire object. Both arms flatten the island
-/// vocabulary (`{id, type, props, loss}`) alongside `op`.
-pub fn island_op_to_value(op: &IslandOp) -> Value {
-    let (verb, at, island) = match op {
-        IslandOp::Set { island } => ("set", None, island),
-        IslandOp::Insert { at, island } => ("insert", Some(*at), island),
-    };
-    let mut m = Map::new();
-    m.insert("op".into(), verb.into());
-    if let Some(at) = at {
-        m.insert("at".into(), Value::from(at));
-    }
-    m.extend(island_fields(island));
-    Value::Object(m)
-}
-
-/// Decode an [`IslandOp`] from its wire object.
+/// Decode an [`IslandOp`] from its wire object. Both arms carry the island
+/// vocabulary (`{id, type, props, loss}`) flattened alongside `op`.
 pub fn island_op_from_value(v: &Value) -> Result<IslandOp, ParseError> {
     let o = v.as_object().ok_or(ParseError::Shape("island op"))?;
     let island = || island_from_value(v);
@@ -998,72 +929,117 @@ mod tests {
     use crate::import::from_markdown;
 
     #[test]
-    fn mark_op_wire_round_trips_each_variant() {
-        let ops = vec![
-            MarkOp::Add {
-                start: 0,
-                end: 3,
-                kind: MarkKind::Strong,
-            },
-            MarkOp::Add {
-                start: 1,
-                end: 2,
-                kind: MarkKind::Link {
-                    url: "https://x".into(),
+    fn mark_op_wire_decodes_each_variant() {
+        let cases = vec![
+            (
+                serde_json::json!({"op": "add", "start": 0, "end": 3, "type": "strong"}),
+                MarkOp::Add {
+                    start: 0,
+                    end: 3,
+                    kind: MarkKind::Strong,
                 },
-            },
-            MarkOp::Remove {
-                start: 4,
-                end: 6,
-                kind: MarkKind::Anchor { id: "c1".into() },
-            },
-            MarkOp::RemoveAnchor { id: "c2".into() },
+            ),
+            (
+                serde_json::json!({
+                    "op": "add", "start": 1, "end": 2, "type": "link", "url": "https://x",
+                }),
+                MarkOp::Add {
+                    start: 1,
+                    end: 2,
+                    kind: MarkKind::Link {
+                        url: "https://x".into(),
+                    },
+                },
+            ),
+            (
+                serde_json::json!({
+                    "op": "remove", "start": 4, "end": 6, "type": "anchor", "id": "c1",
+                }),
+                MarkOp::Remove {
+                    start: 4,
+                    end: 6,
+                    kind: MarkKind::Anchor { id: "c1".into() },
+                },
+            ),
+            (
+                serde_json::json!({"op": "removeAnchor", "id": "c2"}),
+                MarkOp::RemoveAnchor { id: "c2".into() },
+            ),
         ];
-        for op in ops {
-            let v = mark_op_to_value(&op);
-            assert_eq!(mark_op_from_value(&v).unwrap(), op, "round-trip: {v}");
+        for (v, op) in cases {
+            assert_eq!(mark_op_from_value(&v).unwrap(), op, "decode: {v}");
         }
     }
 
     #[test]
-    fn line_op_wire_round_trips_each_variant() {
-        let ops = vec![
-            LineOp::Split { at: 5 },
-            LineOp::Join { line: 1 },
-            LineOp::SetKind {
-                line: 0,
-                kind: LineKind::Heading { level: 2 },
-            },
-            LineOp::SetContainers {
-                line: 2,
-                containers: vec![Container::Quote],
-            },
-            LineOp::SetKind {
-                line: 0,
-                kind: LineKind::Unknown {
-                    tag: "callout".into(),
-                    attrs: serde_json::json!({"variant": "warn"}),
+    fn line_op_wire_decodes_each_variant() {
+        let cases = vec![
+            (
+                serde_json::json!({"op": "split", "at": 5}),
+                LineOp::Split { at: 5 },
+            ),
+            (
+                serde_json::json!({"op": "join", "line": 1}),
+                LineOp::Join { line: 1 },
+            ),
+            (
+                serde_json::json!({"op": "setKind", "line": 0, "kind": "heading", "level": 2}),
+                LineOp::SetKind {
+                    line: 0,
+                    kind: LineKind::Heading { level: 2 },
                 },
-            },
-            LineOp::SetContainers {
-                line: 2,
-                containers: vec![Container::Unknown {
-                    tag: "indent".into(),
-                    attrs: serde_json::json!({"depth": 2}),
-                }],
-            },
-            LineOp::SetContinues {
-                line: 1,
-                continues: true,
-            },
-            LineOp::SetContinues {
-                line: 3,
-                continues: false,
-            },
+            ),
+            (
+                serde_json::json!({
+                    "op": "setContainers", "line": 2, "containers": [{"container": "quote"}],
+                }),
+                LineOp::SetContainers {
+                    line: 2,
+                    containers: vec![Container::Quote],
+                },
+            ),
+            (
+                serde_json::json!({
+                    "op": "setKind", "line": 0, "kind": "callout", "attrs": {"variant": "warn"},
+                }),
+                LineOp::SetKind {
+                    line: 0,
+                    kind: LineKind::Unknown {
+                        tag: "callout".into(),
+                        attrs: serde_json::json!({"variant": "warn"}),
+                    },
+                },
+            ),
+            (
+                serde_json::json!({
+                    "op": "setContainers", "line": 2,
+                    "containers": [{"container": "indent", "attrs": {"depth": 2}}],
+                }),
+                LineOp::SetContainers {
+                    line: 2,
+                    containers: vec![Container::Unknown {
+                        tag: "indent".into(),
+                        attrs: serde_json::json!({"depth": 2}),
+                    }],
+                },
+            ),
+            (
+                serde_json::json!({"op": "setContinues", "line": 1, "continues": true}),
+                LineOp::SetContinues {
+                    line: 1,
+                    continues: true,
+                },
+            ),
+            (
+                serde_json::json!({"op": "setContinues", "line": 3, "continues": false}),
+                LineOp::SetContinues {
+                    line: 3,
+                    continues: false,
+                },
+            ),
         ];
-        for op in ops {
-            let v = line_op_to_value(&op);
-            assert_eq!(line_op_from_value(&v).unwrap(), op, "round-trip: {v}");
+        for (v, op) in cases {
+            assert_eq!(line_op_from_value(&v).unwrap(), op, "decode: {v}");
         }
     }
 
@@ -1480,19 +1456,30 @@ mod tests {
     }
 
     #[test]
-    fn island_op_wire_round_trips_each_variant() {
+    fn island_op_wire_decodes_each_variant() {
         let island = Island::new("isl-0".into(), "table".into())
             .with_props(table_props("H", "a"))
             .with_loss(crate::model::Loss::DEGRADED);
-        let ops = vec![
-            IslandOp::Set {
-                island: island.clone(),
-            },
-            IslandOp::Insert { at: 7, island },
+        let cases = vec![
+            (
+                serde_json::json!({
+                    "op": "set", "id": "isl-0", "type": "table",
+                    "props": table_props("H", "a"), "loss": "degraded",
+                }),
+                IslandOp::Set {
+                    island: island.clone(),
+                },
+            ),
+            (
+                serde_json::json!({
+                    "op": "insert", "at": 7, "id": "isl-0", "type": "table",
+                    "props": table_props("H", "a"), "loss": "degraded",
+                }),
+                IslandOp::Insert { at: 7, island },
+            ),
         ];
-        for op in ops {
-            let v = island_op_to_value(&op);
-            assert_eq!(island_op_from_value(&v).unwrap(), op, "round-trip: {v}");
+        for (v, op) in cases {
+            assert_eq!(island_op_from_value(&v).unwrap(), op, "decode: {v}");
         }
     }
 

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -493,9 +493,8 @@ impl Content {
         });
 
         self.text = new_text;
-        self.lines = sync_lines_for_delta(&old_chars, old_lines, delta);
         let old_islands = std::mem::take(&mut self.islands);
-        self.islands = sync_islands_for_delta(&old_chars, old_islands, delta);
+        (self.lines, self.islands) = sync_for_delta(&old_chars, old_lines, old_islands, delta);
         if self.lines.len() != self.segment_count() {
             return Err(ApplyError::LineCountMismatch {
                 lines: self.lines.len(),
@@ -861,53 +860,66 @@ fn sanitize_inserts(delta: &Delta) -> Cow<'_, Delta> {
     Cow::Owned(Delta { ops })
 }
 
-/// Walk `delta` over `old_chars` and mirror `\n` insert/delete in `lines`, in
-/// one forward pass rather than per-`\n` mid-`Vec` `remove`/`insert`.
+/// Walk `delta` over `old_chars` once, mirroring both structures the base chars
+/// index: `\n` insert/delete in `lines`, and a deleted [`ISLAND_SLOT`] dropping
+/// its island. A `Retain`/`Delete` reaching past the end of the base names no
+/// char.
 ///
-/// The cursor sits *in* a line, `cur`; downstream of it is always the untouched
-/// original suffix (`rest`). `cur == None` is the past-the-end state on a
-/// malformed content (more `\n` than lines), where a split clones a default
-/// line.
-fn sync_lines_for_delta(old_chars: &[char], old_lines: Vec<Line>, delta: &Delta) -> Vec<Line> {
-    let cap = old_lines.len();
+/// The line cursor sits *in* a line, `cur`; downstream of it is always the
+/// untouched original suffix (`rest`), so lines are emitted in order rather than
+/// by per-`\n` mid-`Vec` `remove`/`insert`. `cur == None` is the past-the-end
+/// state on a malformed content (more `\n` than lines), where a split clones a
+/// default line.
+///
+/// Islands are stored in slot order, so the Nth slot the walk passes backs the
+/// Nth island.
+fn sync_for_delta(
+    old_chars: &[char],
+    old_lines: Vec<Line>,
+    old_islands: Vec<Island>,
+    delta: &Delta,
+) -> (Vec<Line>, Vec<Island>) {
     let mut rest = old_lines.into_iter();
-    let mut out: Vec<Line> = Vec::with_capacity(cap);
+    let mut lines: Vec<Line> = Vec::with_capacity(rest.len());
     let mut cur: Option<Line> = rest.next();
+    let mut keep = vec![true; old_islands.len()];
+    let mut slot = 0usize;
     let mut old = 0usize;
 
     for op in &delta.ops {
         match op {
-            Op::Retain(n) => {
-                for _ in 0..*n {
-                    if old >= old_chars.len() {
-                        break;
+            Op::Retain(n) | Op::Delete(n) => {
+                let deleted = matches!(op, Op::Delete(_));
+                let end = old.saturating_add(*n).min(old_chars.len());
+                for &c in &old_chars[old..end] {
+                    match c {
+                        // A deleted '\n' merges the next original into `cur`.
+                        '\n' if deleted => {
+                            rest.next();
+                        }
+                        '\n' => {
+                            lines.extend(cur.take());
+                            cur = rest.next();
+                        }
+                        ISLAND_SLOT => {
+                            if deleted && let Some(k) = keep.get_mut(slot) {
+                                *k = false;
+                            }
+                            slot += 1;
+                        }
+                        _ => {}
                     }
-                    if old_chars[old] == '\n' {
-                        out.extend(cur.take());
-                        cur = rest.next();
-                    }
-                    old += 1;
                 }
+                old = end;
             }
-            Op::Delete(n) => {
-                for _ in 0..*n {
-                    if old >= old_chars.len() {
-                        break;
-                    }
-                    // A deleted '\n' merges the next original into `cur`.
-                    if old_chars[old] == '\n' {
-                        rest.next();
-                    }
-                    old += 1;
-                }
-            }
+            // A raw ISLAND_SLOT insert is rejected before this walk.
             Op::Insert(s) => {
                 for c in s.chars() {
                     if c == '\n' {
                         let mut new_line = match cur.take() {
                             Some(line) => {
                                 let clone = line.clone();
-                                out.push(line);
+                                lines.push(line);
                                 clone
                             }
                             None => Line::new(LineKind::Para),
@@ -920,59 +932,14 @@ fn sync_lines_for_delta(old_chars: &[char], old_lines: Vec<Line>, delta: &Delta)
         }
     }
 
-    out.extend(cur);
-    out.extend(rest);
-    out
-}
-
-/// Drop any island whose [`ISLAND_SLOT`] char `delta` deletes. Islands are
-/// stored in slot order, so the Nth slot backs the Nth island.
-fn sync_islands_for_delta(
-    old_chars: &[char],
-    old_islands: Vec<Island>,
-    delta: &Delta,
-) -> Vec<Island> {
-    let mut keep = vec![true; old_islands.len()];
-    let mut old = 0usize;
-    let mut slot_idx = 0usize;
-
-    for op in &delta.ops {
-        match op {
-            Op::Retain(n) => {
-                for _ in 0..*n {
-                    if old >= old_chars.len() {
-                        break;
-                    }
-                    if old_chars[old] == ISLAND_SLOT {
-                        slot_idx += 1;
-                    }
-                    old += 1;
-                }
-            }
-            Op::Delete(n) => {
-                for _ in 0..*n {
-                    if old >= old_chars.len() {
-                        break;
-                    }
-                    if old_chars[old] == ISLAND_SLOT {
-                        if let Some(k) = keep.get_mut(slot_idx) {
-                            *k = false;
-                        }
-                        slot_idx += 1;
-                    }
-                    old += 1;
-                }
-            }
-            // A raw ISLAND_SLOT insert is rejected before this walk.
-            Op::Insert(_) => {}
-        }
-    }
-
-    old_islands
+    lines.extend(cur);
+    lines.extend(rest);
+    let islands = old_islands
         .into_iter()
         .zip(keep)
         .filter_map(|(island, keep)| keep.then_some(island))
-        .collect()
+        .collect();
+    (lines, islands)
 }
 
 fn newline_at_line_boundary(text: &str, line: usize) -> Result<Usv, ApplyError> {
@@ -1854,6 +1821,11 @@ mod tests {
         }
     }
 
+    /// [`sync_for_delta`] on island-free content.
+    fn sync_lines(old_chars: &[char], old_lines: Vec<Line>, delta: &Delta) -> Vec<Line> {
+        sync_for_delta(old_chars, old_lines, Vec::new(), delta).0
+    }
+
     /// `(tag, continues)` per line: a heading's level, 0 for `Para` (the default
     /// line), 255 for anything else.
     fn tags(lines: &[Line]) -> Vec<(u8, bool)> {
@@ -1880,7 +1852,7 @@ mod tests {
         let d = Delta {
             ops: vec![Op::Retain(3), Op::Insert("\n".into()), Op::Retain(1)],
         };
-        let out = sync_lines_for_delta(&old_chars, lines, &d);
+        let out = sync_lines(&old_chars, lines, &d);
         assert_eq!(out.len(), 3);
         assert_eq!(out[1], l1, "first half is the untouched original line");
         assert_eq!(out[2].kind, LineKind::Heading { level: 5 });
@@ -1895,8 +1867,26 @@ mod tests {
         let d = Delta {
             ops: vec![Op::Retain(1), Op::Delete(1), Op::Retain(3)],
         };
-        let out = sync_lines_for_delta(&old_chars, lines, &d);
+        let out = sync_lines(&old_chars, lines, &d);
         assert_eq!(tags(&out), vec![(1, false), (3, false)]);
+    }
+
+    #[test]
+    fn sync_walks_lines_and_islands_off_one_cursor() {
+        // One delete run crosses a slot and then a '\n'; the retain behind it
+        // has to land on slot 1, and the merged line has to be line 1's.
+        let old_chars: Vec<char> = format!("{ISLAND_SLOT}\n{ISLAND_SLOT}").chars().collect();
+        let d = Delta {
+            ops: vec![Op::Delete(2), Op::Retain(1)],
+        };
+        let (lines, islands) = sync_for_delta(
+            &old_chars,
+            vec![tag_line(1, false), tag_line(2, false)],
+            vec![island("first"), island("second")],
+            &d,
+        );
+        assert_eq!(tags(&lines), vec![(1, false)]);
+        assert_eq!(islands.iter().map(|i| &i.id).collect::<Vec<_>>(), ["second"]);
     }
 
     #[test]
@@ -1907,7 +1897,7 @@ mod tests {
         let d = Delta {
             ops: vec![Op::Retain(1), Op::Delete(1)],
         };
-        let out = sync_lines_for_delta(&old_chars, lines, &d);
+        let out = sync_lines(&old_chars, lines, &d);
         assert_eq!(tags(&out), vec![(1, false)]);
     }
 
@@ -1918,7 +1908,7 @@ mod tests {
         let d = Delta {
             ops: vec![Op::Retain(99)],
         };
-        assert_eq!(sync_lines_for_delta(&old_chars, lines.clone(), &d), lines);
+        assert_eq!(sync_lines(&old_chars, lines.clone(), &d), lines);
     }
 
     #[test]
@@ -2005,7 +1995,7 @@ mod tests {
         let d = Delta {
             ops: vec![Op::Delete(old_chars.len())],
         };
-        let out = sync_lines_for_delta(&old_chars, lines, &d);
+        let out = sync_lines(&old_chars, lines, &d);
         assert_eq!(tags(&out), vec![(0, false)], "only the first line survives");
     }
 
@@ -2018,7 +2008,7 @@ mod tests {
         let d = Delta {
             ops: vec![Op::Retain(2), Op::Insert("\n".into())],
         };
-        let out = sync_lines_for_delta(&old_chars, lines, &d);
+        let out = sync_lines(&old_chars, lines, &d);
         assert_eq!(out.len(), 2);
         assert_eq!(tags(&out)[0], (1, false));
         assert_eq!(out[1].kind, LineKind::Para);

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -315,8 +315,9 @@ fn line_to_value(line: &Line) -> Value {
     if line.continues {
         m.insert("continues".into(), Value::Bool(true));
     }
-    // `line_kind_fields` merges its keys ahead of `containers`/`continues`, so
-    // the canonical order is settled here rather than at each insert.
+    // `line_kind_fields` merges `kind` in ahead of `containers`/`continues`,
+    // which sort before it, so this one encoder cannot settle its order at the
+    // insert.
     Value::Object(sort_own_keys(m))
 }
 
@@ -421,8 +422,9 @@ pub fn mark_to_value(mark: &Mark) -> Value {
             m.insert("attrs".into(), attrs.clone());
         }
     }
-    // A kind's keys interleave with `start`/`end` in ascending order, so this
-    // encoder settles its order here rather than at each insert.
+    // A kind's own keys do not all sort after `start`/`end` — `attrs` precedes
+    // both, `id` falls between them — so this one encoder cannot settle its
+    // order at the insert.
     Value::Object(sort_own_keys(m))
 }
 

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -218,10 +218,9 @@ pub fn line_kind_to_value(kind: &LineKind) -> Value {
     Value::Object(line_kind_fields(kind))
 }
 
-/// The same fields unwrapped, for the op wire ([`crate::ops`]), which flattens
-/// them beside its own keys and so carries the exact discriminant a
-/// `ContentLine` does.
-pub(crate) fn line_kind_fields(kind: &LineKind) -> Map<String, Value> {
+/// The same fields unwrapped, for [`line_to_value`], which flattens them beside
+/// a line's own keys.
+fn line_kind_fields(kind: &LineKind) -> Map<String, Value> {
     let mut m = Map::new();
     match kind {
         LineKind::Para => {
@@ -321,8 +320,7 @@ fn line_from_value(v: &Value) -> Result<Line, ParseError> {
     })
 }
 
-/// Encode a [`Container`] into its canonical wire object. Public so the op wire
-/// ([`crate::ops`]) reuses the same container shape a `ContentLine` carries.
+/// Encode a [`Container`] into its canonical wire object.
 pub fn container_to_value(c: &Container) -> Value {
     let mut m = Map::new();
     match c {
@@ -373,17 +371,10 @@ pub fn container_from_value(v: &Value) -> Result<Container, ParseError> {
 
 /// Encode a [`Mark`] (`{start, end, type, …}`) into its canonical wire object.
 pub fn mark_to_value(mark: &Mark) -> Value {
-    Value::Object(mark_fields(mark.start, mark.end, &mark.kind))
-}
-
-/// The same fields unwrapped and over a mark's parts, for the op wire
-/// ([`crate::ops`]), which flattens them beside its own keys, carries the exact
-/// `type` discriminant a `ContentMark` does, and holds no [`Mark`].
-pub(crate) fn mark_fields(start: Usv, end: Usv, kind: &MarkKind) -> Map<String, Value> {
     let mut m = Map::new();
-    m.insert("start".into(), Value::from(start));
-    m.insert("end".into(), Value::from(end));
-    match kind {
+    m.insert("start".into(), Value::from(mark.start));
+    m.insert("end".into(), Value::from(mark.end));
+    match &mark.kind {
         MarkKind::Strong => {
             m.insert("type".into(), "strong".into());
         }
@@ -412,7 +403,7 @@ pub(crate) fn mark_fields(start: Usv, end: Usv, kind: &MarkKind) -> Map<String, 
             m.insert("attrs".into(), attrs.clone());
         }
     }
-    m
+    Value::Object(m)
 }
 
 /// What every mark carries whatever its type.
@@ -822,18 +813,12 @@ pub(crate) fn table_shape_error(props: &Value) -> Option<Invariant> {
 }
 
 pub(crate) fn island_to_value(island: &Island) -> Value {
-    Value::Object(island_fields(island))
-}
-
-/// The same fields unwrapped, for the op wire ([`crate::ops`]), which flattens
-/// them beside its own keys.
-pub(crate) fn island_fields(island: &Island) -> Map<String, Value> {
     let mut m = Map::new();
     m.insert("id".into(), Value::String(island.id.clone()));
     m.insert("type".into(), Value::String(island.island_type.clone()));
     m.insert("props".into(), island.props.clone());
     m.insert("loss".into(), island.loss.as_str().into());
-    m
+    Value::Object(m)
 }
 
 pub(crate) fn island_from_value(v: &Value) -> Result<Island, ParseError> {

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -18,7 +18,7 @@
 //! The seam encoding and the storage encoding are the *same* canonical form.
 
 use crate::model::{
-    sort_keys_owned, Container, Invariant, Island, Line, LineKind, Loss, Mark,
+    canonicalize_keys, Container, Invariant, Island, Line, LineKind, Loss, Mark,
     MarkKind, Content, Usv,
 };
 use serde_json::{Map, Value};
@@ -50,9 +50,10 @@ impl std::error::Error for ParseError {}
 
 impl Content {
     /// Serialize to canonical JSON bytes. Normalizes a copy first, so the output
-    /// is canonical regardless of the caller's mark/island order, and sorts every
-    /// object key recursively, so the bytes do **not** depend on `serde_json`'s
-    /// `preserve_order` feature in the consumer's crate graph.
+    /// is canonical regardless of the caller's mark/island order, and every
+    /// object key comes out in ascending order at every depth, so the bytes do
+    /// **not** depend on `serde_json`'s `preserve_order` feature in the
+    /// consumer's crate graph.
     pub fn to_canonical_json(&self) -> String {
         to_canonical_value(self).to_string()
     }
@@ -67,7 +68,10 @@ impl Content {
 
     fn to_value(&self) -> Value {
         let mut root = Map::new();
-        root.insert("text".into(), Value::String(self.text.clone()));
+        root.insert(
+            "islands".into(),
+            Value::Array(self.islands.iter().map(island_to_value).collect()),
+        );
         root.insert(
             "lines".into(),
             Value::Array(self.lines.iter().map(line_to_value).collect()),
@@ -76,10 +80,7 @@ impl Content {
             "marks".into(),
             Value::Array(self.marks.iter().map(mark_to_value).collect()),
         );
-        root.insert(
-            "islands".into(),
-            Value::Array(self.islands.iter().map(island_to_value).collect()),
-        );
+        root.insert("text".into(), Value::String(self.text.clone()));
         Value::Object(root)
     }
 
@@ -119,7 +120,22 @@ impl Content {
 pub fn to_canonical_value(rt: &Content) -> Value {
     let mut rt = rt.clone();
     rt.normalize();
-    sort_keys_owned(rt.to_value())
+    let mut v = rt.to_value();
+    // Scans and returns: the encoders emit their fixed keys in ascending order,
+    // and every opaque bag under them was canonicalized by `normalize`. A key
+    // inserted out of order is still repaired here, so the freeze holds without
+    // the encoders having to be trusted for it.
+    canonicalize_keys(&mut v);
+    v
+}
+
+/// One map's own keys in ascending order, its values untouched. Shallow because
+/// every value below is a scalar, an array of encoder objects that sorted
+/// themselves, or a bag [`Content::normalize`] already canonicalized.
+fn sort_own_keys(m: Map<String, Value>) -> Map<String, Value> {
+    let mut entries: Vec<(String, Value)> = m.into_iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries.into_iter().collect()
 }
 
 /// Parse the canonical content form from a structural [`Value`], normalize, and
@@ -300,7 +316,9 @@ fn line_to_value(line: &Line) -> Value {
     if line.continues {
         m.insert("continues".into(), Value::Bool(true));
     }
-    Value::Object(m)
+    // `line_kind_fields` is shared with the op wire, which flattens it beside
+    // keys of its own, so the canonical order is settled here.
+    Value::Object(sort_own_keys(m))
 }
 
 fn line_from_value(v: &Value) -> Result<Line, ParseError> {
@@ -333,15 +351,15 @@ pub fn container_to_value(c: &Container) -> Value {
         } => {
             m.insert("container".into(), "list_item".into());
             m.insert("ordered".into(), Value::Bool(*ordered));
-            m.insert("start".into(), Value::from(*start));
             m.insert("ordinal".into(), Value::from(*ordinal));
+            m.insert("start".into(), Value::from(*start));
         }
         Container::Quote => {
             m.insert("container".into(), "quote".into());
         }
         Container::Unknown { tag, attrs } => {
-            m.insert("container".into(), Value::String(tag.clone()));
             m.insert("attrs".into(), attrs.clone());
+            m.insert("container".into(), Value::String(tag.clone()));
         }
     }
     Value::Object(m)
@@ -371,9 +389,13 @@ pub fn container_from_value(v: &Value) -> Result<Container, ParseError> {
     }
 }
 
-/// Encode a [`Mark`] (`{start, end, type, …}`) into its canonical wire object.
+/// Encode a [`Mark`] (`start`, `end`, `type`, …) into its canonical wire object.
 pub fn mark_to_value(mark: &Mark) -> Value {
-    Value::Object(mark_fields(mark.start, mark.end, &mark.kind))
+    // As in `line_to_value`: `mark_fields` serves the op wire too, so the
+    // canonical order is settled here.
+    Value::Object(sort_own_keys(mark_fields(
+        mark.start, mark.end, &mark.kind,
+    )))
 }
 
 /// The same fields unwrapped and over a mark's parts, for the op wire
@@ -654,15 +676,14 @@ pub fn parse_cell(v: &Value) -> (String, Vec<Mark>) {
     (text, marks)
 }
 
-/// Build a table-cell object `{text, marks}`. Key order is fixed by the
-/// recursive key-sort in [`Content::normalize`], not here.
+/// Build a table-cell object `{marks, text}`.
 pub(crate) fn cell_to_value(text: &str, marks: &[Mark]) -> Value {
     let mut m = Map::new();
-    m.insert("text".into(), Value::String(text.to_string()));
     m.insert(
         "marks".into(),
         Value::Array(marks.iter().map(mark_to_value).collect()),
     );
+    m.insert("text".into(), Value::String(text.to_string()));
     Value::Object(m)
 }
 
@@ -830,9 +851,9 @@ pub(crate) fn island_to_value(island: &Island) -> Value {
 pub(crate) fn island_fields(island: &Island) -> Map<String, Value> {
     let mut m = Map::new();
     m.insert("id".into(), Value::String(island.id.clone()));
-    m.insert("type".into(), Value::String(island.island_type.clone()));
-    m.insert("props".into(), island.props.clone());
     m.insert("loss".into(), island.loss.as_str().into());
+    m.insert("props".into(), island.props.clone());
+    m.insert("type".into(), Value::String(island.island_type.clone()));
     m
 }
 
@@ -1060,6 +1081,133 @@ mod tests {
         let mut two = one.clone();
         two.islands[0].props = serde_json::json!({"a": 2, "b": 1}); // keys reversed
         assert_eq!(one.to_canonical_json(), two.to_canonical_json());
+    }
+
+    /// Every encoder emits its own keys in ascending order, so
+    /// [`to_canonical_value`]'s backstop scans and returns instead of rebuilding
+    /// the tree. A key inserted out of order still serializes canonically — the
+    /// backstop repairs it — so nothing else notices the regression.
+    #[test]
+    fn encoders_emit_keys_in_ascending_order() {
+        use crate::model::is_value_key_sorted;
+        let bag = || serde_json::json!({"a": 1, "b": 2});
+        let sorted = |v: &Value| is_value_key_sorted(v);
+
+        let kinds = [
+            MarkKind::Strong,
+            MarkKind::Emph,
+            MarkKind::Underline,
+            MarkKind::Strike,
+            MarkKind::Code,
+            MarkKind::Link { url: "u".into() },
+            MarkKind::Anchor { id: "a".into() },
+            MarkKind::Unknown {
+                tag: "kbd".into(),
+                attrs: bag(),
+            },
+        ];
+        let marks: Vec<Mark> = kinds
+            .iter()
+            .map(|kind| Mark {
+                start: 0,
+                end: 1,
+                kind: kind.clone(),
+            })
+            .collect();
+        for m in &marks {
+            assert!(sorted(&mark_to_value(m)), "mark {:?}", m.kind);
+        }
+        assert!(sorted(&cell_to_value("t", &marks)));
+
+        let containers = vec![
+            Container::ListItem {
+                ordered: true,
+                start: 3,
+                ordinal: 1,
+            },
+            Container::Quote,
+            Container::Unknown {
+                tag: "indent".into(),
+                attrs: bag(),
+            },
+        ];
+        for c in &containers {
+            assert!(sorted(&container_to_value(c)), "container {c:?}");
+        }
+
+        let line_kinds = [
+            LineKind::Para,
+            LineKind::Heading { level: 2 },
+            LineKind::Code {
+                lang: Some("rust".into()),
+            },
+            LineKind::Code { lang: None },
+            LineKind::Island,
+            LineKind::Rule,
+            LineKind::Unknown {
+                tag: "callout".into(),
+                attrs: bag(),
+            },
+        ];
+        for kind in line_kinds {
+            for continues in [false, true] {
+                let line = Line {
+                    kind: kind.clone(),
+                    containers: containers.clone(),
+                    continues,
+                };
+                assert!(sorted(&line_to_value(&line)), "line {:?}", line.kind);
+            }
+        }
+
+        for island_type in ["table", "image", "widget"] {
+            let island = Island {
+                id: "i1".into(),
+                island_type: island_type.into(),
+                props: bag(),
+                loss: Loss::LOSSLESS,
+            };
+            assert!(sorted(&island_to_value(&island)), "island {island_type}");
+        }
+    }
+
+    /// The whole assembled tree, table cells and all: what the backstop actually
+    /// scans.
+    #[test]
+    fn the_canonical_tree_needs_no_repair() {
+        use crate::model::is_value_key_sorted;
+        let mut rt = Content::empty();
+        rt.text = "hi\n\u{FFFC}".into();
+        rt.lines = vec![
+            Line {
+                kind: LineKind::Heading { level: 2 },
+                containers: vec![Container::Quote],
+                continues: false,
+            },
+            Line {
+                kind: LineKind::Island,
+                containers: vec![],
+                continues: false,
+            },
+        ];
+        rt.marks = vec![Mark {
+            start: 0,
+            end: 2,
+            kind: MarkKind::Link { url: "u".into() },
+        }];
+        rt.islands = vec![Island {
+            id: "i1".into(),
+            island_type: "table".into(),
+            props: serde_json::json!({
+                "header": [{"text": "h", "marks": [{"start": 0, "end": 1, "type": "emph"}]}],
+                "rows": [[{"text": "r", "marks": []}]],
+                "aligns": ["none"],
+            }),
+            loss: Loss::LOSSLESS,
+        }];
+        rt.normalize();
+        assert_eq!(rt.validate(), Ok(()));
+        assert!(is_value_key_sorted(&rt.to_value()));
     }
 
     #[test]

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -978,6 +978,7 @@ fn validate_dto_payload(payload: &Payload) -> Result<(), StorageError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::document::Codec;
 
     fn sample() -> Document {
         Document::parse(
@@ -1039,7 +1040,7 @@ This body and the metadata above are an indorsement card.
         let stored = serde_json::to_string(&doc).unwrap();
         let restored: Document = serde_json::from_str(&stored).unwrap();
         assert_eq!(doc, restored, "content field must survive storage round-trip");
-        let read = restored.main().field_richtext("intro").unwrap().unwrap();
+        let read = restored.main().field_content("intro", Codec::Richtext).unwrap().unwrap();
         assert!(
             read.marks.iter().any(|m| matches!(m.kind, MarkKind::Underline)),
             "underline (content-only) must survive the DTO carrier"

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -18,7 +18,7 @@ use quillmark_content::{ApplyError, ChangeBundle, Content, Delta};
 use crate::document::meta::{validate_composable_kind, CardKindError};
 use crate::error::diag_args;
 use crate::document::payload::MetaKey;
-use crate::document::{Card, Document, Payload, RichtextDecodeError};
+use crate::document::{Card, Codec, ContentDecodeError, Document, Payload};
 use crate::quill::{CoercionError, FieldSchema, FieldType, Leniency, QuillConfig};
 use crate::value::{PathSegment, QuillValue};
 use crate::version::QuillReference;
@@ -313,12 +313,19 @@ fn check_kind(kind: &str) -> Result<(), EditError> {
     })
 }
 
-/// A decode failure on the field itself, under the codec that ran.
-fn field_decode(name: &str, codec: &str, e: RichtextDecodeError) -> EditError {
+/// A decode failure at an address, under the codec that ran. The one
+/// [`EditError::FieldDecode`] constructor for a codec outcome, shared with the
+/// schema-bound reads in [`reader`](crate::reader).
+pub(crate) fn field_decode(
+    name: &str,
+    at: &[PathSegment],
+    codec: Codec,
+    e: ContentDecodeError,
+) -> EditError {
     EditError::FieldDecode {
         field: name.to_string(),
-        at: Vec::new(),
-        codec: codec.to_string(),
+        at: at.to_vec(),
+        codec: codec.name().to_string(),
         message: e.into_message(),
     }
 }
@@ -786,9 +793,9 @@ impl Card {
         if !is_valid_field_name(name) {
             return Err(EditError::InvalidFieldName(name.to_string()));
         }
-        let base = match self.field_richtext(name) {
+        let base = match self.field_content(name, Codec::Richtext) {
             Some(Ok(rt)) => rt,
-            Some(Err(e)) => return Err(field_decode(name, CODEC_RICHTEXT, e)),
+            Some(Err(e)) => return Err(field_decode(name, &[], Codec::Richtext, e)),
             None => Content::empty(),
         };
         diff_import(&base, &body.into()).map_err(EditError::Import)
@@ -871,9 +878,9 @@ impl Card {
         if !is_valid_field_name(name) {
             return Err(EditError::InvalidFieldName(name.to_string()));
         }
-        let base = match self.field_plaintext_content(name) {
-            Some(Ok(rt)) => quillmark_content::export::to_plaintext(&rt),
-            Some(Err(e)) => return Err(field_decode(name, CODEC_PLAINTEXT, e)),
+        let base = match self.field_text(name, Codec::Plaintext) {
+            Some(Ok(text)) => text,
+            Some(Err(e)) => return Err(field_decode(name, &[], Codec::Plaintext, e)),
             None => String::new(),
         };
         // The strict write is the codec: it runs the `from_plaintext` boundary
@@ -923,9 +930,9 @@ impl Card {
         name: &str,
         bundle: &ChangeBundle,
     ) -> Result<(), EditError> {
-        let mut content = match self.field_richtext(name) {
+        let mut content = match self.field_content(name, Codec::Richtext) {
             Some(Ok(rt)) => rt,
-            Some(Err(e)) => return Err(field_decode(name, CODEC_RICHTEXT, e)),
+            Some(Err(e)) => return Err(field_decode(name, &[], Codec::Richtext, e)),
             // Only this arm creates; the `Some` arms resolved an existing field.
             None => {
                 if !is_valid_field_name(name) {

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -59,6 +59,36 @@ pub(crate) fn decode_richtext_value(
     }
 }
 
+/// Why a richtext value did not become stored content, classified so each layer
+/// words the failure in its own error vocabulary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RichtextValueError {
+    /// An accepted encoding that failed to decode.
+    Decode(RichtextDecodeError),
+    /// Neither a canonical content object nor a markdown string.
+    Unshaped,
+    /// `inline` is declared and the content spans more than one paragraph.
+    NotInline,
+}
+
+/// The contract for a richtext value that must *become* stored content: decode
+/// either accepted encoding, enforce `inline`, canonicalize. The strict typed
+/// write and the schema-literal companion cache share it and differ only in the
+/// diagnostic they render from the error.
+pub(crate) fn canonical_richtext_value(
+    value: &serde_json::Value,
+    inline: bool,
+) -> Result<serde_json::Value, RichtextValueError> {
+    let content = match decode_richtext_value(value) {
+        Some(result) => result.map_err(RichtextValueError::Decode)?,
+        None => return Err(RichtextValueError::Unshaped),
+    };
+    if inline && !content.is_inline() {
+        return Err(RichtextValueError::NotInline);
+    }
+    Ok(quillmark_content::serial::to_canonical_value(&content))
+}
+
 /// The plaintext twin of [`decode_richtext_value`]: a string imports verbatim
 /// (never as markdown, so `*hi*` stays four plain characters), so only the
 /// object branch can fail.

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -23,82 +23,104 @@ pub(crate) fn import_body(md: &str) -> Result<Content, ImportError> {
     }
 }
 
-/// Which encoding a `decode_richtext_value` failure came from, so a call site
+/// Which encoding a [`Codec::decode_value`] failure came from, so a call site
 /// can prefix its diagnostic per encoding.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-pub(crate) enum RichtextDecodeError {
+pub(crate) enum ContentDecodeError {
     NotContent(String),
     BadMarkdown(String),
 }
 
-impl RichtextDecodeError {
+impl ContentDecodeError {
     pub(crate) fn into_message(self) -> String {
         match self {
-            RichtextDecodeError::NotContent(m) | RichtextDecodeError::BadMarkdown(m) => m,
+            ContentDecodeError::NotContent(m) | ContentDecodeError::BadMarkdown(m) => m,
         }
     }
 }
 
-/// Decode a JSON value in either accepted richtext encoding: a canonical content
-/// object, or an authored markdown string. `None` when the value is neither an
-/// object nor a string; the call site handles those shapes and maps the error
-/// into its own type.
-pub(crate) fn decode_richtext_value(
-    value: &serde_json::Value,
-) -> Option<Result<Content, RichtextDecodeError>> {
-    match value {
-        serde_json::Value::Object(_) => Some(
-            quillmark_content::serial::from_canonical_value(value)
-                .map_err(|e| RichtextDecodeError::NotContent(e.to_string())),
-        ),
-        serde_json::Value::String(md) => {
-            Some(import_body(md).map_err(|e| RichtextDecodeError::BadMarkdown(e.to_string())))
+/// A content codec: which authored string a [`Content`] field accepts, and which
+/// text a stored content projects back to. Both codecs also accept a canonical
+/// content object, so a codec is exactly the string end of the round trip. The
+/// declared type names one (`reader::content_codec`), and every schema-bound
+/// content read and projection runs the codec it names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Codec {
+    /// A string is markdown, and a content projects back to markdown — lossy,
+    /// content-only marks not surviving.
+    Richtext,
+    /// A string is literal text (`*hi*` stays four characters), and a content
+    /// projects back verbatim.
+    Plaintext,
+}
+
+impl Codec {
+    /// The schema keyword declaring this codec, carried verbatim on
+    /// [`EditError::FieldDecode`].
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Codec::Richtext => edit::CODEC_RICHTEXT,
+            Codec::Plaintext => edit::CODEC_PLAINTEXT,
         }
-        _ => None,
     }
-}
 
-/// The plaintext twin of [`decode_richtext_value`]: a string imports verbatim
-/// (never as markdown, so `*hi*` stays four plain characters), so only the
-/// object branch can fail.
-pub(crate) fn decode_plaintext_value(
-    value: &serde_json::Value,
-) -> Option<Result<Content, String>> {
-    match value {
-        serde_json::Value::Object(_) => {
-            Some(quillmark_content::serial::from_canonical_value(value).map_err(|e| e.to_string()))
+    /// How this codec reads a stored string, for the shape-mismatch message.
+    fn string_form(self) -> &'static str {
+        match self {
+            Codec::Richtext => "a markdown string",
+            Codec::Plaintext => "a string",
         }
-        serde_json::Value::String(s) => Some(Ok(quillmark_content::from_plaintext(s))),
-        _ => None,
     }
-}
 
-/// [`decode_richtext_value`] closed over the shapes a stored field can hold: a
-/// null is the empty content (null ≡ absent), and anything neither object nor
-/// string is a decode failure.
-pub(crate) fn decode_richtext_field(
-    value: &serde_json::Value,
-) -> Result<Content, RichtextDecodeError> {
-    match decode_richtext_value(value) {
-        Some(result) => result,
-        None if value.is_null() => Ok(Content::empty()),
-        None => Err(RichtextDecodeError::NotContent(
-            "expected a richtext content object or a markdown string".to_string(),
-        )),
+    /// Decode a JSON value in either accepted encoding: a canonical content
+    /// object, or an authored string read this codec's way. `None` when the value
+    /// is neither an object nor a string; the call site handles those shapes and
+    /// maps the error into its own type.
+    pub(crate) fn decode_value(
+        self,
+        value: &serde_json::Value,
+    ) -> Option<Result<Content, ContentDecodeError>> {
+        match value {
+            serde_json::Value::Object(_) => Some(
+                quillmark_content::serial::from_canonical_value(value)
+                    .map_err(|e| ContentDecodeError::NotContent(e.to_string())),
+            ),
+            serde_json::Value::String(s) => Some(match self {
+                Codec::Richtext => {
+                    import_body(s).map_err(|e| ContentDecodeError::BadMarkdown(e.to_string()))
+                }
+                Codec::Plaintext => Ok(quillmark_content::from_plaintext(s)),
+            }),
+            _ => None,
+        }
     }
-}
 
-/// The plaintext twin of [`decode_richtext_field`].
-pub(crate) fn decode_plaintext_field(
-    value: &serde_json::Value,
-) -> Result<Content, RichtextDecodeError> {
-    match decode_plaintext_value(value) {
-        Some(result) => result.map_err(RichtextDecodeError::NotContent),
-        None if value.is_null() => Ok(Content::empty()),
-        None => Err(RichtextDecodeError::NotContent(
-            "expected a plaintext content object or a string".to_string(),
-        )),
+    /// [`decode_value`](Self::decode_value) closed over the shapes a stored field
+    /// can hold: a null is the empty content (null ≡ absent), and anything
+    /// neither object nor string is a decode failure.
+    pub(crate) fn decode_field(
+        self,
+        value: &serde_json::Value,
+    ) -> Result<Content, ContentDecodeError> {
+        match self.decode_value(value) {
+            Some(result) => result,
+            None if value.is_null() => Ok(Content::empty()),
+            None => Err(ContentDecodeError::NotContent(format!(
+                "expected a {} content object or {}",
+                self.name(),
+                self.string_form()
+            ))),
+        }
+    }
+
+    /// Project a content back to this codec's text: the inverse of its string
+    /// encoding.
+    pub(crate) fn project(self, content: &Content) -> String {
+        match self {
+            Codec::Richtext => quillmark_content::export::to_markdown(content),
+            Codec::Plaintext => quillmark_content::export::to_plaintext(content),
+        }
     }
 }
 
@@ -222,61 +244,35 @@ impl Card {
         &mut self.body
     }
 
-    /// Read a richtext-valued user field back as a [`Content`]: the field-level
-    /// twin of [`Card::body`]. `None` when absent, `Some(Err(_))` when present
-    /// but neither a content object nor importable markdown. A `Document`
-    /// carries no schema, so the caller names a field it knows is richtext.
-    pub(crate) fn field_richtext(&self, name: &str) -> Option<Result<Content, RichtextDecodeError>> {
-        Some(crate::document::decode_richtext_field(
-            self.payload.get(name)?.as_json(),
-        ))
-    }
-
-    /// The markdown projection of a richtext-valued field (`export ∘ decode`),
-    /// carrying [`field_richtext`](Card::field_richtext)'s `None`/`Ok`/`Err`.
-    pub(crate) fn field_markdown(&self, name: &str) -> Option<Result<String, RichtextDecodeError>> {
-        Some(self.field_richtext(name)?.map(|rt| quillmark_content::export::to_markdown(&rt)))
-    }
-
-    /// Read a plaintext-valued user field back as a [`Content`] content: the
-    /// literal-codec twin of [`field_richtext`](Card::field_richtext). A stored
-    /// string imports verbatim (`*hi*` is four characters, not emphasis), an
-    /// already-canonical content decodes losslessly: the same dispatch coercion
-    /// and validation run for a `plaintext` field, so the read and the render
-    /// agree on the codec.
+    /// Read a content-valued user field back through `codec`: the field-level
+    /// twin of [`Card::body`].
     ///
     /// - `None`: the field is absent.
-    /// - `Some(Ok(rt))`: decoded content.
-    /// - `Some(Err(_))`: the field is present but neither a content object nor a
-    ///   string (e.g. a bare number a `store_field` wrote).
+    /// - `Some(Ok(content))`: decoded content, from either of the codec's
+    ///   encodings — a stored string and an already-canonical content object read
+    ///   back the same.
+    /// - `Some(Err(_))`: the field is present but decodes under neither (e.g. a
+    ///   bare number an opaque `store_field` wrote).
     ///
-    /// A `Document` carries no schema, so the caller names a field it knows is
-    /// plaintext; the schema-bound door is
+    /// A `Document` carries no schema, so the caller names the codec the field is
+    /// declared at; the schema-bound door is
     /// [`TypedReader::get_content`](crate::TypedReader::get_content).
-    pub(crate) fn field_plaintext_content(
+    pub(crate) fn field_content(
         &self,
         name: &str,
-    ) -> Option<Result<Content, RichtextDecodeError>> {
-        Some(crate::document::decode_plaintext_field(
-            self.payload.get(name)?.as_json(),
-        ))
+        codec: Codec,
+    ) -> Option<Result<Content, ContentDecodeError>> {
+        Some(codec.decode_field(self.payload.get(name)?.as_json()))
     }
 
-    /// The plaintext projection of a content-valued field (`to_plaintext ∘
-    /// decode`), the literal-codec twin of [`field_markdown`](Card::field_markdown),
-    /// for a `plaintext`-typed field: marks are never interpreted, so the text is
-    /// verbatim both ways. Carries
-    /// [`field_plaintext_content`](Card::field_plaintext_content)'s `Ok`/`Err`
-    /// decode outcome:
-    ///
-    /// - `None`: the field is absent.
-    /// - `Some(Ok(text))`: the projected literal text.
-    /// - `Some(Err(_))`: the field is present but does not decode as content.
-    pub(crate) fn field_plaintext(&self, name: &str) -> Option<Result<String, RichtextDecodeError>> {
-        Some(
-            self.field_plaintext_content(name)?
-                .map(|rt| quillmark_content::export::to_plaintext(&rt)),
-        )
+    /// The text projection of a content-valued field (`project ∘ decode`),
+    /// carrying [`field_content`](Card::field_content)'s `None`/`Ok`/`Err`.
+    pub(crate) fn field_text(
+        &self,
+        name: &str,
+        codec: Codec,
+    ) -> Option<Result<String, ContentDecodeError>> {
+        Some(self.field_content(name, codec)?.map(|c| codec.project(&c)))
     }
 }
 

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -1,7 +1,7 @@
 
 use crate::document::edit::{is_valid_field_name, EditError};
 use crate::document::meta::is_valid_kind_name;
-use crate::document::{Card, Document};
+use crate::document::{Card, Codec, Document};
 use crate::value::QuillValue;
 use crate::version::QuillReference;
 use std::str::FromStr;
@@ -338,7 +338,7 @@ fn test_overwrite_field_sets_directly() {
 
     let mut card = Card::new("note").unwrap();
     card.overwrite_field("intro", content.clone()).unwrap();
-    let read = card.field_richtext("intro").unwrap().unwrap();
+    let read = card.field_content("intro", Codec::Richtext).unwrap().unwrap();
     assert_eq!(read, content);
     assert!(read.marks.iter().any(|m| matches!(m.kind, MarkKind::Underline)));
 
@@ -358,14 +358,14 @@ fn test_revise_field_diff_imports_and_returns_delta() {
     let delta = card.revise_field("intro", "hello target world").unwrap();
     assert!(!delta.ops.is_empty());
 
-    let mut base = card.field_richtext("intro").unwrap().unwrap();
+    let mut base = card.field_content("intro", Codec::Richtext).unwrap().unwrap();
     // 6..12 is "target".
     base.marks
         .push(Mark::new(6, 12, MarkKind::Anchor { id: "c1".into() }));
     base.normalize();
     card.overwrite_field("intro", base).unwrap();
     card.revise_field("intro", "why keep the target here").unwrap();
-    let read = card.field_richtext("intro").unwrap().unwrap();
+    let read = card.field_content("intro", Codec::Richtext).unwrap().unwrap();
     assert!(read
         .marks
         .iter()
@@ -396,7 +396,7 @@ fn test_revise_field_checked_preserves_anchors_and_enforces_inline() {
         .unwrap();
     assert!(!delta.ops.is_empty());
 
-    let mut base = card.field_richtext("subject").unwrap().unwrap();
+    let mut base = card.field_content("subject", Codec::Richtext).unwrap().unwrap();
     // 6..12 is "target".
     base.marks
         .push(Mark::new(6, 12, MarkKind::Anchor { id: "c1".into() }));
@@ -404,7 +404,7 @@ fn test_revise_field_checked_preserves_anchors_and_enforces_inline() {
     card.overwrite_field("subject", base).unwrap();
     card.revise_field_checked("subject", "why keep the target here", &inline)
         .unwrap();
-    let read = card.field_richtext("subject").unwrap().unwrap();
+    let read = card.field_content("subject", Codec::Richtext).unwrap().unwrap();
     assert!(
         read.marks
             .iter()
@@ -412,19 +412,19 @@ fn test_revise_field_checked_preserves_anchors_and_enforces_inline() {
         "anchor should rebase onto surviving text, unlike the cold commit_field"
     );
 
-    let before = card.field_markdown("subject").unwrap().unwrap();
+    let before = card.field_text("subject", Codec::Richtext).unwrap().unwrap();
     let err = card
         .revise_field_checked("subject", "line one\n\nline two", &inline)
         .unwrap_err();
     assert_eq!(err.code(), "edit::field_not_inline");
-    assert_eq!(card.field_markdown("subject").unwrap().unwrap(), before);
+    assert_eq!(card.field_text("subject", Codec::Richtext).unwrap().unwrap(), before);
 
     let block = FieldSchema::new("body".to_string(), FieldType::RichText { inline: false }, None);
     let d = card
         .revise_field_checked("body", "para one\n\npara two", &block)
         .unwrap();
     assert!(!d.ops.is_empty());
-    assert!(card.field_markdown("body").unwrap().unwrap().contains("para two"));
+    assert!(card.field_text("body", Codec::Richtext).unwrap().unwrap().contains("para two"));
 }
 
 #[test]
@@ -440,7 +440,7 @@ fn test_commit_field_richtext_content_object_reads_back() {
     commit_richtext(&mut card, "intro", &json, false).unwrap();
 
     assert!(card.payload().get("intro").unwrap().as_json().is_object());
-    let read = card.field_richtext("intro").unwrap().unwrap();
+    let read = card.field_content("intro", Codec::Richtext).unwrap().unwrap();
     assert_eq!(read, content);
     assert!(read.marks.iter().any(|m| matches!(m.kind, MarkKind::Underline)));
 }
@@ -450,11 +450,11 @@ fn test_commit_field_richtext_markdown_null_and_rejects_bad() {
     let mut card = Card::new("note").unwrap();
 
     commit_richtext(&mut card, "intro", &serde_json::json!("**bold** intro"), false).unwrap();
-    assert_eq!(card.field_markdown("intro").unwrap().unwrap(), "**bold** intro");
+    assert_eq!(card.field_text("intro", Codec::Richtext).unwrap().unwrap(), "**bold** intro");
 
     commit_richtext(&mut card, "intro", &serde_json::Value::Null, false).unwrap();
     assert!(card.payload().get("intro").unwrap().as_json().is_null());
-    assert!(card.field_richtext("intro").unwrap().unwrap().is_blank());
+    assert!(card.field_content("intro", Codec::Richtext).unwrap().unwrap().is_blank());
 
     assert_eq!(
         commit_richtext(&mut card, "intro", &serde_json::json!({ "not": "a content" }), false)
@@ -475,7 +475,7 @@ fn test_commit_field_richtext_inline_enforced_at_write() {
     let mut card = Card::new("note").unwrap();
 
     commit_richtext(&mut card, "title", &serde_json::json!("A single line"), true).unwrap();
-    assert_eq!(card.field_markdown("title").unwrap().unwrap(), "A single line");
+    assert_eq!(card.field_text("title", Codec::Richtext).unwrap().unwrap(), "A single line");
 
     let err = commit_richtext(
         &mut card,
@@ -485,7 +485,7 @@ fn test_commit_field_richtext_inline_enforced_at_write() {
     )
     .unwrap_err();
     assert_eq!(err.code(), "edit::field_not_inline");
-    assert_eq!(card.field_markdown("title").unwrap().unwrap(), "A single line");
+    assert_eq!(card.field_text("title", Codec::Richtext).unwrap().unwrap(), "A single line");
 }
 
 #[test]
@@ -577,14 +577,14 @@ fn test_commit_field_rejects_bad_name() {
 }
 
 #[test]
-fn test_field_richtext_absent_and_non_richtext() {
+fn test_field_content_absent_and_non_content() {
     let mut card = Card::new("note").unwrap();
-    assert!(card.field_richtext("missing").is_none());
-    assert!(card.field_markdown("missing").is_none());
+    assert!(card.field_content("missing", Codec::Richtext).is_none());
+    assert!(card.field_text("missing", Codec::Richtext).is_none());
 
     card.store_field("count", 3).unwrap();
-    assert!(card.field_richtext("count").unwrap().is_err());
-    assert!(card.field_markdown("count").unwrap().is_err());
+    assert!(card.field_content("count", Codec::Richtext).unwrap().is_err());
+    assert!(card.field_text("count", Codec::Richtext).unwrap().is_err());
 }
 
 #[test]
@@ -764,7 +764,7 @@ fn test_apply_field_change_splices_and_persists() {
     .unwrap();
 
     assert!(card.payload().get("intro").unwrap().as_json().is_object());
-    let rt = card.field_richtext("intro").unwrap().unwrap();
+    let rt = card.field_content("intro", Codec::Richtext).unwrap().unwrap();
     assert_eq!(rt.text, "abXc");
     assert!(rt.marks.iter().any(|m| matches!(m.kind, MarkKind::Strong)));
 }
@@ -788,7 +788,7 @@ fn test_apply_field_change_treats_an_absent_field_as_empty() {
     let mut card = Card::new("note").unwrap();
     card.apply_field_change("intro", &ChangeBundle::default())
         .expect("a zero-base bundle lands on the empty content");
-    assert_eq!(card.field_markdown("intro").unwrap().unwrap(), "");
+    assert_eq!(card.field_text("intro", Codec::Richtext).unwrap().unwrap(), "");
 
     let stale = ChangeBundle {
         delta: quillmark_content::Delta {

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -295,7 +295,7 @@ fn body_from_wire(body: &JsonValue) -> Result<Content, WireError> {
         key: "$body".to_string(),
         reason,
     };
-    match super::decode_richtext_value(body) {
+    match super::Codec::Richtext.decode_value(body) {
         Some(result) => result.map_err(|e| invalid(e.into_message())),
         None => match body {
             JsonValue::Null => Ok(Content::empty()),
@@ -333,6 +333,7 @@ fn validate_wire_field(key: &str, value: &JsonValue) -> Result<(), WireError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::document::Codec;
     use serde_json::json;
 
     /// Nested `!must_fill` markers inside a field value survive Card → wire →
@@ -390,7 +391,7 @@ mod tests {
 
         let back = Card::try_from(wire).expect("wire → card");
         assert_eq!(back, card, "content field must survive Card → wire → Card");
-        let read = back.field_richtext("intro").unwrap().unwrap();
+        let read = back.field_content("intro", Codec::Richtext).unwrap().unwrap();
         assert!(read.marks.iter().any(|m| matches!(m.kind, MarkKind::Underline)));
     }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -454,6 +454,15 @@ impl RenderError {
         Self { diags: vec![diag] }
     }
 
+    /// A failure carrying one error diagnostic under `code`, the shape most
+    /// engine-side refusals take. A diagnostic needing a hint, a path or args
+    /// builds one and goes through [`from_diag`](Self::from_diag).
+    pub fn coded(code: &str, message: impl Into<String>) -> Self {
+        Self::from_diag(
+            Diagnostic::new(Severity::Error, message.into()).with_code(code.to_string()),
+        )
+    }
+
     pub fn diagnostics(&self) -> &[Diagnostic] {
         &self.diags
     }

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -268,24 +268,25 @@ fn append_scalar(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
     items.push(PayloadItem::comment_inline(type_expression(field)));
 }
 
-/// Build the per-property body of a defaultless typed container: the value
-/// mapping (each property at its own cell, in declaration order), the nested
-/// comments (description + `# e.g.` + inline type annotation, addressed by
-/// `container_path`/slot), and the nested fill paths. `prefix` is the container
+/// Build the per-property body of a defaultless typed container into `map`:
+/// each property at its own cell in declaration order, plus the nested comments
+/// (description + `# e.g.` + inline type annotation, addressed by
+/// `container_path`/slot) and the nested fill paths. `prefix` is the container
 /// path of the mapping relative to the field value (`[]` for a typed dict,
 /// `[Index(0)]` for a typed table's synthetic row).
+///
+/// A property's slot is where it lands in `map`, so a caller seating its own
+/// cell first (a variant's discriminant) shifts the rest by handing over a
+/// mapping that already holds it.
 fn build_property_mapping(
+    map: &mut JsonMap<String, JsonValue>,
     props: &IndexMap<String, Box<FieldSchema>>,
     prefix: &[PathSegment],
-) -> (
-    JsonMap<String, JsonValue>,
-    Vec<NestedComment>,
-    Vec<Vec<PathSegment>>,
-) {
-    let mut map = JsonMap::new();
+) -> (Vec<NestedComment>, Vec<Vec<PathSegment>>) {
     let mut nested = Vec::new();
     let mut fills = Vec::new();
-    for (slot, prop) in props.values().map(|b| b.as_ref()).enumerate() {
+    for prop in props.values().map(|b| b.as_ref()) {
+        let slot = map.len();
         if let Some(desc) = collapse_opt(&prop.description) {
             nested.push(NestedComment {
                 container_path: prefix.to_vec(),
@@ -318,7 +319,7 @@ fn build_property_mapping(
             inline: true,
         });
     }
-    (map, nested, fills)
+    (nested, fills)
 }
 
 /// One property's contribution to its parent's mapping: its value, and the
@@ -348,7 +349,8 @@ fn container_cell(
     path: &[PathSegment],
 ) -> (JsonValue, Vec<NestedComment>, Vec<Vec<PathSegment>>) {
     if let Some(props) = typed_dict_props(field) {
-        let (map, nested, fills) = build_property_mapping(props, path);
+        let mut map = JsonMap::new();
+        let (nested, fills) = build_property_mapping(&mut map, props, path);
         return (JsonValue::Object(map), nested, fills);
     }
 
@@ -364,7 +366,8 @@ fn container_cell(
         None => {
             let mut row_path = path.to_vec();
             row_path.push(PathSegment::Index(0));
-            let (row, nested, fills) = build_property_mapping(row_props, &row_path);
+            let mut row = JsonMap::new();
+            let (nested, fills) = build_property_mapping(&mut row, row_props, &row_path);
             (
                 JsonValue::Array(vec![JsonValue::Object(row)]),
                 nested,
@@ -401,7 +404,6 @@ fn append_variant(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
 
     let member = scalar_value(field);
     let mut map = JsonMap::new();
-    let mut nested = Vec::new();
     let mut fills = Vec::new();
     map.insert(
         VARIANT_DISCRIMINANT_KEY.to_string(),
@@ -416,42 +418,18 @@ fn append_variant(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
         fills.push(vec![PathSegment::Key(VARIANT_DISCRIMINANT_KEY.to_string())]);
     }
 
+    // A cell is a field of the container, so it expands as one: the mapping
+    // already holding the discriminant is what seats the live world one slot
+    // past it.
     let live = member.as_str().and_then(|m| field.variant_fields(m));
-    if let Some(fields) = live {
-        for (slot, prop) in fields.values().map(|b| b.as_ref()).enumerate() {
-            // Slot 0 is the discriminant, so every variant field sits one past it.
-            let position = slot + 1;
-            if let Some(desc) = collapse_opt(&prop.description) {
-                nested.push(NestedComment {
-                    container_path: Vec::new(),
-                    position,
-                    text: desc,
-                    inline: false,
-                });
-            }
-            if prop.default.is_some() {
-                if let Some(eg) = prop.example.as_ref() {
-                    nested.push(NestedComment {
-                        container_path: Vec::new(),
-                        position,
-                        text: format!("e.g. {}", eg_hint(eg)),
-                        inline: false,
-                    });
-                }
-            }
-            let (json, fill) = scalar_cell(prop);
-            map.insert(prop.name.clone(), json);
-            if fill {
-                fills.push(vec![PathSegment::Key(prop.name.clone())]);
-            }
-            nested.push(NestedComment {
-                container_path: Vec::new(),
-                position,
-                text: type_expression(prop),
-                inline: true,
-            });
+    let nested = match live {
+        Some(fields) => {
+            let (nested, sub_fills) = build_property_mapping(&mut map, fields, &[]);
+            fills.extend(sub_fills);
+            nested
         }
-    }
+        None => Vec::new(),
+    };
 
     push_container_field(
         items,

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -596,37 +596,40 @@ impl QuillConfig {
                 // literal / validation sites): the string branch below reduces a
                 // bare scalar or length-1 array to text before importing, which
                 // the strict decoder must not do, so it stays open-coded here.
+                let inline_err = || {
+                    CoercionError::uncoercible(
+                        path,
+                        "<richtext>",
+                        "richtext(inline)",
+                        "richtext(inline) requires a single paragraph line \
+                             with no list/quote container and no islands",
+                    )
+                };
                 let inline_check =
                     |rt: &quillmark_content::Content| -> Result<(), CoercionError> {
                         if inline && !rt.is_inline() {
-                            return Err(CoercionError::uncoercible(
-                                path,
-                                "<richtext>",
-                                "richtext(inline)",
-                                "richtext(inline) requires a single paragraph line \
-                                     with no list/quote container and no islands",
-                            ));
+                            return Err(inline_err());
                         }
                         Ok(())
                     };
-                // A strict write uses `decode_richtext_value` semantics: a
+                // A strict write is `document::canonical_richtext_value`: a
                 // canonical content object or a markdown string, nothing else. No
                 // scalar→string reduction (the render floor's lenient cascade
                 // below): a bare scalar for a richtext field fails the write. The
                 // messages mirror `Card::commit_field`'s richtext error variants,
                 // which the bindings key on.
                 if mode == Leniency::Write {
-                    let content = match crate::document::decode_richtext_value(json_value) {
-                        Some(result) => result.map_err(|e| {
-                            CoercionError::uncoercible(
+                    use crate::document::RichtextValueError as E;
+                    return crate::document::canonical_richtext_value(json_value, inline)
+                        .map(QuillValue::from_json)
+                        .map_err(|e| match e {
+                            E::Decode(e) => CoercionError::uncoercible(
                                 path,
                                 "<richtext>",
                                 "richtext",
                                 e.into_message(),
-                            )
-                        })?,
-                        None => {
-                            return Err(CoercionError::uncoercible(
+                            ),
+                            E::Unshaped => CoercionError::uncoercible(
                                 path,
                                 json_value,
                                 "richtext",
@@ -639,13 +642,9 @@ impl QuillConfig {
                                         _ => "an unsupported value",
                                     }
                                 ),
-                            ));
-                        }
-                    };
-                    inline_check(&content)?;
-                    return Ok(QuillValue::from_json(
-                        quillmark_content::serial::to_canonical_value(&content),
-                    ));
+                            ),
+                            E::NotInline => inline_err(),
+                        });
                 }
                 if json_value.is_object() {
                     let rt = quillmark_content::serial::from_canonical_value(json_value).map_err(
@@ -2282,32 +2281,22 @@ fn literal_content(
     }
     match &field.r#type {
         FieldType::RichText { inline } => {
-            let rt = match crate::document::decode_richtext_value(json) {
-                Some(Ok(rt)) => rt,
-                Some(Err(e)) => {
-                    let reason = match e {
-                        crate::document::RichtextDecodeError::BadMarkdown(m) => {
-                            format!("markdown import failed: {m}")
-                        }
-                        crate::document::RichtextDecodeError::NotContent(m) => {
-                            format!("not a valid richtext content: {m}")
-                        }
-                    };
-                    return Err(richtext_literal_error(label, &reason));
-                }
-                None => {
-                    return Err(richtext_literal_error(
+            use crate::document::{RichtextDecodeError as D, RichtextValueError as E};
+            crate::document::canonical_richtext_value(json, *inline)
+                .map(|content| Some(QuillValue::from_json(content)))
+                .map_err(|e| match e {
+                    E::Decode(D::BadMarkdown(m)) => {
+                        richtext_literal_error(label, &format!("markdown import failed: {m}"))
+                    }
+                    E::Decode(D::NotContent(m)) => {
+                        richtext_literal_error(label, &format!("not a valid richtext content: {m}"))
+                    }
+                    E::Unshaped => richtext_literal_error(
                         label,
                         "expected a markdown string (richtext literals are authored as markdown)",
-                    ));
-                }
-            };
-            if *inline && !rt.is_inline() {
-                return Err(richtext_inline_error(label));
-            }
-            Ok(Some(QuillValue::from_json(
-                quillmark_content::serial::to_canonical_value(&rt),
-            )))
+                    ),
+                    E::NotInline => richtext_inline_error(label),
+                })
         }
         FieldType::PlainText { inline } => {
             // Plaintext literals are authored as literal strings and imported

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -591,11 +591,12 @@ impl QuillConfig {
                 // surface, so multi-block content is a coercion error here, in
                 // lockstep with the validation-layer `validation::not_inline` check.
                 //
-                // This is the deliberately-lenient sibling of
-                // `document::Codec::Richtext.decode_value` (used by the strict wire /
-                // literal / validation sites): the string branch below reduces a
-                // bare scalar or length-1 array to text before importing, which
-                // the strict decoder must not do, so it stays open-coded here.
+                // This is the deliberately-lenient sibling of the strict
+                // decoders: `document::canonical_richtext_value` at the write
+                // and literal sites, `Codec::Richtext.decode_value` at the wire
+                // and validation sites. The string branch below reduces a bare
+                // scalar or length-1 array to text before importing, which a
+                // strict decoder must not do, so it stays open-coded here.
                 let inline_err = || {
                     CoercionError::uncoercible(
                         path,
@@ -612,12 +613,8 @@ impl QuillConfig {
                         }
                         Ok(())
                     };
-                // A strict write is `document::canonical_richtext_value`: a
-                // canonical content object or a markdown string, nothing else. No
-                // scalar→string reduction (the render floor's lenient cascade
-                // below): a bare scalar for a richtext field fails the write. The
-                // messages mirror `Card::commit_field`'s richtext error variants,
-                // which the bindings key on.
+                // The messages mirror `Card::commit_field`'s richtext error
+                // variants, which the bindings key on.
                 if mode == Leniency::Write {
                     use crate::document::RichtextValueError as E;
                     return crate::document::canonical_richtext_value(json_value, inline)

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -303,7 +303,7 @@ impl QuillConfig {
     ///
     /// Validation keeps its own read-only dispatch (`validation::validate_value`),
     /// synced with this via the shared helpers `scalar_as_string` /
-    /// `decode_richtext_value`.
+    /// `Codec::Richtext.decode_value`.
     pub(crate) fn conform_value(
         value: &QuillValue,
         field_schema: &super::FieldSchema,
@@ -592,7 +592,7 @@ impl QuillConfig {
                 // lockstep with the validation-layer `validation::not_inline` check.
                 //
                 // This is the deliberately-lenient sibling of
-                // `document::decode_richtext_value` (used by the strict wire /
+                // `document::Codec::Richtext.decode_value` (used by the strict wire /
                 // literal / validation sites): the string branch below reduces a
                 // bare scalar or length-1 array to text before importing, which
                 // the strict decoder must not do, so it stays open-coded here.
@@ -609,14 +609,14 @@ impl QuillConfig {
                         }
                         Ok(())
                     };
-                // A strict write uses `decode_richtext_value` semantics: a
+                // A strict write uses `Codec::Richtext.decode_value` semantics: a
                 // canonical content object or a markdown string, nothing else. No
                 // scalar→string reduction (the render floor's lenient cascade
                 // below): a bare scalar for a richtext field fails the write. The
                 // messages mirror `Card::commit_field`'s richtext error variants,
                 // which the bindings key on.
                 if mode == Leniency::Write {
-                    let content = match crate::document::decode_richtext_value(json_value) {
+                    let content = match crate::document::Codec::Richtext.decode_value(json_value) {
                         Some(result) => result.map_err(|e| {
                             CoercionError::uncoercible(
                                 path,
@@ -2282,14 +2282,14 @@ fn literal_content(
     }
     match &field.r#type {
         FieldType::RichText { inline } => {
-            let rt = match crate::document::decode_richtext_value(json) {
+            let rt = match crate::document::Codec::Richtext.decode_value(json) {
                 Some(Ok(rt)) => rt,
                 Some(Err(e)) => {
                     let reason = match e {
-                        crate::document::RichtextDecodeError::BadMarkdown(m) => {
+                        crate::document::ContentDecodeError::BadMarkdown(m) => {
                             format!("markdown import failed: {m}")
                         }
-                        crate::document::RichtextDecodeError::NotContent(m) => {
+                        crate::document::ContentDecodeError::NotContent(m) => {
                             format!("not a valid richtext content: {m}")
                         }
                     };
@@ -2314,12 +2314,12 @@ fn literal_content(
             // verbatim (never markdown), so the cached content is plain by
             // construction; a content-object literal is revalidated. Shares the
             // one object-vs-string dispatch with the validation shape check.
-            let rt = match crate::document::decode_plaintext_value(json) {
+            let rt = match crate::document::Codec::Plaintext.decode_value(json) {
                 Some(Ok(rt)) => rt,
                 Some(Err(e)) => {
                     return Err(richtext_literal_error(
                         label,
-                        &format!("not a valid richtext content: {e}"),
+                        &format!("not a valid richtext content: {}", e.into_message()),
                     ))
                 }
                 None => {

--- a/crates/core/src/quill/ignore.rs
+++ b/crates/core/src/quill/ignore.rs
@@ -1,10 +1,33 @@
 //! .quillignore parsing and path matching.
 use std::path::Path;
 
-/// Simple gitignore-style pattern matcher for .quillignore
+use glob::{MatchOptions, Pattern};
+
+/// `*` stops at a path separator, so a pattern spans one path segment unless it
+/// spells the separators out — the gitignore reading of a `.quillignore` line.
+const MATCH: MatchOptions = MatchOptions {
+    case_sensitive: true,
+    require_literal_separator: true,
+    require_literal_leading_dot: false,
+};
+
+/// Gitignore-style pattern matcher for .quillignore
 #[derive(Debug, Clone)]
 pub struct QuillIgnore {
-    pub(crate) patterns: Vec<String>,
+    rules: Vec<Rule>,
+}
+
+/// One `.quillignore` line, parsed once at construction.
+#[derive(Debug, Clone)]
+enum Rule {
+    /// `dir/`: the entry itself and everything beneath it.
+    Dir(String),
+    /// A literal name: the whole path, or the basename at any depth.
+    Name(String),
+    /// A glob, matched against the whole path and against the basename, so a
+    /// slash-free pattern applies at any depth and a slashed one is anchored
+    /// at the bundle root. As in gitignore, `*` does not cross `/`.
+    Glob(Pattern),
 }
 
 impl Default for QuillIgnore {
@@ -24,65 +47,60 @@ impl Default for QuillIgnore {
 impl QuillIgnore {
     /// Create a new QuillIgnore from pattern strings
     pub fn new(patterns: Vec<String>) -> Self {
-        Self { patterns }
+        Self {
+            rules: patterns.into_iter().map(Rule::parse).collect(),
+        }
     }
 
     /// Parse .quillignore content into patterns
     pub fn from_content(content: &str) -> Self {
-        let patterns = content
-            .lines()
-            .map(|line| line.trim())
-            .filter(|line| !line.is_empty() && !line.starts_with('#'))
-            .map(|line| line.to_string())
-            .collect();
-        Self::new(patterns)
+        Self::new(
+            content
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty() && !line.starts_with('#'))
+                .map(str::to_string)
+                .collect(),
+        )
     }
 
     /// Check if a path should be ignored
     pub fn is_ignored<P: AsRef<Path>>(&self, path: P) -> bool {
-        let path = path.as_ref();
-        let path_str = path.to_string_lossy();
+        let path = path
+            .as_ref()
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
+        let basename = path.rsplit_once('/').map_or(path.as_str(), |(_, name)| name);
+        self.rules.iter().any(|rule| rule.matches(&path, basename))
+    }
+}
 
-        for pattern in &self.patterns {
-            if self.matches_pattern(pattern, &path_str) {
-                return true;
-            }
+impl Rule {
+    fn parse(pattern: String) -> Self {
+        if let Some(prefix) = pattern.strip_suffix('/') {
+            return Rule::Dir(prefix.to_string());
         }
-        false
+        if !pattern.contains(['*', '?', '[']) {
+            return Rule::Name(pattern);
+        }
+        match Pattern::new(&pattern) {
+            Ok(glob) => Rule::Glob(glob),
+            // An unparseable glob still matches the name it spells out.
+            Err(_) => Rule::Name(pattern),
+        }
     }
 
-    /// Simple pattern matching (supports * wildcard and directory patterns)
-    fn matches_pattern(&self, pattern: &str, path: &str) -> bool {
-        // Handle directory patterns
-        if let Some(pattern_prefix) = pattern.strip_suffix('/') {
-            return path.starts_with(pattern_prefix)
-                && (path.len() == pattern_prefix.len()
-                    || path.chars().nth(pattern_prefix.len()) == Some('/'));
-        }
-
-        // Handle exact matches
-        if !pattern.contains('*') {
-            return path == pattern || path.ends_with(&format!("/{}", pattern));
-        }
-
-        // Simple wildcard matching
-        if pattern == "*" {
-            return true;
-        }
-
-        // Handle patterns with wildcards
-        let pattern_parts: Vec<&str> = pattern.split('*').collect();
-        if pattern_parts.len() == 2 {
-            let (prefix, suffix) = (pattern_parts[0], pattern_parts[1]);
-            if prefix.is_empty() {
-                return path.ends_with(suffix);
-            } else if suffix.is_empty() {
-                return path.starts_with(prefix);
-            } else {
-                return path.starts_with(prefix) && path.ends_with(suffix);
+    fn matches(&self, path: &str, basename: &str) -> bool {
+        match self {
+            Rule::Dir(prefix) => path
+                .strip_prefix(prefix.as_str())
+                .is_some_and(|rest| rest.is_empty() || rest.starts_with('/')),
+            Rule::Name(name) => path == name || basename == name,
+            Rule::Glob(glob) => {
+                glob.matches_with(path, MATCH) || glob.matches_with(basename, MATCH)
             }
         }
-
-        false
     }
 }

--- a/crates/core/src/quill/ignore.rs
+++ b/crates/core/src/quill/ignore.rs
@@ -27,7 +27,12 @@ enum Rule {
     /// A glob, matched against the whole path and against the basename, so a
     /// slash-free pattern applies at any depth and a slashed one is anchored
     /// at the bundle root. As in gitignore, `*` does not cross `/`.
-    Glob(Pattern),
+    ///
+    /// The line it was written as matches too: `[` opens a character class and
+    /// is also an ordinary character in a filename, so `Cinzel[wght].ttf` names
+    /// both a glob over `Cinzelw.ttf`/`Cinzelg.ttf`/… and the variable font
+    /// sitting in the usaf_memo fixture. Both readings ignore.
+    Glob(Pattern, String),
 }
 
 impl Default for QuillIgnore {
@@ -86,7 +91,7 @@ impl Rule {
             return Rule::Name(pattern);
         }
         match Pattern::new(&pattern) {
-            Ok(glob) => Rule::Glob(glob),
+            Ok(glob) => Rule::Glob(glob, pattern),
             // An unparseable glob still matches the name it spells out.
             Err(_) => Rule::Name(pattern),
         }
@@ -98,8 +103,11 @@ impl Rule {
                 .strip_prefix(prefix.as_str())
                 .is_some_and(|rest| rest.is_empty() || rest.starts_with('/')),
             Rule::Name(name) => path == name || basename == name,
-            Rule::Glob(glob) => {
-                glob.matches_with(path, MATCH) || glob.matches_with(basename, MATCH)
+            Rule::Glob(glob, raw) => {
+                path == raw
+                    || basename == raw
+                    || glob.matches_with(path, MATCH)
+                    || glob.matches_with(basename, MATCH)
             }
         }
     }

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -122,6 +122,20 @@ fn test_quillignore_wildcard_does_not_cross_slash() {
     assert!(!ignore.is_ignored("vendor/assets/logo.png"));
 }
 
+/// `[` opens a glob character class and is an ordinary character in a filename,
+/// so a line spelling one out ignores the file it names as well as the class it
+/// describes. The variable font in the usaf_memo fixture is spelled this way.
+#[test]
+fn test_quillignore_bracketed_name_ignores_the_file_it_spells() {
+    let ignore = QuillIgnore::new(vec!["Cinzel[wght].ttf".to_string()]);
+
+    assert!(ignore.is_ignored("Cinzel[wght].ttf"));
+    assert!(ignore.is_ignored("fonts/Cinzel/Cinzel[wght].ttf"));
+    // The character-class reading survives alongside it.
+    assert!(ignore.is_ignored("Cinzelw.ttf"));
+    assert!(!ignore.is_ignored("Cinzel.ttf"));
+}
+
 #[test]
 fn test_quillignore_matching() {
     let ignore = QuillIgnore::new(vec![

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -87,9 +87,39 @@ node_modules/
 .git/
 "#;
     let ignore = QuillIgnore::from_content(ignore_content);
-    assert_eq!(ignore.patterns.len(), 4);
-    assert!(ignore.patterns.contains(&"*.tmp".to_string()));
-    assert!(ignore.patterns.contains(&"target/".to_string()));
+    assert!(ignore.is_ignored("scratch.tmp"));
+    assert!(ignore.is_ignored("target/debug"));
+    assert!(!ignore.is_ignored("# This is a comment"));
+    // A blank line is not a rule that swallows everything.
+    assert!(!ignore.is_ignored("plate.typ"));
+}
+
+#[test]
+fn test_quillignore_multiple_wildcards() {
+    let ignore = QuillIgnore::new(vec![
+        "**/*.tmp".to_string(),
+        "*.sublime-*".to_string(),
+        "a*b*c".to_string(),
+    ]);
+
+    assert!(ignore.is_ignored("scratch.tmp"));
+    assert!(ignore.is_ignored("deep/nested/scratch.tmp"));
+    assert!(!ignore.is_ignored("scratch.txt"));
+
+    assert!(ignore.is_ignored("quill.sublime-project"));
+    assert!(ignore.is_ignored("editor/quill.sublime-workspace"));
+
+    assert!(ignore.is_ignored("axbxc"));
+    assert!(!ignore.is_ignored("axbx"));
+}
+
+#[test]
+fn test_quillignore_wildcard_does_not_cross_slash() {
+    let ignore = QuillIgnore::new(vec!["assets/*.png".to_string()]);
+
+    assert!(ignore.is_ignored("assets/logo.png"));
+    assert!(!ignore.is_ignored("assets/icons/logo.png"));
+    assert!(!ignore.is_ignored("vendor/assets/logo.png"));
 }
 
 #[test]

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2358,6 +2358,21 @@ fn inline_richtext_example_over_one_para_is_a_load_error() {
     );
 }
 
+/// A richtext literal is authored as markdown or as a canonical content object;
+/// a bare scalar is neither, and the load error says so rather than importing
+/// the scalar's text.
+#[test]
+fn a_bare_scalar_richtext_example_is_a_load_error() {
+    let err = quill_with_field("    tag:\n      type: richtext\n      example: 47\n").unwrap_err();
+    assert!(
+        err.iter().any(|d| {
+            d.code.as_deref() == Some("quill::richtext_example_import")
+                && d.message.contains("expected a markdown string")
+        }),
+        "a numeric richtext example should fail load naming the encoding, got: {err:?}"
+    );
+}
+
 #[test]
 fn inline_richtext_single_line_example_loads_and_caches_content() {
     let config = quill_with_field(

--- a/crates/core/src/quill/tests/variant_tests.rs
+++ b/crates/core/src/quill/tests/variant_tests.rs
@@ -608,6 +608,84 @@ fn the_blueprint_emits_the_default_worlds_cells_and_round_trips() {
     assert!(value.get("controlled_by").is_some());
 }
 
+/// A cell holds a container like any field, so the blueprint expands one per
+/// property. A flattened cell would hand the author a scalar slot where the
+/// schema wants a mapping, drop every property's own description and `default:`,
+/// and stamp the marker on a path the obligation predicate never addresses.
+#[test]
+fn the_blueprint_expands_a_container_cell_per_property() {
+    const YAML: &str = r#"
+quill:
+  name: variant_container
+  version: "0.1.0"
+  backend: typst
+  description: variant container probe
+
+typst:
+  plate_file: plate.typ
+
+main:
+  fields:
+    classification:
+      type: enum
+      values: [UNCLASSIFIED, CUI]
+      default: CUI
+      variants:
+        CUI:
+          controlled_by:
+            type: object
+            description: Controlling office.
+            properties:
+              office: { type: string, description: Office symbol. }
+              phone: { type: string, default: "" }
+          citations:
+            type: array
+            items:
+              type: object
+              properties:
+                src: { type: string }
+"#;
+    let bp = QuillConfig::from_yaml(YAML).expect("loads").blueprint();
+    assert!(
+        bp.contains(concat!(
+            "  # Controlling office.\n",
+            "  controlled_by: # object\n",
+            "    # Office symbol.\n",
+            "    office: !must_fill # string\n",
+            "    phone: \"\" # string\n",
+            "  citations: # array<object>\n",
+            "    - src: !must_fill # string\n",
+        )),
+        "{bp}"
+    );
+
+    // The marked cells are the cells the schema-side predicate warns at: a
+    // container is a namespace on both surfaces, never a cell on either.
+    let document = Document::parse(&bp).expect("the blueprint parses").document;
+    let warned: Vec<String> = quill_from_yaml(YAML)
+        .validate(&document)
+        .into_iter()
+        .filter(|d| d.code.as_deref() == Some("validation::must_fill"))
+        .filter_map(|d| d.path)
+        .collect();
+    assert!(
+        warned.contains(&"main.classification.controlled_by.office".to_string())
+            && warned.contains(&"main.classification.citations[0].src".to_string()),
+        "{warned:?}"
+    );
+    assert!(
+        !warned
+            .iter()
+            .any(|p| p == "main.classification.controlled_by"),
+        "{warned:?}"
+    );
+
+    let reparsed = Document::parse(&document.to_markdown())
+        .expect("re-emit parses")
+        .document;
+    assert_eq!(document, reparsed, "the expansion round-trips");
+}
+
 /// Which world is live decides which fields are even candidates, so the
 /// discriminant must resolve before the field set is walked.
 #[test]

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -559,8 +559,9 @@ fn validate_value(
     if type_valid {
         match field.r#type {
             FieldType::RichText { inline: true } => {
-                let parsed =
-                    crate::document::decode_richtext_value(value.as_json()).and_then(Result::ok);
+                let parsed = crate::document::Codec::Richtext
+                    .decode_value(value.as_json())
+                    .and_then(Result::ok);
                 if let Some(rt) = parsed {
                     if !rt.is_inline() {
                         errors.push(ValidationError::NotInline {
@@ -575,7 +576,8 @@ fn validate_value(
                 // a canonical content object. The plain constraint is primary;
                 // the single-line constraint applies only when `inline`. A decode
                 // error is another layer's to report (swallowed via `.ok()`).
-                if let Some(rt) = crate::document::decode_plaintext_value(value.as_json())
+                if let Some(rt) = crate::document::Codec::Plaintext
+                    .decode_value(value.as_json())
                     .and_then(Result::ok)
                 {
                     if !rt.is_plain() {

--- a/crates/core/src/reader.rs
+++ b/crates/core/src/reader.rs
@@ -37,8 +37,8 @@
 use indexmap::IndexMap;
 use quillmark_content::Content;
 
-use crate::document::edit::{CODEC_PLAINTEXT, CODEC_RICHTEXT};
-use crate::document::{Card, Document, EditError, RichtextDecodeError};
+use crate::document::edit::field_decode;
+use crate::document::{Card, Codec, Document, EditError};
 use crate::quill::{CardSchema, FieldSchema, FieldType, QuillConfig};
 use crate::value::{PathSegment, QuillValue};
 
@@ -208,23 +208,16 @@ fn read_field(
     let schema = fields_schema
         .and_then(|m| m.get(name))
         .ok_or_else(|| EditError::unknown_field(name))?;
-    match schema.r#type {
-        FieldType::RichText { .. } => project(
-            card.field_markdown(name),
-            name,
-            CODEC_RICHTEXT,
-            ReadValue::Markdown,
-        ),
-        FieldType::PlainText { .. } => project(
-            card.field_plaintext(name),
-            name,
-            CODEC_PLAINTEXT,
-            ReadValue::Plaintext,
-        ),
-        _ => Ok(card
-            .payload()
-            .get(name)
-            .map(|v| ReadValue::Value(v.clone()))),
+    let Some(codec) = content_codec(&schema.r#type) else {
+        return Ok(card.payload().get(name).map(|v| ReadValue::Value(v.clone())));
+    };
+    match card.field_text(name, codec) {
+        None => Ok(None),
+        Some(Ok(text)) => Ok(Some(match codec {
+            Codec::Richtext => ReadValue::Markdown(text),
+            Codec::Plaintext => ReadValue::Plaintext(text),
+        })),
+        Some(Err(e)) => Err(field_decode(name, &[], codec, e)),
     }
 }
 
@@ -246,7 +239,7 @@ fn read_content(
     let leaf = schema_at(field, name, at)?;
     // The codec rides out of the dispatch: it is the declared type's, not the
     // stored shape's.
-    let (decode, codec) = content_codec(&leaf.r#type).ok_or_else(|| EditError::FieldNotContent {
+    let codec = content_codec(&leaf.r#type).ok_or_else(|| EditError::FieldNotContent {
         field: name.to_string(),
         at: at.to_vec(),
         declared: leaf.r#type.as_str().to_string(),
@@ -254,28 +247,20 @@ fn read_content(
     let Some(value) = card.payload().get(name).and_then(|v| value_at(v.as_json(), at)) else {
         return Ok(None);
     };
-    decode(value).map(Some).map_err(|e| EditError::FieldDecode {
-        field: name.to_string(),
-        at: at.to_vec(),
-        codec: codec.to_string(),
-        message: e.into_message(),
-    })
+    codec
+        .decode_field(value)
+        .map(Some)
+        .map_err(|e| field_decode(name, at, codec, e))
 }
 
-type ContentCodec = (
-    fn(&serde_json::Value) -> Result<Content, RichtextDecodeError>,
-    &'static str,
-);
-
 /// The one declared-type → codec dispatch: `None` for a type that is no content
-/// leaf. Every schema-bound [`Content`] read routes through this, so a codec
-/// change reaches the whole-field and the nested read by construction.
-fn content_codec(r#type: &FieldType) -> Option<ContentCodec> {
+/// leaf. Every schema-bound content read routes through this — the whole field,
+/// a nested leaf, and [`get`](TypedReader::get)'s text projection alike — so a
+/// codec change reaches all three by construction.
+fn content_codec(r#type: &FieldType) -> Option<Codec> {
     match r#type {
-        FieldType::RichText { .. } => Some((crate::document::decode_richtext_field, CODEC_RICHTEXT)),
-        FieldType::PlainText { .. } => {
-            Some((crate::document::decode_plaintext_field, CODEC_PLAINTEXT))
-        }
+        FieldType::RichText { .. } => Some(Codec::Richtext),
+        FieldType::PlainText { .. } => Some(Codec::Plaintext),
         _ => None,
     }
 }
@@ -336,28 +321,10 @@ fn value_at<'a>(value: &'a serde_json::Value, at: &[PathSegment]) -> Option<&'a 
     Some(cursor)
 }
 
-/// Lift a codec projection into a [`ReadValue`].
-fn project(
-    projection: Option<Result<String, RichtextDecodeError>>,
-    name: &str,
-    codec: &str,
-    wrap: fn(String) -> ReadValue,
-) -> Result<Option<ReadValue>, EditError> {
-    match projection {
-        None => Ok(None),
-        Some(Ok(text)) => Ok(Some(wrap(text))),
-        Some(Err(e)) => Err(EditError::FieldDecode {
-            field: name.to_string(),
-            at: Vec::new(),
-            codec: codec.to_string(),
-            message: e.into_message(),
-        }),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::document::edit::CODEC_RICHTEXT;
     use crate::document::Document;
     use crate::version::QuillReference;
     use std::str::FromStr;

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -1,7 +1,6 @@
 use crate::quill::QuillConfig;
 use crate::{
     ContentHit, Diagnostic, Document, RenderError, RenderOptions, RenderResult, RenderedRegion,
-    Severity,
 };
 pub use quillmark_content::{ApplyError, Assoc, ChangeBundle, Delta, IslandOp, LineOp, MarkOp, Op};
 use std::sync::OnceLock;
@@ -40,12 +39,9 @@ pub trait SessionHandle: Send + Sync + 'static {
     /// keeps serving it. The returned [`ChangeSet`] reports the pages the edit
     /// visibly changed. Default: update is unsupported.
     fn update(&mut self, _json_data: &serde_json::Value) -> Result<ChangeSet, RenderError> {
-        Err(RenderError::from_diag(
-            Diagnostic::new(
-                Severity::Error,
-                "this backend's session does not support update".to_string(),
-            )
-            .with_code("backend::update_unsupported".to_string()),
+        Err(RenderError::coded(
+            "backend::update_unsupported",
+            "this backend's session does not support update",
         ))
     }
 
@@ -315,6 +311,7 @@ impl LiveSession {
 mod tests {
     use super::*;
     use crate::version::QuillReference;
+    use crate::Severity;
     use std::str::FromStr;
 
     const QUILL_YAML: &str = "\

--- a/crates/core/src/writer.rs
+++ b/crates/core/src/writer.rs
@@ -269,6 +269,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::document::Codec;
     use crate::document::{Card, Document};
     use crate::version::QuillReference;
     use std::str::FromStr;
@@ -313,7 +314,7 @@ card_kinds:
             doc.main().payload().get("qty").unwrap().as_json(),
             &serde_json::json!(3)
         );
-        assert_eq!(doc.main().field_markdown("subject").unwrap().unwrap(), "Hello");
+        assert_eq!(doc.main().field_text("subject", Codec::Richtext).unwrap().unwrap(), "Hello");
     }
 
     #[test]
@@ -355,7 +356,7 @@ card_kinds:
             .unwrap();
         assert_eq!(doc.cards().len(), 1);
         assert_eq!(doc.cards()[0].kind(), Some("note"));
-        assert_eq!(doc.cards()[0].field_markdown("body").unwrap().unwrap(), "**hi**");
+        assert_eq!(doc.cards()[0].field_text("body", Codec::Richtext).unwrap().unwrap(), "**hi**");
         assert_eq!(doc.cards()[0].body_markdown(), "card body");
     }
 
@@ -372,7 +373,7 @@ card_kinds:
         let bodies: Vec<String> = doc
             .cards()
             .iter()
-            .map(|c| c.field_markdown("body").unwrap().unwrap())
+            .map(|c| c.field_text("body", Codec::Richtext).unwrap().unwrap())
             .collect();
         assert_eq!(bodies, ["a", "b", "c"]);
 
@@ -389,7 +390,7 @@ card_kinds:
         {
             let mut ed = TypedWriter::new(&config, &mut doc);
             let removed = ed.remove_card(1).unwrap();
-            assert_eq!(removed.field_markdown("body").unwrap().unwrap(), "b");
+            assert_eq!(removed.field_text("body", Codec::Richtext).unwrap().unwrap(), "b");
             assert!(ed.remove_card(5).is_none());
         }
         assert_eq!(doc.cards().len(), 2);
@@ -420,7 +421,7 @@ card_kinds:
         let err = card_ed.set("stray", "v").unwrap_err();
         assert_eq!(err.code(), "edit::unknown_field");
 
-        assert_eq!(doc.cards()[0].field_markdown("body").unwrap().unwrap(), "**hi**");
+        assert_eq!(doc.cards()[0].field_text("body", Codec::Richtext).unwrap().unwrap(), "**hi**");
 
         let mut ed = TypedWriter::new(&config, &mut doc);
         assert!(matches!(
@@ -435,7 +436,7 @@ card_kinds:
         let mut doc = blank_doc();
         let mut ed = TypedWriter::new(&config, &mut doc);
         let _delta = ed.revise_field("subject", "Hello").unwrap();
-        assert_eq!(doc.main().field_markdown("subject").unwrap().unwrap(), "Hello");
+        assert_eq!(doc.main().field_text("subject", Codec::Richtext).unwrap().unwrap(), "Hello");
 
         let mut ed = TypedWriter::new(&config, &mut doc);
         assert_eq!(
@@ -445,7 +446,7 @@ card_kinds:
         // `richtext(inline)` rejects a multi-block result.
         let err = ed.revise_field("subject", "a\n\nb").unwrap_err();
         assert_eq!(err.code(), "edit::field_not_inline");
-        assert_eq!(doc.main().field_markdown("subject").unwrap().unwrap(), "Hello");
+        assert_eq!(doc.main().field_text("subject", Codec::Richtext).unwrap().unwrap(), "Hello");
     }
 
     #[test]
@@ -456,7 +457,7 @@ card_kinds:
 
         let mut ed = TypedWriter::new(&config, &mut doc);
         ed.card(0).unwrap().revise_field("body", "**hi**").unwrap();
-        assert_eq!(doc.cards()[0].field_markdown("body").unwrap().unwrap(), "**hi**");
+        assert_eq!(doc.cards()[0].field_text("body", Codec::Richtext).unwrap().unwrap(), "**hi**");
 
         let mut ed = TypedWriter::new(&config, &mut doc);
         assert_eq!(

--- a/crates/fuzz/src/pdf_fuzz.rs
+++ b/crates/fuzz/src/pdf_fuzz.rs
@@ -14,7 +14,9 @@
 use std::sync::LazyLock;
 
 use proptest::prelude::*;
-use quillmark_pdf::{page_media_boxes, stamp, FieldSpec, FieldType, PdfUpdate, StampOptions};
+use quillmark_pdf::{
+    page_media_boxes, reader::ObjectIndex, stamp, FieldSpec, FieldType, PdfUpdate, StampOptions,
+};
 
 /// A real AcroForm the spine accepts, so a mutant of it exercises parse paths a
 /// random buffer never reaches. Read once: thousands of cases mutate a copy.
@@ -44,8 +46,9 @@ fn every_field_kind() -> Vec<FieldSpec> {
 /// Drive every byte-taking entry point once; completing at all is the property.
 fn exercise(pdf: &[u8]) {
     let _ = page_media_boxes(pdf);
-    let _ = PdfUpdate::begin(pdf, None);
-    let _ = PdfUpdate::begin(pdf, Some("quillmark-fuzz"));
+    let idx = ObjectIndex::new(pdf);
+    let _ = PdfUpdate::begin(&idx, None);
+    let _ = PdfUpdate::begin(&idx, Some("quillmark-fuzz"));
     let _ = stamp(pdf.to_vec(), &[], &StampOptions::default());
     let _ = stamp(
         pdf.to_vec(),

--- a/crates/quillmark-pdf/src/error.rs
+++ b/crates/quillmark-pdf/src/error.rs
@@ -21,9 +21,6 @@ impl PdfError {
 
 impl From<PdfError> for quillmark_core::RenderError {
     fn from(e: PdfError) -> Self {
-        quillmark_core::RenderError::from_diag(
-            quillmark_core::Diagnostic::new(quillmark_core::Severity::Error, e.message)
-                .with_code(e.code.to_string()),
-        )
+        quillmark_core::RenderError::coded(e.code, e.message)
     }
 }

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -12,7 +12,7 @@
 //! branches. `hayro-syntax` is read-only and exposes no byte spans, so it cannot
 //! drive a byte-splice append; hence this bespoke scanner.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::error::PdfError;
 
@@ -163,29 +163,108 @@ pub(crate) fn append_incremental_update(
     Ok(pdf)
 }
 
-/// Locate object `id` and return `(obj_start, endobj_end)`.
+/// A base PDF and the offset of every indirect object header in it, collected in
+/// one forward pass. Every read of an object goes through this.
 ///
-/// Matches `<id> <generation> obj` at a token boundary, so `19 0 obj` is not
+/// A per-object scan cannot stop early — a base carrying prior incremental
+/// updates serializes an id more than once and the live copy is the last — so
+/// reading one object without an index walks the whole buffer, and a stamp or
+/// flatten pass reads O(pages) objects.
+///
+/// A header is `<id> <generation> obj` at a token boundary, so `19 0 obj` is not
 /// found inside `519 0 obj`, at any generation (re-saved PDFs carry non-zero
-/// ones). A base with prior incremental updates can serialize an id more than
-/// once; the live copy is the last, so this returns the last match.
-pub fn find_object_bytes(pdf: &[u8], id: u32) -> Option<(usize, usize)> {
-    let prefix = format!("{id} ");
-    let p = prefix.as_bytes();
-    let mut last_start = None;
-    let mut i = 0;
-    while i + p.len() <= pdf.len() {
-        if (i == 0 || matches!(pdf[i - 1], b'\n' | b'\r' | b' '))
-            && pdf[i..].starts_with(p)
-            && is_obj_header_tail(&pdf[i + p.len()..])
-        {
-            last_start = Some(i);
+/// ones). A later occurrence overwrites an earlier one, so a lookup answers with
+/// the live copy.
+pub struct ObjectIndex<'a> {
+    pdf: &'a [u8],
+    starts: HashMap<u32, usize>,
+}
+
+impl<'a> ObjectIndex<'a> {
+    pub fn new(pdf: &'a [u8]) -> Self {
+        let mut starts = HashMap::new();
+        for i in 0..pdf.len() {
+            if !pdf[i].is_ascii_digit() || !(i == 0 || matches!(pdf[i - 1], b'\n' | b'\r' | b' ')) {
+                continue;
+            }
+            if let Some(id) = obj_header_id(&pdf[i..]) {
+                starts.insert(id, i);
+            }
         }
-        i += 1;
+        Self { pdf, starts }
     }
-    let start = last_start?;
-    let end = find_endobj_end(pdf, start + p.len())?;
-    Some((start, end))
+
+    /// The indexed bytes, for the scans that read no object.
+    pub fn bytes(&self) -> &'a [u8] {
+        self.pdf
+    }
+
+    /// `(obj_start, endobj_end)` of object `id`.
+    pub fn object_bytes(&self, id: u32) -> Option<(usize, usize)> {
+        let start = *self.starts.get(&id)?;
+        Some((start, find_endobj_end(self.pdf, start)?))
+    }
+
+    /// The inner dict bytes of object `id`. `what` names the object in both
+    /// failure messages — `"{what} not found"` and `"{what} dict not
+    /// parseable"` — under the caller's error `code`; an Option-returning caller
+    /// calls `.ok()`.
+    pub fn dict(&self, id: u32, code: &'static str, what: &str) -> Result<&'a [u8], PdfError> {
+        let (s, e) = self
+            .object_bytes(id)
+            .ok_or_else(|| err(code, format!("{what} not found")))?;
+        extract_outer_dict(&self.pdf[s..e])
+            .ok_or_else(|| err(code, format!("{what} dict not parseable")))
+    }
+
+    /// The generation in object `id`'s header, or `None` when the object is
+    /// absent or its generation malformed.
+    fn generation(&self, id: u32) -> Option<u16> {
+        let start = *self.starts.get(&id)?;
+        let header = &self.pdf[start..];
+        let id_digits = header.iter().take_while(|b| b.is_ascii_digit()).count();
+        // Past the id and the one space a header writes after it.
+        let rest = &header[id_digits + 1..];
+        let n = rest.iter().take_while(|b| b.is_ascii_digit()).count();
+        std::str::from_utf8(&rest[..n]).ok()?.parse().ok()
+    }
+
+    /// Reject overwriting a base object that lives at a non-zero generation.
+    ///
+    /// The update writer re-emits overwritten objects at generation 0 and
+    /// references them as generation 0, while the reader accepts a header at any
+    /// generation. A base whose catalog / page / `/Info` sits at a non-zero
+    /// generation therefore parses fine yet would produce a malformed update: the
+    /// new `/Root` points at generation 0 while the prior xref resolves the true
+    /// generation.
+    ///
+    /// `None` (object absent) is left for the caller's not-found error path.
+    pub(crate) fn assert_overwrite_gen_zero(&self, id: u32, what: &str) -> Result<(), PdfError> {
+        match self.generation(id) {
+            Some(0) | None => Ok(()),
+            Some(generation) => Err(err(
+                "pdf::nonzero_generation",
+                format!(
+                    "{what} object {id} is at generation {generation}; the stamp spine re-emits \
+                     overwritten objects at generation 0 and cannot preserve a non-zero generation"
+                ),
+            )),
+        }
+    }
+}
+
+/// The object id of the `<id> <generation> obj` header at the start of `rest`,
+/// when there is one. An id written with a leading zero is not one: the index
+/// matches the exact decimal form a reference to the object is written in.
+fn obj_header_id(rest: &[u8]) -> Option<u32> {
+    let digits = rest.iter().take_while(|b| b.is_ascii_digit()).count();
+    if (digits > 1 && rest[0] == b'0')
+        || rest.get(digits) != Some(&b' ')
+        || !is_obj_header_tail(&rest[digits + 1..])
+    {
+        return None;
+    }
+    std::str::from_utf8(&rest[..digits]).ok()?.parse().ok()
 }
 
 /// The index just past the `endobj` closing the body at `from`. Literal
@@ -205,38 +284,6 @@ fn find_endobj_end(pdf: &[u8], from: usize) -> Option<usize> {
         i += 1;
     }
     None
-}
-
-/// The generation in object `id`'s header, or `None` when it is absent or
-/// malformed. Reads the live copy, matching [`find_object_bytes`].
-pub(crate) fn object_generation(pdf: &[u8], id: u32) -> Option<u16> {
-    let (start, _) = find_object_bytes(pdf, id)?;
-    let after_id = start + format!("{id} ").len();
-    let rest = &pdf[after_id..];
-    let n = rest.iter().take_while(|b| b.is_ascii_digit()).count();
-    std::str::from_utf8(&rest[..n]).ok()?.parse().ok()
-}
-
-/// Reject overwriting a base object that lives at a non-zero generation.
-///
-/// The update writer re-emits overwritten objects at generation 0 and references
-/// them as generation 0, while the reader accepts a header at any generation. A
-/// base whose catalog / page / `/Info` sits at a non-zero generation therefore
-/// parses fine yet would produce a malformed update: the new `/Root` points at
-/// generation 0 while the prior xref resolves the true generation.
-///
-/// `None` (object absent) is left for the caller's not-found error path.
-pub(crate) fn assert_overwrite_gen_zero(pdf: &[u8], id: u32, what: &str) -> Result<(), PdfError> {
-    match object_generation(pdf, id) {
-        Some(0) | None => Ok(()),
-        Some(generation) => Err(err(
-            "pdf::nonzero_generation",
-            format!(
-                "{what} object {id} is at generation {generation}; the stamp spine re-emits \
-                 overwritten objects at generation 0 and cannot preserve a non-zero generation"
-            ),
-        )),
-    }
 }
 
 /// Whether the bytes after an `<id> ` prefix continue as `<generation> obj`.
@@ -538,19 +585,6 @@ fn skip_ws(s: &[u8]) -> &[u8] {
     &s[ws_end(s, 0)..]
 }
 
-/// The inner dict bytes of object `id`. `what` names the object in both failure
-/// messages — `"{what} not found"` and `"{what} dict not parseable"` — under
-/// the caller's error `code`; an Option-returning caller calls `.ok()`.
-pub fn object_dict<'a>(
-    pdf: &'a [u8],
-    id: u32,
-    code: &'static str,
-    what: &str,
-) -> Result<&'a [u8], PdfError> {
-    let (s, e) = find_object_bytes(pdf, id).ok_or_else(|| err(code, format!("{what} not found")))?;
-    extract_outer_dict(&pdf[s..e]).ok_or_else(|| err(code, format!("{what} dict not parseable")))
-}
-
 /// Open the base's trailer: the xref offset, the trailer dict, and the catalog
 /// (`/Root`) object id, after refusing an xref stream. `code` carries the
 /// caller's error code for a missing or malformed `/Root`.
@@ -569,15 +603,14 @@ pub(crate) fn open_trailer<'a>(
 
 /// Flatten the catalog's `/Pages` tree into page object ids in document order.
 /// The walk is capped to prevent runaway on a pathological PDF.
-pub(crate) fn resolve_page_ids(pdf: &[u8], catalog_id: u32) -> Result<Vec<u32>, PdfError> {
-    let root_pages_id = root_pages_id(pdf, catalog_id)?;
+pub(crate) fn resolve_page_ids(idx: &ObjectIndex, catalog_id: u32) -> Result<Vec<u32>, PdfError> {
+    let root_pages_id = root_pages_id(idx, catalog_id)?;
 
     const MAX_NODES: usize = 100_000;
     let mut out = Vec::new();
     let mut stack = vec![root_pages_id];
-    // A node reached twice is a cyclic or shared-node `/Pages` tree, and an
-    // amplification vector: every visit re-scans the whole file, so a tiny
-    // `/Kids` self-cycle would drive MAX_NODES full-file scans without this.
+    // A node reached twice is a cyclic or shared-node `/Pages` tree: a `/Kids`
+    // self-cycle would otherwise walk until MAX_NODES.
     let mut seen: HashSet<u32> = HashSet::new();
     while let Some(node_id) = stack.pop() {
         if !seen.insert(node_id) {
@@ -589,7 +622,7 @@ pub(crate) fn resolve_page_ids(pdf: &[u8], catalog_id: u32) -> Result<Vec<u32>, 
         if seen.len() > MAX_NODES {
             return Err(err(CODE_PARSE, "page tree exceeds 100 000 nodes"));
         }
-        let dict = object_dict(pdf, node_id, CODE_PARSE, &format!("page node {node_id}"))?;
+        let dict = idx.dict(node_id, CODE_PARSE, &format!("page node {node_id}"))?;
         let typ = find_dict_value(dict, "Type")
             .map(|b| String::from_utf8_lossy(b.trim_ascii()).into_owned())
             .unwrap_or_default();
@@ -610,8 +643,8 @@ pub(crate) fn resolve_page_ids(pdf: &[u8], catalog_id: u32) -> Result<Vec<u32>, 
 }
 
 /// The catalog's root `/Pages` node id.
-fn root_pages_id(pdf: &[u8], catalog_id: u32) -> Result<u32, PdfError> {
-    let cat_dict = object_dict(pdf, catalog_id, CODE_PARSE, "catalog")?;
+fn root_pages_id(idx: &ObjectIndex, catalog_id: u32) -> Result<u32, PdfError> {
+    let cat_dict = idx.dict(catalog_id, CODE_PARSE, "catalog")?;
     find_dict_value(cat_dict, "Pages")
         .and_then(parse_indirect_ref)
         .map(|(id, _)| id)
@@ -622,16 +655,13 @@ fn root_pages_id(pdf: &[u8], catalog_id: u32) -> Result<u32, PdfError> {
 /// from the root `/Pages`. The stamp and flatten paths write geometry in
 /// unrotated user space and do not compensate, so a rotated base page would
 /// display every widget away from its intended box.
-///
-/// The inherited value is resolved once for the whole batch: reading it costs a
-/// full-file scan per page otherwise.
 pub(crate) fn assert_unrotated_pages(
-    pdf: &[u8],
+    idx: &ObjectIndex,
     catalog_id: u32,
     page_ids: &[u32],
 ) -> Result<(), PdfError> {
     let read_rotate = |id: u32| -> Option<i64> {
-        let dict = object_dict(pdf, id, CODE_PARSE, "page").ok()?;
+        let dict = idx.dict(id, CODE_PARSE, "page").ok()?;
         let raw = find_dict_value(dict, "Rotate")?;
         std::str::from_utf8(raw.trim_ascii())
             .ok()?
@@ -639,7 +669,7 @@ pub(crate) fn assert_unrotated_pages(
             .parse::<i64>()
             .ok()
     };
-    let inherited = root_pages_id(pdf, catalog_id).ok().and_then(read_rotate);
+    let inherited = root_pages_id(idx, catalog_id).ok().and_then(read_rotate);
     for &page_id in page_ids {
         let rotate = read_rotate(page_id).or(inherited).unwrap_or(0);
         if rotate.rem_euclid(360) != 0 {
@@ -719,11 +749,12 @@ fn normalize_rect(mb: [f32; 4]) -> [f32; 4] {
 pub(crate) fn page_media_boxes(pdf: &[u8]) -> Result<Vec<[f32; 4]>, PdfError> {
     let (_, _, catalog_id) = open_trailer(pdf, CODE_PARSE)?;
 
-    let inherited = root_pages_media_box(pdf, catalog_id);
-    let page_ids = resolve_page_ids(pdf, catalog_id)?;
+    let idx = ObjectIndex::new(pdf);
+    let inherited = root_pages_media_box(&idx, catalog_id);
+    let page_ids = resolve_page_ids(&idx, catalog_id)?;
     let mut out = Vec::with_capacity(page_ids.len());
     for id in page_ids {
-        let dict = object_dict(pdf, id, CODE_PARSE, &format!("page node {id}"))?;
+        let dict = idx.dict(id, CODE_PARSE, &format!("page node {id}"))?;
         let mb = find_dict_value(dict, "MediaBox")
             .and_then(parse_rect_array)
             .or(inherited)
@@ -734,9 +765,9 @@ pub(crate) fn page_media_boxes(pdf: &[u8]) -> Result<Vec<[f32; 4]>, PdfError> {
 }
 
 /// The root `/Pages` node's `/MediaBox`, if present: the value pages inherit.
-fn root_pages_media_box(pdf: &[u8], catalog_id: u32) -> Option<[f32; 4]> {
-    let pages_id = root_pages_id(pdf, catalog_id).ok()?;
-    let dict = object_dict(pdf, pages_id, CODE_PARSE, "root /Pages node").ok()?;
+fn root_pages_media_box(idx: &ObjectIndex, catalog_id: u32) -> Option<[f32; 4]> {
+    let pages_id = root_pages_id(idx, catalog_id).ok()?;
+    let dict = idx.dict(pages_id, CODE_PARSE, "root /Pages node").ok()?;
     find_dict_value(dict, "MediaBox").and_then(parse_rect_array)
 }
 
@@ -776,7 +807,8 @@ mod tests {
     #[test]
     fn endobj_inside_comment_does_not_truncate_object() {
         let pdf = b"%PDF\n3 0 obj\n<< /A 1 >> %endobj in a comment\n/B 2 >>\nendobj\n";
-        let (s, e) = find_object_bytes(pdf, 3).expect("found object 3");
+        let idx = ObjectIndex::new(pdf);
+        let (s, e) = idx.object_bytes(3).expect("found object 3");
         assert_eq!(&pdf[e - 6..e], b"endobj");
         assert!(&pdf[s..e].ends_with(b"/B 2 >>\nendobj"));
     }
@@ -846,25 +878,50 @@ mod tests {
     #[test]
     fn find_object_at_token_boundary() {
         let pdf = b"%PDF\n519 0 obj\n<< /A 1 >>\nendobj\n19 0 obj\n<< /B 2 >>\nendobj\n";
-        let (s, e) = find_object_bytes(pdf, 19).expect("found object 19");
+        let idx = ObjectIndex::new(pdf);
+        let (s, e) = idx.object_bytes(19).expect("found object 19");
         assert_eq!(&pdf[s..e], b"19 0 obj\n<< /B 2 >>\nendobj");
+    }
+
+    #[test]
+    fn index_resolves_every_object_from_one_pass() {
+        let pdf = b"%PDF\n1 0 obj\n<< /A 1 >>\nendobj\n2 0 obj\n<< /B 2 >>\nendobj\n\
+                    3 0 obj\n<< /C 3 >>\nendobj\n";
+        let idx = ObjectIndex::new(pdf);
+        for (id, body) in [(1u32, &b"/A 1"[..]), (2, b"/B 2"), (3, b"/C 3")] {
+            assert_eq!(idx.dict(id, CODE_PARSE, "obj").unwrap().trim_ascii(), body);
+        }
+        assert!(idx.object_bytes(4).is_none());
+    }
+
+    #[test]
+    fn index_ignores_a_leading_zero_id_header() {
+        // `019` is not how a `19 0 R` reference writes the id, so it is not
+        // object 19 and does not supersede the real one.
+        let pdf = b"%PDF\n19 0 obj\n<< /V (real) >>\nendobj\n019 0 obj\n<< /V (decoy) >>\nendobj\n";
+        let dict = ObjectIndex::new(pdf).dict(19, CODE_PARSE, "obj").unwrap();
+        assert_eq!(find_dict_value(dict, "V").unwrap().trim_ascii(), b"(real)");
     }
 
     #[test]
     fn object_generation_reads_header_gen() {
         let pdf = b"%PDF\n7 2 obj\n<< /C 3 >>\nendobj\n4 0 obj\n<< /D 1 >>\nendobj\n";
-        assert_eq!(object_generation(pdf, 7), Some(2));
-        assert_eq!(object_generation(pdf, 4), Some(0));
-        assert_eq!(object_generation(pdf, 99), None);
+        let idx = ObjectIndex::new(pdf);
+        assert_eq!(idx.generation(7), Some(2));
+        assert_eq!(idx.generation(4), Some(0));
+        assert_eq!(idx.generation(99), None);
     }
 
     #[test]
     fn assert_overwrite_gen_zero_rejects_nonzero() {
         let pdf = b"%PDF\n7 2 obj\n<< /C 3 >>\nendobj\n4 0 obj\n<< /D 1 >>\nendobj\n";
-        assert!(assert_overwrite_gen_zero(pdf, 4, "x").is_ok());
+        let idx = ObjectIndex::new(pdf);
+        assert!(idx.assert_overwrite_gen_zero(4, "x").is_ok());
         // Absent is accepted: the caller owns the not-found path.
-        assert!(assert_overwrite_gen_zero(pdf, 99, "x").is_ok());
-        let e = assert_overwrite_gen_zero(pdf, 7, "catalog").expect_err("generation 2 rejected");
+        assert!(idx.assert_overwrite_gen_zero(99, "x").is_ok());
+        let e = idx
+            .assert_overwrite_gen_zero(7, "catalog")
+            .expect_err("generation 2 rejected");
         assert_eq!(e.code, "pdf::nonzero_generation");
         assert!(e.message.contains("generation 2"), "{}", e.message);
     }
@@ -873,14 +930,16 @@ mod tests {
     fn find_object_returns_last_revision() {
         // Same id serialized twice, as an incremental update writes it.
         let pdf = b"%PDF\n4 0 obj\n<< /V (old) >>\nendobj\n4 0 obj\n<< /V (new) >>\nendobj\n";
-        let (s, e) = find_object_bytes(pdf, 4).expect("found object 4");
+        let idx = ObjectIndex::new(pdf);
+        let (s, e) = idx.object_bytes(4).expect("found object 4");
         assert_eq!(&pdf[s..e], b"4 0 obj\n<< /V (new) >>\nendobj");
     }
 
     #[test]
     fn endobj_inside_string_does_not_truncate_object() {
         let pdf = b"%PDF\n3 0 obj\n<< /Title (My endobj report) /Author (X) >>\nendobj\n";
-        let (s, e) = find_object_bytes(pdf, 3).expect("found object 3");
+        let idx = ObjectIndex::new(pdf);
+        let (s, e) = idx.object_bytes(3).expect("found object 3");
         assert_eq!(
             &pdf[s..e],
             b"3 0 obj\n<< /Title (My endobj report) /Author (X) >>\nendobj"
@@ -894,7 +953,7 @@ mod tests {
     fn page_tree_cycle_is_rejected() {
         let pdf = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
                     2 0 obj\n<< /Type /Pages /Kids [2 0 R] /Count 1 >>\nendobj\n";
-        let e = resolve_page_ids(pdf, 1).expect_err("cycle rejected");
+        let e = resolve_page_ids(&ObjectIndex::new(pdf), 1).expect_err("cycle rejected");
         assert_eq!(e.code, CODE_PARSE);
         assert!(e.message.contains("revisits"), "{}", e.message);
     }
@@ -905,11 +964,12 @@ mod tests {
         let pdf = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
                     2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 /Rotate 90 >>\nendobj\n\
                     3 0 obj\n<< /Type /Page /Parent 2 0 R >>\nendobj\n";
-        let e = assert_unrotated_pages(pdf, 1, &[3]).expect_err("rotated page rejected");
+        let e = assert_unrotated_pages(&ObjectIndex::new(pdf), 1, &[3])
+            .expect_err("rotated page rejected");
         assert_eq!(e.code, "pdf::rotated_page");
         let flat = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
                      2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\
                      3 0 obj\n<< /Type /Page /Parent 2 0 R >>\nendobj\n";
-        assert!(assert_unrotated_pages(flat, 1, &[3]).is_ok());
+        assert!(assert_unrotated_pages(&ObjectIndex::new(flat), 1, &[3]).is_ok());
     }
 }

--- a/crates/quillmark-pdf/src/stamp.rs
+++ b/crates/quillmark-pdf/src/stamp.rs
@@ -21,7 +21,7 @@ use pdf_writer::{Chunk, Finish, Name, Rect, Ref, Str, TextStr};
 use quillmark_core::RenderedRegion;
 
 use crate::error::PdfError;
-use crate::reader::{err, object_dict, parse_indirect_ref, UpdatedObject};
+use crate::reader::{err, parse_indirect_ref, ObjectIndex, UpdatedObject};
 use crate::update::PdfUpdate;
 use crate::writer::{alloc_id, append_refs_to_array_key, dict_object, OnNonArray};
 use crate::{FieldSpec, FieldType, FormFont, TextAlign};
@@ -103,10 +103,11 @@ pub fn stamp(
     }
 
     let pdf = base;
-    let mut up = PdfUpdate::begin(&pdf, opts.producer.as_deref())?;
+    let idx = ObjectIndex::new(&pdf);
+    let mut up = PdfUpdate::begin(&idx, opts.producer.as_deref())?;
 
     if !fields.is_empty() {
-        let page_ids = up.resolve_pages(&pdf, fields)?;
+        let page_ids = up.resolve_pages(&idx, fields)?;
         let page_count = page_ids.len();
 
         let fonts = fonts_used(fields);
@@ -173,7 +174,7 @@ pub fn stamp(
 
         // A widget is fillable only if reachable both ways: the catalog's
         // `/AcroForm /Fields` (added here) and the page's `/Annots` (below).
-        let cat_dict = object_dict(&pdf, up.catalog_id, CODE_PARSE, "catalog")?;
+        let cat_dict = idx.dict(up.catalog_id, CODE_PARSE, "catalog")?;
         let mut cat_inner = cat_dict.to_vec();
         cat_inner.extend_from_slice(format!(" /AcroForm {acroform_id} 0 R").as_bytes());
         up.objects.push(dict_object(up.catalog_id, &cat_inner));
@@ -184,7 +185,7 @@ pub fn stamp(
             }
             let page_obj_id = page_ids[page_idx];
             let what = format!("page node {page_obj_id}");
-            let pg_dict = object_dict(&pdf, page_obj_id, CODE_PARSE, &what)?;
+            let pg_dict = idx.dict(page_obj_id, CODE_PARSE, &what)?;
             up.objects.push(dict_object(
                 page_obj_id,
                 &rewrite_page_with_annots(pg_dict, widget_refs)?,

--- a/crates/quillmark-pdf/src/update.rs
+++ b/crates/quillmark-pdf/src/update.rs
@@ -5,8 +5,8 @@
 
 use crate::error::PdfError;
 use crate::reader::{
-    append_incremental_update, assert_overwrite_gen_zero, assert_unrotated_pages, err,
-    find_dict_value, open_trailer, parse_indirect_ref, resolve_page_ids, UpdatedObject,
+    append_incremental_update, assert_unrotated_pages, err, find_dict_value, open_trailer,
+    parse_indirect_ref, resolve_page_ids, ObjectIndex, UpdatedObject,
 };
 use crate::writer::apply_producer_stamp;
 use crate::FieldSpec;
@@ -30,10 +30,11 @@ pub struct PdfUpdate {
 }
 
 impl PdfUpdate {
-    /// Open `pdf` for an incremental update. The caller then pushes its objects
-    /// onto [`objects`](Self::objects) and calls [`finish`](Self::finish).
-    pub fn begin(pdf: &[u8], producer: Option<&str>) -> Result<Self, PdfError> {
-        let (xref_offset, trailer, catalog_id) = open_trailer(pdf, CODE_PARSE)?;
+    /// Open the indexed base for an incremental update. The caller then pushes
+    /// its objects onto [`objects`](Self::objects) and calls
+    /// [`finish`](Self::finish) with the base's bytes.
+    pub fn begin(idx: &ObjectIndex, producer: Option<&str>) -> Result<Self, PdfError> {
+        let (xref_offset, trailer, catalog_id) = open_trailer(idx.bytes(), CODE_PARSE)?;
         if find_dict_value(trailer, "Encrypt").is_some() {
             return Err(err(
                 "pdf::encrypted",
@@ -43,7 +44,7 @@ impl PdfUpdate {
         // The new trailer re-references the catalog as `/Root <id> 0 R`, so a
         // non-zero-generation catalog would be silently corrupted even when only
         // the producer is stamped (catalog not itself overwritten).
-        assert_overwrite_gen_zero(pdf, catalog_id, "catalog (/Root)")?;
+        idx.assert_overwrite_gen_zero(catalog_id, "catalog (/Root)")?;
         let size = find_dict_value(trailer, "Size")
             .and_then(|v| std::str::from_utf8(v.trim_ascii()).ok())
             .and_then(|s| s.parse::<u32>().ok())
@@ -58,7 +59,7 @@ impl PdfUpdate {
         let mut extra_info_ref = None;
         if let Some(producer) = producer {
             extra_info_ref =
-                apply_producer_stamp(pdf, info_ref, producer, &mut next_id, &mut objects)?;
+                apply_producer_stamp(idx, info_ref, producer, &mut next_id, &mut objects)?;
         }
 
         Ok(Self {
@@ -72,11 +73,13 @@ impl PdfUpdate {
 
     /// Resolve the base's page object ids, bounds-checking every field's `page`
     /// so a spec targeting a non-existent page errors rather than panicking later.
-    pub fn resolve_pages(&self, pdf: &[u8], fields: &[FieldSpec]) -> Result<Vec<u32>, PdfError> {
-        let page_ids = resolve_page_ids(pdf, self.catalog_id)?;
+    pub fn resolve_pages(
+        &self,
+        idx: &ObjectIndex,
+        fields: &[FieldSpec],
+    ) -> Result<Vec<u32>, PdfError> {
+        let page_ids = resolve_page_ids(idx, self.catalog_id)?;
         let page_count = page_ids.len();
-        // Both assertions below re-scan the whole byte buffer, so validate each
-        // distinct page once rather than pay O(fields × file_size).
         let mut checked = vec![false; page_count];
         let mut targeted = Vec::new();
         for spec in fields {
@@ -94,13 +97,13 @@ impl PdfUpdate {
             }
             // A targeted page is overwritten and referenced as gen 0, so a
             // non-zero-generation page would be silently corrupted.
-            assert_overwrite_gen_zero(pdf, page_ids[spec.page], "page")?;
+            idx.assert_overwrite_gen_zero(page_ids[spec.page], "page")?;
             checked[spec.page] = true;
             targeted.push(page_ids[spec.page]);
         }
         // Geometry is written in unrotated user space, so a rotated target page
         // would mis-place every field.
-        assert_unrotated_pages(pdf, self.catalog_id, &targeted)?;
+        assert_unrotated_pages(idx, self.catalog_id, &targeted)?;
         Ok(page_ids)
     }
 

--- a/crates/quillmark-pdf/src/writer.rs
+++ b/crates/quillmark-pdf/src/writer.rs
@@ -3,9 +3,7 @@
 //! `/Producer` stamp.
 
 use crate::error::PdfError;
-use crate::reader::{
-    assert_overwrite_gen_zero, err, find_dict_value, object_dict, splice_dict_value, UpdatedObject,
-};
+use crate::reader::{err, find_dict_value, splice_dict_value, ObjectIndex, UpdatedObject};
 
 const CODE_PARSE: &str = "pdf::write";
 
@@ -133,7 +131,7 @@ pub(crate) fn upsert_producer(info_dict: &[u8], literal: &[u8]) -> Vec<u8> {
 /// `/Info` onto `objects`. Returns `Some(info_id)` when a new `/Info` was
 /// allocated, which the caller threads into the trailer.
 pub(crate) fn apply_producer_stamp(
-    pdf: &[u8],
+    idx: &ObjectIndex,
     info_ref: Option<(u32, u16)>,
     producer: &str,
     next_id: &mut u32,
@@ -144,9 +142,9 @@ pub(crate) fn apply_producer_stamp(
         Some((info_id, _)) => {
             // Overwritten in place at generation 0; a non-zero-generation
             // `/Info` would be silently corrupted.
-            assert_overwrite_gen_zero(pdf, info_id, "/Info")?;
+            idx.assert_overwrite_gen_zero(info_id, "/Info")?;
             let what = format!("/Info object {info_id}");
-            let info_dict = object_dict(pdf, info_id, CODE_PARSE, &what)?;
+            let info_dict = idx.dict(info_id, CODE_PARSE, &what)?;
             objects.push(dict_object(info_id, &upsert_producer(info_dict, &literal)));
             Ok(None)
         }

--- a/crates/quillmark/src/load.rs
+++ b/crates/quillmark/src/load.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::path::{Path, PathBuf};
 
-use quillmark_core::{Diagnostic, FileTreeNode, Quill, QuillIgnore, RenderError, Severity};
+use quillmark_core::{Diagnostic, FileTreeNode, Quill, QuillIgnore, RenderError};
 
 /// Load a quill from a filesystem directory. Honours a root `.quillignore`,
 /// else a default ignore set.
@@ -22,10 +22,7 @@ pub fn quill_from_path_with_warnings<P: AsRef<Path>>(
     path: P,
 ) -> Result<(Quill, Vec<Diagnostic>), RenderError> {
     let tree = load_tree_from_path(path.as_ref()).map_err(|e| {
-        RenderError::from_diag(
-            Diagnostic::new(Severity::Error, format!("Failed to load quill: {}", e))
-                .with_code("quill::load_failed".to_string()),
-        )
+        RenderError::coded("quill::load_failed", format!("Failed to load quill: {e}"))
     })?;
     Quill::from_tree_with_warnings(tree).map_err(RenderError::new)
 }

--- a/crates/quillmark/src/load.rs
+++ b/crates/quillmark/src/load.rs
@@ -142,4 +142,19 @@ mod tests {
         assert!(tree.get_file("leak.txt").is_none());
         assert_eq!(tree.get_file("real.txt"), Some(&b"ok"[..]));
     }
+
+    #[test]
+    fn load_dir_honours_multi_wildcard_ignore_patterns() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        std::fs::write(root.join(".quillignore"), "**/*.tmp\n").unwrap();
+        std::fs::create_dir(root.join("nested")).unwrap();
+        std::fs::write(root.join("nested/scratch.tmp"), b"drop").unwrap();
+        std::fs::write(root.join("nested/plate.typ"), b"keep").unwrap();
+
+        let tree = load_tree_from_path(root).unwrap();
+        assert!(tree.get_file("nested/scratch.tmp").is_none());
+        assert_eq!(tree.get_file("nested/plate.typ"), Some(&b"keep"[..]));
+    }
 }

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -31,7 +31,9 @@ It exists so no public signature names `serde-saphyr`. A third-party error type 
 Two surfaces return one directly (`QuillValue::from_yaml_str`, `QuillConfig::schema_yaml`); `QuillConfig::from_yaml_with_warnings` converts through it to `quill::yaml_parse_error`. The card-yaml path does not travel this way: it becomes `ParseError::YamlErrorWithLocation`, which additionally knows the enclosing block.
 
 **`RenderError`**: the main rendering error, a struct carrying a non-empty
-`Vec<Diagnostic>` (`RenderError::new` / `from_diag`; `diagnostics()` borrows,
+`Vec<Diagnostic>` (`RenderError::new` / `from_diag` / `coded(code, message)`
+for the one-error-diagnostic case every engine-side refusal takes;
+`diagnostics()` borrows,
 `into_diagnostics()` consumes). There is no failure taxonomy beyond the
 diagnostics themselves: the machine-routable identity of a failure is each
 diagnostic's namespaced `code` (`parse::*`, `validation::*`, `quill::*`,

--- a/prose/canon/QUILL.md
+++ b/prose/canon/QUILL.md
@@ -115,7 +115,7 @@ Errors flow through `RenderError` (a non-empty `Vec<Diagnostic>`) and surface to
 
 When loading from disk, `quillmark::quill_from_path` respects a `.quillignore` file at the bundle root. If absent, default patterns apply: `.git/`, `.gitignore`, `.quillignore`, `target/`, `node_modules/`.
 
-A line is one of three rules. `dir/` drops that directory and its subtree, anchored at the bundle root. A line free of `*`, `?` and `[` is a literal name, matching the whole path or the basename at any depth. Anything else is a glob (`glob::Pattern`), matched against both the whole path and the basename, so a slash-free pattern applies at any depth and a slashed one anchors at the root; `*` stops at `/`. A glob that fails to compile falls back to a literal name.
+A line is one of three rules. `dir/` drops that directory and its subtree, anchored at the bundle root. A line free of `*`, `?` and `[` is a literal name, matching the whole path or the basename at any depth. Anything else is a glob (`glob::Pattern`), matched against both the whole path and the basename, so a slash-free pattern applies at any depth and a slashed one anchors at the root; `*` stops at `/`. A glob also matches the line it was written as, since `[` is both a character-class opener and an ordinary character in a filename. A glob that fails to compile falls back to a literal name.
 
 ## API
 

--- a/prose/canon/QUILL.md
+++ b/prose/canon/QUILL.md
@@ -115,6 +115,8 @@ Errors flow through `RenderError` (a non-empty `Vec<Diagnostic>`) and surface to
 
 When loading from disk, `quillmark::quill_from_path` respects a `.quillignore` file at the bundle root. If absent, default patterns apply: `.git/`, `.gitignore`, `.quillignore`, `target/`, `node_modules/`.
 
+A line is one of three rules. `dir/` drops that directory and its subtree, anchored at the bundle root. A line free of `*`, `?` and `[` is a literal name, matching the whole path or the basename at any depth. Anything else is a glob (`glob::Pattern`), matched against both the whole path and the basename, so a slash-free pattern applies at any depth and a slashed one anchors at the root; `*` stops at `/`. A glob that fails to compile falls back to a literal name.
+
 ## API
 
 Construction:


### PR DESCRIPTION
Integrates the ten open PRs (#1347–#1356) onto one branch, reviewed together rather than one at a time.

Each PR arrived with green CI (test / lint / python / wasm), so review focused on the implementations and on what only shows up once they sit in the same tree.

## What lands

**Fixes**

- **#1348** — a variant's `object` / `array<object>` cell went through the scalar path, rendering as `controlled_by: !must_fill # object`: a null where the schema wants a mapping, every property's description and `default:` dropped, and the marker on a path the obligation predicate never warns at.
- **#1352** — `.quillignore` matched exactly one `*` and returned no match for the rest, so `**/*.tmp` and the shipped fixture's `*.sublime-*` were dead lines. Patterns compile through `glob::Pattern` now; `*` stops at `/` and a slashed pattern anchors at the bundle root.

**Performance**

- **#1356** — reading one object from a PDF base walked every byte of it, unmemoized, so a stamp or flatten pass paid O(pages) whole-file scans. `ObjectIndex` collects the offsets in one pass: a 20-page 300 KB form stamps in 0.7 ms rather than 37 ms.
- **#1354** — `to_canonical_value` rebuilt the tree it had just encoded. The encoders emit ascending keys and the terminal pass scans instead. Canonical bytes unchanged, byte for byte.

**Consolidation**

- **#1349** — the richtext/plaintext split was spelled out across eight functions; one `Codec` value carries it.
- **#1353** — one home for the richtext import contract, shared by the strict write and the schema-literal cache.
- **#1350** — `RenderError::coded(code, message)` replaces nine hand-spelled constructions, including two per-crate `engine_err` copies.
- **#1347** — one delta walk syncs lines and islands instead of two identical passes.
- **#1351** — the three op-wire encoders had no caller in the workspace; their round-trip tests become decoder tests over the literal JSON a binding actually sends.
- **#1355** — a pdfform session holds its flattened PDF parsed rather than reparsing it per render path.

## Breaking

- `quillmark-content` drops `mark_op_to_value`, `line_op_to_value`, `island_op_to_value` (#1351). Verified zero references anywhere in the workspace, bindings and docs included — bundles are authored on the JS/Python side and enter through `change_bundle_from_value`.
- `quillmark-pdf`: `PdfUpdate::begin` and `resolve_pages` take `&ObjectIndex` rather than bytes; `reader::find_object_bytes` / `object_dict` become `ObjectIndex::object_bytes` / `ObjectIndex::dict` (#1356).
- `pdfform::svg_parse_failed` / `png_parse_failed` collapse into `pdfform::flat_parse_failed`, raised from `open`/`update` rather than at render time (#1355).

This is a minor-version integration, not a patch.

## Conflicts resolved here

Merged with local git throughout, since `.gitattributes` marks `CHANGELOG.md` `merge=union` and GitHub's merge machinery does not read it. Three conflicts were real:

1. **`pdfform/lib.rs`** (#1350 × #1355) — #1350 deleted the per-crate `engine_err`; #1355 added a call site to it. Dropped the now-dead `open_flat` and pointed the new call at `RenderError::coded`.
2. **`content/serial.rs`** (#1351 × #1354) — #1351 folded `mark_fields` / `island_fields` into their callers while #1354 reordered their inserts. `island_to_value` now inserts ascending directly; `mark_to_value` keeps `sort_own_keys`, because a kind's keys do not all sort after `start`/`end` (`attrs` precedes both, `id` falls between them) and so cannot be settled at the insert.
3. **`core/document/mod.rs` + `quill/config.rs`** (#1349 × #1353) — re-expressed `canonical_richtext_value` in terms of `Codec::Richtext` and `ContentDecodeError`.

## Verification

- `cargo test --workspace`: 40 test binaries, 0 failures.
- `cargo build --workspace --all-targets`: no unused-import, dead-code or never-read warnings, confirming the combination orphaned nothing.
- #1354's `encoders_emit_keys_in_ascending_order` and `golden_bytes_are_feature_independent` both pass after the `serial.rs` resolution — those are what would catch a bad merge there.

## Added on top of the ten

- Changelog entries for #1348 (a user-facing fix that shipped without one) and for #1356's public signature change (its entry described only the perf result).
- A dense-prose pass over the merged result. It found one genuine drift: the lenient-coercion comment still named `decode_value` as the seam for the write and literal sites, which now reach it through `canonical_richtext_value`, and the strict branch restated that function's own documented contract. What survives is the hazard — the bindings key on those message strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dp6QhDKw4XTMi6nn7j9yoG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dp6QhDKw4XTMi6nn7j9yoG)_