### PR TITLE
fix(content): complete container identity, and check what it rests on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,9 @@
     The open-set promise that a container this build does not know survives
     untouched is now total rather than holding up to an adjacency quotient.
 
-  `ordinal` is canonicalized alongside it, to a gapless 0-based index within
+  An item boundary is a parent boundary: two inner lists under two outer list
+  items are two lists, so an inner run restarts its `ordinal` and needs no
+  discriminator. `ordinal` is canonicalized alongside it, to a gapless 0-based index within
   its run, so `[5, 9]` and `[0, 1]` stop being two spellings of the same two
   items. `instance` is written to the wire only when non-zero, so a stored row
   that needs no discriminator — nearly all of them — keeps its exact bytes and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ## Unreleased
 
+- fix(content): **two adjacent containers of one shape are no longer read as
+  one.** Container identity is the container path plus contiguity, and the path
+  carried nothing to tell one instance from the next, so two adjacent runs of
+  equal shape welded: `[Quote], [Quote]` read as a single two-paragraph quote,
+  and two one-item lists as a single item whose second line came back as an
+  unnumbered continuation paragraph — the marker gone. `Container` now carries
+  an `instance` discriminator on every arm, `Content::normalize` canonicalizes
+  it to `0` (flipping to `1` only where the adjacent preceding run would
+  otherwise weld), and the two projections read it. Four defects close with it:
+  - `from_markdown("- a\n\n<!-- -->\n\n- b")` — the CommonMark idiom for
+    spelling two lists apart — no longer destroys the second list's marker.
+  - Two adjacent ordered lists typeset with their own numbering. They reached
+    the Typst emitter as one run and `+` markers numbered the second list on
+    from the first, so `1. 2.` / `1. 2.` rendered **1 2 3 4**. The run's first
+    item now states its number, which resets Typst's running counter.
+  - `1. a` beside a list starting at `3` keeps that `start` through the
+    Markdown projection. CommonMark reads only a list's first number, so
+    `1. a\n\n3. b` re-imported as one list of two items and the `start` was
+    lost — breaking the round-trip fixed point `export` documents. Adjacent
+    lists now alternate their marker (`-`/`+`, `.`/`)`), which is how
+    CommonMark itself spells two lists apart, so the boundary survives the
+    projection with no comment marker in the authored file.
+  - Adjacent `Unknown` containers of equal `(tag, attrs)` round-trip as two.
+    The open-set promise that a container this build does not know survives
+    untouched is now total rather than holding up to an adjacency quotient.
+
+  `ordinal` is canonicalized alongside it, to a gapless 0-based index within
+  its run, so `[5, 9]` and `[0, 1]` stop being two spellings of the same two
+  items. `instance` is written to the wire only when non-zero, so a stored row
+  that needs no discriminator — nearly all of them — keeps its exact bytes and
+  its content hash. **Breaking for Rust consumers** that match `Container`
+  exhaustively: `Quote` is now a struct variant, and `ListItem`/`Unknown` carry
+  the extra field. On the TypeScript surface `instance` is optional; a consumer
+  that never writes adjacent same-shape siblings needs no change.
+
 - fix(blueprint): **a variant's `object` or `array<object>` cell expands per
   property.** The cell went through the scalar path, so it rendered as
   `controlled_by: !must_fill # object` — a null where the schema wants a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- fix(content): **a `continues` line that crosses a container boundary no longer
+  survives.** A within-block break lives inside one container, and `LineOp::Join`
+  mints the crossing shape whenever it merges two lines of differing paths — the
+  line after the seam keeps continuing across it. Both projections already read
+  the flag as dead there (`export::emit_block` and `emit::segment_end` each
+  require the depth to match before absorbing a continuation), so `normalize`
+  now clears it, which states what was already true and changes nothing
+  observable. `Content::validate` gains `Invariant::ContinuesAcrossContainers`
+  to catch a hand-built content that skipped `normalize`, and
+  `LineOp::SetContinues` refuses the *deliberate* crossing up front with
+  `ApplyError::ContinuesAcrossContainers` — the same repair-or-refuse split the
+  line-kind rule already makes. This was the one relational line invariant
+  nothing checked: `validate` is otherwise strictly per-line, while every
+  container rule is a property of a line pair.
+
 - fix(content): **two adjacent containers of one shape are no longer read as
   one.** Container identity is the container path plus contiguity, and the path
   carried nothing to tell one instance from the next, so two adjacent runs of

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -388,13 +388,13 @@ impl<'a> Emit<'a> {
     /// discipline (top-level terminated vs list item body).
     fn try_emit_container(&mut self, range: Range<usize>, depth: usize, i: usize) -> Option<usize> {
         match self.rt.lines[i].containers.get(depth).cloned() {
-            Some(Container::ListItem { ordered, start, .. }) => {
-                let j = self.list_run_end(range.clone(), depth, ordered, start, i);
+            Some(key @ Container::ListItem { ordered, start, .. }) => {
+                let j = self.container_run_end(range.clone(), depth, &key, i);
                 self.emit_list(i..j, depth, ordered, start);
                 Some(j)
             }
-            Some(Container::Quote) => {
-                let j = self.container_run_end(range.clone(), depth, &Container::Quote, i);
+            Some(key @ Container::Quote { .. }) => {
+                let j = self.container_run_end(range.clone(), depth, &key, i);
                 self.emit_quote(i..j, depth);
                 Some(j)
             }
@@ -412,8 +412,12 @@ impl<'a> Emit<'a> {
         }
     }
 
-    /// Whole-container equality, what a container with no shape of its own
-    /// (`Quote`, an unknown) needs; [`Self::list_run_end`] is the list sibling.
+    /// One container instance's run: the lines whose container at `depth` has
+    /// the same run key (shape without `ordinal`) *and* the same `instance`.
+    ///
+    /// One rule for every container kind. A list's items differ only in
+    /// `ordinal`, which the run key masks, so they group; an adjacent list of
+    /// identical shape carries the other `instance`, so it does not.
     fn container_run_end(
         &self,
         range: Range<usize>,
@@ -422,7 +426,12 @@ impl<'a> Emit<'a> {
         i: usize,
     ) -> usize {
         let mut j = i + 1;
-        while j < range.end && self.rt.lines[j].containers.get(depth) == Some(key) {
+        while j < range.end
+            && self.rt.lines[j]
+                .containers
+                .get(depth)
+                .is_some_and(|c| c.same_run(key) && c.instance() == key.instance())
+        {
             j += 1;
         }
         j
@@ -435,30 +444,6 @@ impl<'a> Emit<'a> {
             && self.rt.lines[j].continues
         {
             j += 1;
-        }
-        j
-    }
-
-    /// Different-shape adjacent lists stay separate; same-shape ones already
-    /// merged at import.
-    fn list_run_end(
-        &self,
-        range: Range<usize>,
-        depth: usize,
-        ordered: bool,
-        start: u64,
-        i: usize,
-    ) -> usize {
-        let mut j = i + 1;
-        while j < range.end {
-            match self.rt.lines[j].containers.get(depth) {
-                Some(Container::ListItem {
-                    ordered: o,
-                    start: s,
-                    ..
-                }) if *o == ordered && *s == start => j += 1,
-                _ => break,
-            }
         }
         j
     }
@@ -519,7 +504,11 @@ impl<'a> Emit<'a> {
         let indent = "  ".repeat(depth);
         self.out.push_str(&indent);
         if ordered {
-            if first && start != 1 {
+            // Typst runs one counter across adjacent `+` items
+            // (`typst-layout::lists` takes `item.number.unwrap_or(number)`), so
+            // two adjacent lists would number 1 2 3 4. Stating the first item's
+            // number resets it, which is the whole boundary in the projection.
+            if first {
                 self.out.push_str(&format!("{}. ", start));
             } else {
                 self.out.push_str("+ ");
@@ -1455,6 +1444,7 @@ mod tests {
         let indent = || Container::Unknown {
             tag: "indent".to_string(),
             attrs: serde_json::Value::Null,
+            instance: 0,
         };
         let mut rt = Content::new(
             "heads up\nsecond".to_string(),
@@ -1477,8 +1467,8 @@ mod tests {
             "heads up#linebreak()second\n\n"
         );
         // Inside a known container the known wrapper still renders.
-        rt.lines[0].containers.insert(0, Container::Quote);
-        rt.lines[1].containers.insert(0, Container::Quote);
+        rt.lines[0].containers.insert(0, Container::Quote { instance: 0 });
+        rt.lines[1].containers.insert(0, Container::Quote { instance: 0 });
         assert_eq!(
             emit_content(&rt).unwrap().markup,
             "#quote(block: true)[\nheads up#linebreak()second\n\n]\n\n"

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -779,6 +779,7 @@ mod tests {
                 ordered: false,
                 start: 1,
                 ordinal,
+                instance: 0,
             }])
         };
         let mut rt = Content::new(

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -245,6 +245,7 @@ export declare function isListItemContainer(
 	ordered: boolean;
 	start: number;
 	ordinal: number;
+	instance?: number;
 };
 
 // The guards above answer "is this arm X". These four answer "is this a value

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -454,7 +454,7 @@ export function isCodeLine(line) {
 
 /**
  * @param {import('../core/wasm.js').ContentContainer} container
- * @returns {container is import('../core/wasm.js').ContentContainer & { container: 'list_item'; ordered: boolean; start: number; ordinal: number }}
+ * @returns {container is import('../core/wasm.js').ContentContainer & { container: 'list_item'; ordered: boolean; start: number; ordinal: number; instance?: number }}
  */
 export function isListItemContainer(container) {
 	return container.container === 'list_item';

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -221,11 +221,18 @@ export type ContentLineKind =
 
 /** An ancestor block a line nests inside, outermost first. Open like
  * `ContentLine.kind`: an unrecognized container round-trips with opaque `attrs`
- * and renders transparently (its lines sit at the enclosing level). */
+ * and renders transparently (its lines sit at the enclosing level).
+ *
+ * Two adjacent lines sit in the same container iff their whole path matches.
+ * `instance` is what tells one container from an adjacent sibling of identical
+ * shape — two consecutive quotes, or two consecutive lists — which contiguity
+ * alone reads as one. Omit it (or write `0`) unless a path immediately above or
+ * below is otherwise identical; a write is canonicalized to `0`/`1` on the way
+ * in, so any distinct pair of values works. */
 export type ContentContainer =
-    | { container: "list_item"; ordered: boolean; start: number; ordinal: number }
-    | { container: "quote" }
-    | { container: string; attrs: unknown };
+    | { container: "list_item"; ordered: boolean; start: number; ordinal: number; instance?: number }
+    | { container: "quote"; instance?: number }
+    | { container: string; attrs: unknown; instance?: number };
 
 /** A mark over char range `[start, end)` into `Content.text`. The open `type`
  * arm blocks discriminant narrowing, so read a payload-carrying arm behind its

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -205,20 +205,37 @@ fn emit_container(
             ordered,
             start,
             ordinal,
+            instance,
         } => {
+            // CommonMark starts a new list at a change of bullet char or of
+            // ordered delimiter, and stores neither, so the marker is where the
+            // `instance` alternation lands: it spells two adjacent lists apart
+            // in the projection exactly as `instance` does in the model.
+            //
+            // `+` rather than `*` for the second bullet: `* ***` is four
+            // asterisks separated by spaces, which reads as a thematic break
+            // and would take the item with it (see
+            // `rule_opening_a_list_item_keeps_its_item`).
             let marker = if *ordered {
                 // `start`/`ordinal` are unbounded `u64` and `validate` does not
                 // ceiling them, so a corrupt/adversarial content can drive the
                 // sum past `u64::MAX`; saturate rather than panic (or wrap under
                 // release overflow-checks) on the render path.
-                format!("{}. ", start.saturating_add(*ordinal))
-            } else {
+                let n = start.saturating_add(*ordinal);
+                if instance % 2 == 0 {
+                    format!("{n}. ")
+                } else {
+                    format!("{n}) ")
+                }
+            } else if instance % 2 == 0 {
                 "- ".to_string()
+            } else {
+                "+ ".to_string()
             };
             let indent = " ".repeat(marker.len());
             prefix_lines(&inner, &marker, &indent, out);
         }
-        Container::Quote => {
+        Container::Quote { .. } => {
             // `> ` on content lines, `>` on blank lines so paragraphs stay in
             // one quote on re-import.
             prefix_quote(&inner, out);
@@ -975,6 +992,117 @@ mod tests {
     use crate::model::{Line, Loss, Mark};
 
     /// export∘import is the identity on the content.
+    /// A content built by hand, as a client writing `Content` directly builds
+    /// one, normalized the way every write lane normalizes it.
+    fn stored(text: &str, containers: Vec<Vec<Container>>) -> Content {
+        let lines = containers
+            .into_iter()
+            .map(|c| {
+                let mut l = crate::model::Line::new(LineKind::Para);
+                l.containers = c;
+                l
+            })
+            .collect();
+        let mut rt = Content::new(text.to_string(), lines);
+        rt.normalize();
+        rt.validate().expect("stored content validates");
+        rt
+    }
+
+    fn li(ordinal: u64, instance: u64) -> Vec<Container> {
+        vec![Container::ListItem {
+            ordered: false,
+            start: 1,
+            ordinal,
+            instance,
+        }]
+    }
+
+    fn oli(ordinal: u64, instance: u64) -> Vec<Container> {
+        vec![Container::ListItem {
+            ordered: true,
+            start: 1,
+            ordinal,
+            instance,
+        }]
+    }
+
+    /// The shapes #1357 recorded as inexpressible, now spelled by `instance`
+    /// and carried through markdown by the marker alternation CommonMark
+    /// already reads. Each is checked *from storage*, not from an import, since
+    /// a client writing `Content` directly is the lane that mints them.
+    #[test]
+    fn adjacent_sibling_containers_project_and_return() {
+        let cases: &[(Content, &str)] = &[
+            // Two one-item lists: the shape that used to come back as one item
+            // with an unnumbered continuation paragraph.
+            (stored("a\nb", vec![li(0, 0), li(0, 1)]), "- a\n\n+ b"),
+            // Which is still distinct from one item spanning two paragraphs.
+            (stored("a\nb", vec![li(0, 0), li(0, 0)]), "- a\n\n  b"),
+            // A one-item list then a longer one: no ordinal below 0 to restart
+            // to, so nothing but `instance` can hold this apart.
+            (
+                stored("a\nb\nc", vec![li(0, 0), li(0, 1), li(1, 1)]),
+                "- a\n\n+ b\n\n+ c",
+            ),
+            // Two adjacent quotes, which markdown spells with the blank line.
+            (
+                stored(
+                    "a\nb",
+                    vec![
+                        vec![Container::Quote { instance: 0 }],
+                        vec![Container::Quote { instance: 1 }],
+                    ],
+                ),
+                "> a\n\n> b",
+            ),
+            // Still distinct from one quote of two paragraphs.
+            (
+                stored(
+                    "a\nb",
+                    vec![
+                        vec![Container::Quote { instance: 0 }],
+                        vec![Container::Quote { instance: 0 }],
+                    ],
+                ),
+                "> a\n>\n> b",
+            ),
+        ];
+        for (rt, expected) in cases {
+            let md = to_markdown(rt);
+            assert_eq!(&md, expected);
+            assert_eq!(&from_markdown(&md).unwrap(), rt, "{md:?} did not return");
+        }
+    }
+
+    /// The alternate markers meet the rule collision the primary ones already
+    /// dodge. `+ ***` is a list item holding a thematic break; `* ***` would be
+    /// four asterisks separated by spaces, which is a break outright and takes
+    /// the item with it — which is why the second bullet is `+`.
+    #[test]
+    fn alternate_markers_do_not_collide_with_a_rule() {
+        let mut rt = stored("a\n\nb", vec![li(0, 0), li(0, 1), li(1, 1)]);
+        rt.lines[1].kind = LineKind::Rule;
+        rt.validate().expect("validates");
+        assert_eq!(to_markdown(&rt), "- a\n\n+ ***\n\n+ b");
+        assert_eq!(from_markdown(&to_markdown(&rt)).unwrap(), rt);
+
+        let mut rt = stored("a\n\nb", vec![oli(0, 0), oli(0, 1), oli(1, 1)]);
+        rt.lines[1].kind = LineKind::Rule;
+        assert_eq!(to_markdown(&rt), "1. a\n\n1) ***\n\n2) b");
+        assert_eq!(from_markdown(&to_markdown(&rt)).unwrap(), rt);
+    }
+
+    /// Two ordered lists whose `start` differs: CommonMark reads only a list's
+    /// *first* number, so without a marker change the second list's `start`
+    /// re-imports as the first list's second item.
+    #[test]
+    fn adjacent_ordered_lists_keep_their_start() {
+        let rt = from_markdown("1. a\n\n<!-- -->\n\n3. b").unwrap();
+        assert_eq!(to_markdown(&rt), "1. a\n\n3) b");
+        round_trips("1. a\n\n<!-- -->\n\n3. b");
+    }
+
     fn round_trips(md: &str) {
         let rt = from_markdown(md).unwrap();
         let md2 = to_markdown(&rt);
@@ -1025,6 +1153,7 @@ mod tests {
                     containers: vec![Container::Unknown {
                         tag: "indent".into(),
                         attrs: serde_json::Value::Null,
+                        instance: 0,
                     }],
                     continues: false,
                 },
@@ -1033,6 +1162,7 @@ mod tests {
                     containers: vec![Container::Unknown {
                         tag: "indent".into(),
                         attrs: serde_json::Value::Null,
+                        instance: 0,
                     }],
                     continues: false,
                 },
@@ -1044,8 +1174,8 @@ mod tests {
         assert_eq!(rt.validate(), Ok(()));
         assert_eq!(to_markdown(&rt), "**heads** up\n\nstill inside");
         // An unknown container inside a known one adds no prefix of its own.
-        rt.lines[0].containers.insert(0, Container::Quote);
-        rt.lines[1].containers.insert(0, Container::Quote);
+        rt.lines[0].containers.insert(0, Container::Quote { instance: 0 });
+        rt.lines[1].containers.insert(0, Container::Quote { instance: 0 });
         assert_eq!(to_markdown(&rt), "> **heads** up\n>\n> still inside");
     }
 

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -11,10 +11,9 @@
 //! - **Soft breaks → space; hard breaks → a `continues` line**, kept distinct
 //!   from a paragraph boundary. A hard break inside a heading is a space, ATX
 //!   headings being unable to carry one.
-//! - **Adjacent sibling lists of the same shape merge.** Item identity is
-//!   positional `ordinal`, not a minted list instance, so two consecutive lists
-//!   whose items share an `ordinal` are indistinguishable from one list.
-//!   Adjacent block quotes likewise merge.
+//! - **Adjacent sibling containers keep their boundary.** Two consecutive lists
+//!   of one shape, and two consecutive block quotes, are told apart by
+//!   `Container::instance`, minted here and canonicalized by `normalize`.
 //! - **Empty blocks and containers keep their line**, so the structure survives
 //!   rather than vanishing.
 //! - **Island ids are minted sequentially** (`isl-0`, `isl-1`, …), so import is
@@ -200,6 +199,10 @@ struct Builder {
     /// quote, an empty `- ` item) can still get one.
     container_marks: Vec<usize>,
     list_stack: Vec<ListInfo>,
+    /// Bumped at every container open, so two adjacent runs of one shape never
+    /// carry the same `instance`. Only distinctness matters: `normalize`
+    /// rewrites these to the canonical `0`/`1` alternation.
+    next_instance: u64,
     // code block
     code_lang: Option<String>,
     in_code: bool,
@@ -218,6 +221,9 @@ struct ListInfo {
     start: u64,
     /// 0-based index of the next item: becomes the item's `ordinal`.
     count: u64,
+    /// Shared by every item of this list, so the items of one list group and
+    /// an adjacent list of the same shape does not join them.
+    instance: u64,
 }
 
 struct TableAcc {
@@ -261,6 +267,7 @@ impl Builder {
             containers: Vec::new(),
             container_marks: Vec::new(),
             list_stack: Vec::new(),
+            next_instance: 0,
             code_lang: None,
             in_code: false,
             code_opened: false,
@@ -308,6 +315,12 @@ impl Builder {
 
     /// Lines emitted so far, counting the line currently open. A container that
     /// closes with this unchanged from when it opened produced nothing.
+    /// A container-instance value nothing else in this import holds.
+    fn mint_instance(&mut self) -> u64 {
+        self.next_instance += 1;
+        self.next_instance
+    }
+
     fn emitted(&self) -> usize {
         self.lines.len() + usize::from(self.cur.is_some())
     }
@@ -481,10 +494,12 @@ impl Builder {
             }
             Tag::List(start) => {
                 self.pending = None; // nested list content sets its own
+                let instance = self.mint_instance();
                 self.list_stack.push(ListInfo {
                     ordered: start.is_some(),
                     start: start.unwrap_or(1),
                     count: 0,
+                    instance,
                 });
             }
             Tag::Item => {
@@ -500,12 +515,14 @@ impl Builder {
                             ordered: info.ordered,
                             start: info.start,
                             ordinal,
+                            instance: info.instance,
                         }
                     }
                     None => Container::ListItem {
                         ordered: false,
                         start: 1,
                         ordinal: 0,
+                        instance: 0,
                     },
                 };
                 self.containers.push(container);
@@ -514,7 +531,8 @@ impl Builder {
             Tag::BlockQuote(_) => {
                 self.pending = None; // quote content sets its own
                 self.container_marks.push(self.emitted());
-                self.containers.push(Container::Quote);
+                let instance = self.mint_instance();
+                self.containers.push(Container::Quote { instance });
                 self.check_depth()?;
             }
             Tag::Table(aligns) => {
@@ -1053,7 +1071,8 @@ mod tests {
             vec![Container::ListItem {
                 ordered: false,
                 start: 1,
-                ordinal: 0
+                ordinal: 0,
+                instance: 0,
             }]
         );
         assert_eq!(
@@ -1061,7 +1080,8 @@ mod tests {
             vec![Container::ListItem {
                 ordered: false,
                 start: 1,
-                ordinal: 1
+                ordinal: 1,
+                instance: 0,
             }]
         );
     }
@@ -1074,7 +1094,8 @@ mod tests {
             vec![Container::ListItem {
                 ordered: true,
                 start: 3,
-                ordinal: 0
+                ordinal: 0,
+                instance: 0,
             }]
         );
         assert_eq!(
@@ -1082,7 +1103,8 @@ mod tests {
             vec![Container::ListItem {
                 ordered: true,
                 start: 3,
-                ordinal: 1
+                ordinal: 1,
+                instance: 0,
             }]
         );
     }
@@ -1097,7 +1119,8 @@ mod tests {
             vec![Container::ListItem {
                 ordered: false,
                 start: 1,
-                ordinal: 0
+                ordinal: 0,
+                instance: 0,
             }]
         );
     }
@@ -1106,7 +1129,7 @@ mod tests {
     fn blockquote_container() {
         let rt = imp("> quoted");
         assert_eq!(rt.text, "quoted");
-        assert_eq!(rt.lines[0].containers, vec![Container::Quote]);
+        assert_eq!(rt.lines[0].containers, vec![Container::Quote { instance: 0 }]);
     }
 
     #[test]
@@ -1188,16 +1211,55 @@ mod tests {
     fn empty_blockquote_keeps_its_line() {
         let rt = imp("> ");
         assert_eq!(rt.lines.len(), 1);
-        assert_eq!(rt.lines[0].containers, vec![Container::Quote]);
+        assert_eq!(rt.lines[0].containers, vec![Container::Quote { instance: 0 }]);
     }
 
+    /// Every way markdown spells two adjacent sibling containers apart — a
+    /// bullet-char change, an ordered-delimiter change, an HTML comment between
+    /// them, a blank line between quotes — reaches the model as two runs
+    /// carrying different `instance`, and survives the round trip as two.
     #[test]
-    fn adjacent_sibling_lists_merge_is_stable() {
-        // Two sibling bullet lists collapse to one: distinct markdown, one
-        // content, and the content is still a fixed point.
-        let rt = imp("* a\n\n+ b");
-        let rt2 = from_markdown(&crate::export::to_markdown(&rt)).unwrap();
-        assert_eq!(rt, rt2, "merged sibling lists still round-trip");
+    fn adjacent_sibling_containers_keep_their_boundary() {
+        let cases: &[(&str, usize)] = &[
+            ("* a\n\n+ b", 2),
+            ("- a\n\n<!-- -->\n\n- b", 2),
+            ("1. a\n\n1) b", 2),
+            ("1. a\n\n<!-- -->\n\n3. b", 2),
+            ("> a\n\n> b", 2),
+            // Three in a row: the discriminator alternates rather than climbing.
+            ("- a\n\n<!-- -->\n\n- b\n\n<!-- -->\n\n- c", 3),
+            // The non-boundaries, pinned against a rule that splits too eagerly.
+            ("- a\n- b", 1),
+            ("> a\n>\n> b", 1),
+        ];
+        for (md, runs) in cases {
+            let rt = imp(md);
+            let mut seen: Vec<_> = rt
+                .lines
+                .iter()
+                .map(|l| (l.containers[0].run_key(), l.containers[0].instance()))
+                .collect();
+            seen.dedup();
+            assert_eq!(seen.len(), *runs, "{md:?} -> {:?}", rt.lines);
+            let rt2 = from_markdown(&crate::export::to_markdown(&rt)).unwrap();
+            assert_eq!(rt, rt2, "{md:?} is not a fixed point");
+        }
+    }
+
+    /// The canonical `instance` is 0 wherever nothing adjacent needs telling
+    /// apart, so an ordinary document carries no discriminator at all.
+    #[test]
+    fn instance_stays_zero_without_an_adjacent_sibling() {
+        for md in ["- a\n- b\n- c", "> a\n>\n> b", "1. a\n2. b", "- a\n\npara\n\n- b"] {
+            let rt = imp(md);
+            assert!(
+                rt.lines
+                    .iter()
+                    .all(|l| l.containers.iter().all(|c| c.instance() == 0)),
+                "{md:?} minted a discriminator it does not need: {:?}",
+                rt.lines
+            );
+        }
     }
 
     #[test]

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -633,6 +633,12 @@ pub enum Invariant {
     BadHeadingLevel(u8),
     /// The first line has `continues: true` (nothing precedes it to continue).
     FirstLineContinues,
+    /// A line has `continues: true` but sits in a different container path than
+    /// the line before it, so the block it claims to continue is not the block
+    /// above. `normalize` clears the flag; this catches a hand-built content
+    /// that skipped it, the same pairing as
+    /// [`LineKindMismatch`](Invariant::LineKindMismatch).
+    ContinuesAcrossContainers { line: usize },
     /// An [`MarkKind::Unknown`] reused a reserved built-in `type` name.
     ReservedUnknownTag(String),
     /// A [`LineKind::Unknown`] reused a reserved built-in `kind` name: its
@@ -800,6 +806,20 @@ impl Content {
     /// serialization commits to.
     pub fn normalize(&mut self) {
         canonicalize_containers(&mut self.lines);
+        // A `continues` line whose container path differs from the line above
+        // claims to continue a block it is not in. `Join` mints these by
+        // merging two lines of differing paths, leaving the *next* line
+        // continuing across the seam. Both projections already read the flag as
+        // dead there — `export::emit_block` and `emit::segment_end` both
+        // require the depth to match before they absorb a continuation — so
+        // clearing it changes nothing observable and states what is already
+        // true. Same treatment, and the same reason, as the line-kind demotion
+        // below; a *deliberate* one is refused up front by the op channel.
+        for i in 1..self.lines.len() {
+            if self.lines[i].continues && self.lines[i].containers != self.lines[i - 1].containers {
+                self.lines[i].continues = false;
+            }
+        }
         // A splice writes text, never kinds: typing into a table line leaves it
         // `Island` over prose, joining a fence to an image line leaves it `Code`
         // over a slot, and export reads the kind and not the text, so the
@@ -923,6 +943,16 @@ impl Content {
         }
         if self.lines.first().is_some_and(|l| l.continues) {
             return Err(Invariant::FirstLineContinues);
+        }
+        // The one relational line invariant `validate` carries. Every other
+        // container rule is a property of a line pair too, and `normalize`
+        // settles each: a non-canonical `ordinal` renumbers, a run opening
+        // under a fresh parent re-reads, this flag clears. What is left here is
+        // the assertion that it ran.
+        for (i, pair) in self.lines.windows(2).enumerate() {
+            if pair[1].continues && pair[1].containers != pair[0].containers {
+                return Err(Invariant::ContinuesAcrossContainers { line: i + 1 });
+            }
         }
         // Only the formatting-mark edge test below reads it.
         let chars: Vec<char> = if self.marks.iter().any(|m| m.kind.is_formatting()) {
@@ -1573,6 +1603,67 @@ mod tests {
             );
             assert_eq!(once, twice);
         }
+    }
+
+    /// A within-block break lives inside one container. `Join` mints the
+    /// crossing shape by merging two lines of differing paths, which leaves the
+    /// *next* line continuing across the seam; `normalize` clears it, and
+    /// `validate` asserts that it ran.
+    #[test]
+    fn continues_across_a_container_boundary_is_cleared() {
+        let mut rt = Content::new(
+            "a\nb".to_string(),
+            vec![
+                Line::new(LineKind::Para),
+                Line::new(LineKind::Para)
+                    .with_containers(vec![Container::Quote { instance: 0 }])
+                    .with_continues(true),
+            ],
+        );
+        assert_eq!(
+            rt.validate(),
+            Err(Invariant::ContinuesAcrossContainers { line: 1 }),
+            "a hand-built content that skipped normalize is caught"
+        );
+        rt.normalize();
+        assert!(!rt.lines[1].continues, "normalize clears it");
+        assert_eq!(rt.validate(), Ok(()));
+
+        // Equal-length but different containers is the same crossing: two list
+        // items are two blocks, and a hard break does not span them.
+        let li = |ordinal| {
+            vec![Container::ListItem {
+                ordered: false,
+                start: 1,
+                ordinal,
+                instance: 0,
+            }]
+        };
+        let mut rt = Content::new(
+            "a\nb".to_string(),
+            vec![
+                Line::new(LineKind::Para).with_containers(li(0)),
+                Line::new(LineKind::Para)
+                    .with_containers(li(1))
+                    .with_continues(true),
+            ],
+        );
+        rt.normalize();
+        assert!(!rt.lines[1].continues);
+
+        // The within-container break is untouched: same path, flag kept.
+        let mut rt = Content::new(
+            "a\nb".to_string(),
+            vec![
+                Line::new(LineKind::Para).with_containers(li(0)),
+                Line::new(LineKind::Para)
+                    .with_containers(li(0))
+                    .with_continues(true),
+            ],
+        );
+        rt.normalize();
+        assert!(rt.lines[1].continues, "a hard break inside one item survives");
+        assert_eq!(rt.validate(), Ok(()));
     }
 
     #[test]

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -1123,6 +1123,13 @@ fn canonicalize_containers(lines: &mut [Line]) {
                 if raw_ordinal != run.raw_ordinal {
                     run.ordinal += 1;
                     run.raw_ordinal = raw_ordinal;
+                    // The run continues but the *item* changed, and an item is
+                    // a parent: everything below is inside a different one, so
+                    // it neither continues its predecessor nor has an adjacent
+                    // sibling to be told apart from. Two inner lists under two
+                    // outer items are two lists however alike they look.
+                    state.truncate(d + 1);
+                    opened_above = true;
                 }
             } else {
                 // The run being replaced is this one's adjacent predecessor,
@@ -1566,6 +1573,51 @@ mod tests {
             canon(vec![li(0, 1), li(0, 2), li(0, 3)]),
             vec![(0, 0), (0, 1), (0, 0)]
         );
+        // An *item* boundary is a parent boundary: two inner lists under two
+        // outer items are two lists, so the inner ordinal restarts and the
+        // inner discriminator resets. Without this the second item's inner run
+        // continues the first's, and the two project to one markdown.
+        let outer = |ordinal| Container::ListItem {
+            ordered: false,
+            start: 1,
+            ordinal,
+            instance: 0,
+        };
+        let inner = |ordinal| Container::ListItem {
+            ordered: true,
+            start: 1,
+            ordinal,
+            instance: 0,
+        };
+        let nested = |a: Container, b: Container| {
+            let mut rt = Content::new(
+                "x\ny".to_string(),
+                vec![
+                    Line::new(LineKind::Para).with_containers(vec![outer(0), a]),
+                    Line::new(LineKind::Para).with_containers(vec![outer(1), b]),
+                ],
+            );
+            rt.normalize();
+            rt.lines
+                .iter()
+                .map(|l| match &l.containers[1] {
+                    Container::ListItem {
+                        ordinal, instance, ..
+                    } => (*ordinal, *instance),
+                    other => (0, other.instance()),
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(nested(inner(5), inner(7)), vec![(0, 0), (0, 0)]);
+        assert_eq!(
+            nested(
+                Container::Quote { instance: 3 },
+                Container::Quote { instance: 8 }
+            ),
+            vec![(0, 0), (0, 0)],
+            "an inner quote under the next item needs no discriminator"
+        );
+
         // A different container kind between them is already a boundary, so
         // the discriminator resets.
         assert_eq!(

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -141,27 +141,136 @@ impl LineKind {
 pub enum Container {
     /// A list item. `ordered` distinguishes `1.` from `-`; `start` is the list's
     /// first number (1 by default); `ordinal` is this item's 0-based index in
-    /// its list. Two *adjacent* lines belong to the same item iff their whole
-    /// container path (ordinals included) is equal. Identity is path **plus
-    /// contiguity**: two sibling inner lists under one outer item can produce
-    /// equal first-item paths, distinguished only by the non-adjacency of their
-    /// runs.
+    /// its list; `instance` tells this list from an adjacent one of the same
+    /// shape (see [`Container::instance`]).
+    ///
+    /// Two *adjacent* lines belong to the same item iff their whole container
+    /// path is equal. Identity is path **plus contiguity**: two sibling inner
+    /// lists under one outer item can produce equal first-item paths,
+    /// distinguished only by the non-adjacency of their runs.
     ListItem {
         ordered: bool,
         start: u64,
         ordinal: u64,
+        instance: u64,
     },
-    /// A block quote. Adjacent lines sharing `[Quote]` are one multi-paragraph
-    /// quote; two adjacent separate quotes are not distinguished (they merge on
-    /// round-trip: a documented canonicalization).
-    Quote,
+    /// A block quote. Adjacent lines sharing one `Quote` are one
+    /// multi-paragraph quote; two adjacent quotes differ in `instance`.
+    Quote { instance: u64 },
     /// Open-set escape hatch: a container this build does not know, kept in the
     /// path so it round-trips, transparent to both projections. Two adjacent
-    /// lines sit in the same one iff their whole `(tag, attrs)` is equal.
+    /// lines sit in the same one iff their whole `(tag, attrs, instance)` is
+    /// equal.
     Unknown {
         tag: String,
         attrs: JsonValue,
+        instance: u64,
     },
+}
+
+impl Container {
+    /// Which instance of its shape this container is, among a run of adjacent
+    /// siblings that would otherwise be indistinguishable.
+    ///
+    /// Container identity is path plus contiguity, so two adjacent runs of
+    /// equal shape read as one: `[Quote], [Quote]` is one quote, and two
+    /// one-item lists are one item spanning two paragraphs. `instance` is the
+    /// one field that exists to break that tie, and it is the whole reason the
+    /// encoding is complete rather than a quotient.
+    ///
+    /// [`Content::normalize`] canonicalizes it to **0, flipping to 1 only where
+    /// the adjacent preceding sibling run would otherwise weld with this one**,
+    /// so a document that needs no discriminator carries none, and one that
+    /// needs it alternates `0, 1, 0, 1`. Non-adjacent runs never collide, so
+    /// two values suffice. A producer may mint any distinct values it likes;
+    /// normalize collapses them to the canonical pair.
+    pub fn instance(&self) -> u64 {
+        match self {
+            Container::ListItem { instance, .. }
+            | Container::Quote { instance }
+            | Container::Unknown { instance, .. } => *instance,
+        }
+    }
+
+    /// This container with `instance` replaced.
+    #[cfg(test)]
+    pub(crate) fn with_instance(&self, n: u64) -> Container {
+        let mut c = self.clone();
+        c.set_instance(n);
+        c
+    }
+
+    fn set_instance(&mut self, n: u64) {
+        match self {
+            Container::ListItem { instance, .. }
+            | Container::Quote { instance }
+            | Container::Unknown { instance, .. } => *instance = n,
+        }
+    }
+
+    /// Whether these two share a [`run_key`](Self::run_key), without building
+    /// one: an `Unknown`'s key holds its whole `attrs`, and both the emitters
+    /// and `normalize` ask this once per line.
+    pub fn same_run(&self, other: &Container) -> bool {
+        match (self, other) {
+            (
+                Container::ListItem {
+                    ordered: a, start: b, ..
+                },
+                Container::ListItem {
+                    ordered: c, start: d, ..
+                },
+            ) => a == c && b == d,
+            (Container::Quote { .. }, Container::Quote { .. }) => true,
+            (
+                Container::Unknown {
+                    tag: a, attrs: b, ..
+                },
+                Container::Unknown {
+                    tag: c, attrs: d, ..
+                },
+            ) => a == c && b == d,
+            _ => false,
+        }
+    }
+
+    /// Whether two adjacent runs of these shapes would weld — that is, whether
+    /// the second needs a fresh `instance` to be readable as its own container.
+    ///
+    /// Coarser than [`same_run`](Self::same_run) for lists, because `start` is
+    /// invisible in Markdown: CommonMark reads only a list's *first* number, so
+    /// `1. a` beside `3. b` re-imports as one list of two items and the second
+    /// list's `start` is lost. Comparing `ordered` alone mints the
+    /// discriminator there too, and the marker alternation carries it.
+    fn same_weld(&self, other: &Container) -> bool {
+        match (self, other) {
+            (Container::ListItem { ordered: a, .. }, Container::ListItem { ordered: b, .. }) => {
+                a == b
+            }
+            _ => self.same_run(other),
+        }
+    }
+
+    /// This container's **run key**: its shape with `ordinal` and `instance`
+    /// masked off. Two adjacent lines sit in the same container instance iff
+    /// their run keys *and* instances match; the two emitters and
+    /// `quill::support::census` all group on that pair.
+    pub fn run_key(&self) -> Container {
+        match self {
+            Container::ListItem { ordered, start, .. } => Container::ListItem {
+                ordered: *ordered,
+                start: *start,
+                ordinal: 0,
+                instance: 0,
+            },
+            Container::Quote { .. } => Container::Quote { instance: 0 },
+            Container::Unknown { tag, attrs, .. } => Container::Unknown {
+                tag: tag.clone(),
+                attrs: attrs.clone(),
+                instance: 0,
+            },
+        }
+    }
 }
 
 /// A mark over a char range `[start, end)`. `start == end` (zero-width) is legal
@@ -684,11 +793,13 @@ impl Content {
         self.text.chars().filter(|c| *c == '\n').count() + 1
     }
 
-    /// Normalize marks in place: drop zero-width formatting, union same-kind
-    /// formatting that is adjacent or overlapping, recursively key-sort island
-    /// props and unknown-mark attrs, then sort marks canonically. Idempotent:
-    /// the fixed point the canonical serialization commits to.
+    /// Normalize in place: canonicalize container `ordinal`/`instance`, drop
+    /// zero-width formatting, union same-kind formatting that is adjacent or
+    /// overlapping, recursively key-sort island props and unknown-mark attrs,
+    /// then sort marks canonically. Idempotent: the fixed point the canonical
+    /// serialization commits to.
     pub fn normalize(&mut self) {
+        canonicalize_containers(&mut self.lines);
         // A splice writes text, never kinds: typing into a table line leaves it
         // `Island` over prose, joining a fence to an image line leaves it `Code`
         // over a slot, and export reads the kind and not the text, so the
@@ -870,7 +981,7 @@ impl Content {
                 _ => {}
             }
             for c in &line.containers {
-                if let Container::Unknown { tag, attrs } = c {
+                if let Container::Unknown { tag, attrs, .. } = c {
                     if Self::RESERVED_CONTAINERS.contains(&tag.as_str()) {
                         return Err(Invariant::ReservedUnknownContainer(tag.clone()));
                     }
@@ -933,6 +1044,83 @@ impl Content {
 /// same-kind formatting marks union when adjacent *or* overlapping, different
 /// kinds overlap freely (never split into runs), and identity/unknown marks
 /// never merge. Zero-width formatting is dropped; zero-width anchors survive.
+/// One open container run, while [`canonicalize_containers`] walks past it.
+struct Run {
+    /// The container **as stored** at the line that opened this run, which is
+    /// what decides where the input's runs begin: a producer's own `instance`
+    /// values separate its runs whatever they are, and only their canonical
+    /// spelling is this pass's business. Cloned once per run, not per line.
+    raw: Container,
+    instance: u64,
+    ordinal: u64,
+    raw_ordinal: u64,
+}
+
+/// Canonicalize every container path: `instance` to the minimal discriminator
+/// the adjacency needs, `ordinal` to a gapless 0-based index.
+///
+/// Both are derived from *run structure*, which the stored path already spells:
+/// a run opens where the stored run key or the stored `instance` changes, and
+/// within one list item `ordinal` repeating continues that item across its
+/// paragraphs while any change opens the next. So `[5, 9]` and `[0, 1]` are the
+/// same two items, `[3, 3, 7]` is two items the first of which spans two
+/// paragraphs, and a producer's `instance: 7, 9` pair reads as the same two
+/// runs as `0, 1`.
+///
+/// `instance` resets to 0 wherever the preceding sibling run could not weld
+/// with this one anyway — a different container kind, an intervening block, a
+/// fresh parent — so it stays 0 in every document that needs no discriminator.
+fn canonicalize_containers(lines: &mut [Line]) {
+    let mut state: Vec<Run> = Vec::new();
+    for line in lines.iter_mut() {
+        let depth_len = line.containers.len();
+        // Once a depth opens a new run, every depth below it is under a fresh
+        // parent, so nothing there can be continuing a run and nothing there
+        // has an adjacent predecessor to be told apart from.
+        let mut opened_above = false;
+        for d in 0..depth_len {
+            let here = &line.containers[d];
+            let raw_ordinal = match here {
+                Container::ListItem { ordinal, .. } => *ordinal,
+                _ => 0,
+            };
+            let continues = !opened_above
+                && state
+                    .get(d)
+                    .is_some_and(|r| r.raw.same_run(here) && r.raw.instance() == here.instance());
+            if continues {
+                let run = &mut state[d];
+                if raw_ordinal != run.raw_ordinal {
+                    run.ordinal += 1;
+                    run.raw_ordinal = raw_ordinal;
+                }
+            } else {
+                // The run being replaced is this one's adjacent predecessor,
+                // and only then: a fresh parent above leaves none.
+                let instance = match state.get(d) {
+                    Some(prev) if !opened_above && prev.raw.same_weld(here) => 1 - prev.instance,
+                    _ => 0,
+                };
+                let raw = here.clone();
+                state.truncate(d);
+                state.push(Run {
+                    raw,
+                    instance,
+                    ordinal: 0,
+                    raw_ordinal,
+                });
+                opened_above = true;
+            }
+            let (ordinal, instance) = (state[d].ordinal, state[d].instance);
+            if let Container::ListItem { ordinal: o, .. } = &mut line.containers[d] {
+                *o = ordinal;
+            }
+            line.containers[d].set_instance(instance);
+        }
+        state.truncate(depth_len);
+    }
+}
+
 pub(crate) fn normalize_marks(marks: Vec<Mark>) -> Vec<Mark> {
     use std::collections::BTreeMap;
 
@@ -1115,9 +1303,9 @@ mod tests {
     #[test]
     fn container_nesting_is_capped() {
         let mut rt = tagged("hi", LineKind::Para);
-        rt.lines[0].containers = vec![Container::Quote; crate::MAX_NESTING_DEPTH];
+        rt.lines[0].containers = vec![Container::Quote { instance: 0 }; crate::MAX_NESTING_DEPTH];
         assert_eq!(rt.validate(), Ok(()));
-        rt.lines[0].containers.push(Container::Quote);
+        rt.lines[0].containers.push(Container::Quote { instance: 0 });
         assert_eq!(
             rt.validate(),
             Err(Invariant::NestingTooDeep {
@@ -1160,6 +1348,7 @@ mod tests {
         rt.lines[0].containers = vec![Container::Unknown {
             tag: "indent".into(),
             attrs: nested(crate::MAX_JSON_DEPTH + 1),
+            instance: 0,
         }];
         assert_eq!(rt.validate(), too_deep("container attrs"));
 
@@ -1287,6 +1476,103 @@ mod tests {
                 segments: 2
             })
         );
+    }
+
+    fn li(ordinal: u64, instance: u64) -> Container {
+        Container::ListItem {
+            ordered: false,
+            start: 1,
+            ordinal,
+            instance,
+        }
+    }
+
+    fn canon(cs: Vec<Container>) -> Vec<(u64, u64)> {
+        let text = vec!["x"; cs.len()].join("\n");
+        let lines = cs
+            .into_iter()
+            .map(|c| {
+                let mut l = Line::new(LineKind::Para);
+                l.containers = vec![c];
+                l
+            })
+            .collect();
+        let mut rt = Content::new(text, lines);
+        rt.normalize();
+        rt.validate().expect("canonical content validates");
+        rt.lines
+            .iter()
+            .map(|l| match &l.containers[0] {
+                Container::ListItem {
+                    ordinal, instance, ..
+                } => (*ordinal, *instance),
+                other => (0, other.instance()),
+            })
+            .collect()
+    }
+
+    /// `ordinal` is a gapless index within a run and `instance` the minimal
+    /// discriminator the adjacency needs; both are read off run structure, so
+    /// a producer's arbitrary values collapse to one spelling.
+    #[test]
+    fn normalize_canonicalizes_container_paths() {
+        // A repeat continues one item across its paragraphs; any change opens
+        // the next item, whatever the stored numbers.
+        assert_eq!(canon(vec![li(5, 0), li(9, 0)]), vec![(0, 0), (1, 0)]);
+        assert_eq!(
+            canon(vec![li(3, 0), li(3, 0), li(7, 0)]),
+            vec![(0, 0), (0, 0), (1, 0)]
+        );
+        // A differing `instance` opens the next *list*, and canonicalizes to
+        // the 0/1 alternation however the producer spelled it.
+        assert_eq!(canon(vec![li(0, 0), li(0, 4)]), vec![(0, 0), (0, 1)]);
+        assert_eq!(
+            canon(vec![li(0, 7), li(1, 7), li(0, 2)]),
+            vec![(0, 0), (1, 0), (0, 1)]
+        );
+        // Three adjacent lists alternate rather than climbing: non-adjacent
+        // runs never collide, so two values suffice.
+        assert_eq!(
+            canon(vec![li(0, 1), li(0, 2), li(0, 3)]),
+            vec![(0, 0), (0, 1), (0, 0)]
+        );
+        // A different container kind between them is already a boundary, so
+        // the discriminator resets.
+        assert_eq!(
+            canon(vec![
+                li(0, 9),
+                Container::Quote { instance: 4 },
+                li(0, 3)
+            ]),
+            vec![(0, 0), (0, 0), (0, 0)]
+        );
+    }
+
+    #[test]
+    fn normalize_of_container_paths_is_idempotent() {
+        for case in [
+            vec![li(5, 0), li(9, 3)],
+            vec![li(0, 1), li(0, 2), li(0, 3)],
+            vec![li(3, 0), li(3, 0), li(7, 8)],
+            vec![Container::Quote { instance: 2 }, Container::Quote { instance: 9 }],
+        ] {
+            let once = canon(case.clone());
+            let twice = canon(
+                case.into_iter()
+                    .zip(&once)
+                    .map(|(c, (ordinal, instance))| match c {
+                        Container::ListItem { ordered, start, .. } => Container::ListItem {
+                            ordered,
+                            start,
+                            ordinal: *ordinal,
+                            instance: *instance,
+                        },
+                        other => other.with_instance(*instance),
+                    })
+                    .collect(),
+            );
+            assert_eq!(once, twice);
+        }
     }
 
     #[test]

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -962,7 +962,7 @@ mod tests {
                 }),
                 LineOp::SetContainers {
                     line: 2,
-                    containers: vec![Container::Quote],
+                    containers: vec![Container::Quote { instance: 0 }],
                 },
             ),
             (
@@ -987,6 +987,7 @@ mod tests {
                     containers: vec![Container::Unknown {
                         tag: "indent".into(),
                         attrs: serde_json::json!({"depth": 2}),
+                        instance: 0,
                     }],
                 },
             ),
@@ -1260,7 +1261,7 @@ mod tests {
     #[test]
     fn line_op_set_containers_is_depth_capped() {
         let mut rt = from_markdown("hi").unwrap();
-        let deep = vec![Container::Quote; crate::MAX_NESTING_DEPTH + 1];
+        let deep = vec![Container::Quote { instance: 0 }; crate::MAX_NESTING_DEPTH + 1];
         assert_eq!(
             rt.apply_line_ops(&[LineOp::SetContainers {
                 line: 0,
@@ -1831,7 +1832,7 @@ mod tests {
         let old_chars: Vec<char> = "a\nbc".chars().collect();
         let l1 = Line {
             kind: LineKind::Heading { level: 5 },
-            containers: vec![Container::Quote],
+            containers: vec![Container::Quote { instance: 0 }],
             continues: true,
         };
         let lines = vec![tag_line(1, false), l1.clone()];
@@ -1843,7 +1844,7 @@ mod tests {
         assert_eq!(out.len(), 3);
         assert_eq!(out[1], l1, "first half is the untouched original line");
         assert_eq!(out[2].kind, LineKind::Heading { level: 5 });
-        assert_eq!(out[2].containers, vec![Container::Quote]);
+        assert_eq!(out[2].containers, vec![Container::Quote { instance: 0 }]);
         assert!(!out[2].continues, "the split clone starts a new block");
     }
 

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -327,6 +327,10 @@ pub enum ApplyError {
     /// nothing before it to continue. Refused because `normalize` does not
     /// repair it.
     FirstLineContinues,
+    /// [`LineOp::SetContinues`] would make a line continue a block it is not in:
+    /// its container path differs from the previous line's, and a within-block
+    /// break lives inside one container.
+    ContinuesAcrossContainers { line: usize },
     /// The text delta's expected base length disagreed with the content:
     /// it was built against a different revision.
     DeltaBaseMismatch {
@@ -643,6 +647,19 @@ impl Content {
                 LineOp::SetContinues { line, continues } => {
                     if *line == 0 && *continues {
                         return Err(ApplyError::FirstLineContinues);
+                    }
+                    // The same refusal one line further on: nothing precedes
+                    // line 0 to continue, and the line before *this* one is a
+                    // block in a different container, which is no more
+                    // continuable.
+                    if *continues
+                        && self
+                            .lines
+                            .get(*line)
+                            .zip(self.lines.get(line.wrapping_sub(1)))
+                            .is_some_and(|(l, prev)| l.containers != prev.containers)
+                    {
+                        return Err(ApplyError::ContinuesAcrossContainers { line: *line });
                     }
                     let l = self.line_mut(*line)?;
                     l.continues = *continues;
@@ -1256,6 +1273,50 @@ mod tests {
             })
         );
         assert_eq!(tbl.lines[0].kind, LineKind::Island);
+    }
+
+    /// The deliberate crossing is refused up front, where the incidental one
+    /// (a `Join` across two paths) is repaired by `normalize`: the same split
+    /// the line-kind rule makes.
+    #[test]
+    fn set_continues_across_a_container_boundary_is_refused() {
+        let mut rt = from_markdown("- a\n\npara").unwrap();
+        assert_ne!(rt.lines[0].containers, rt.lines[1].containers);
+        assert_eq!(
+            rt.apply_line_ops(&[LineOp::SetContinues {
+                line: 1,
+                continues: true
+            }]),
+            Err(ApplyError::ContinuesAcrossContainers { line: 1 })
+        );
+
+        // Inside one container it is an ordinary hard break.
+        let mut rt = from_markdown("- a\n\n  b").unwrap();
+        assert_eq!(rt.lines[0].containers, rt.lines[1].containers);
+        assert_eq!(
+            rt.apply_line_ops(&[LineOp::SetContinues {
+                line: 1,
+                continues: true
+            }]),
+            Ok(())
+        );
+        assert!(rt.lines[1].continues);
+    }
+
+    /// A `Join` merging two lines of differing paths leaves the line after the
+    /// seam continuing across it. The op is accepted and the content is still
+    /// storable, which is what putting the repair in `normalize` rather than
+    /// `validate` buys.
+    #[test]
+    fn join_across_two_paths_leaves_a_valid_content() {
+        let mut rt = from_markdown("- a\n\npara\\\nbroken").unwrap();
+        let seam = rt
+            .lines
+            .iter()
+            .position(|l| l.continues)
+            .expect("the hard break is there");
+        assert!(rt.apply_line_ops(&[LineOp::Join { line: seam - 2 }]).is_ok());
+        assert_eq!(rt.validate(), Ok(()), "the join left a storable content");
     }
 
     #[test]

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -347,19 +347,27 @@ pub fn container_to_value(c: &Container) -> Value {
             ordered,
             start,
             ordinal,
+            ..
         } => {
             m.insert("container".into(), "list_item".into());
             m.insert("ordered".into(), Value::Bool(*ordered));
             m.insert("ordinal".into(), Value::from(*ordinal));
             m.insert("start".into(), Value::from(*start));
         }
-        Container::Quote => {
+        Container::Quote { .. } => {
             m.insert("container".into(), "quote".into());
         }
-        Container::Unknown { tag, attrs } => {
+        Container::Unknown { tag, attrs, .. } => {
             m.insert("attrs".into(), attrs.clone());
             m.insert("container".into(), Value::String(tag.clone()));
         }
+    }
+    // Written only where it is doing work. `normalize` leaves it 0 on every
+    // path with no adjacent same-shape sibling to be told apart from, which is
+    // nearly all of them, so the common row carries no key and the encoding
+    // stays byte-identical to one written before the field existed.
+    if c.instance() != 0 {
+        m.insert("instance".into(), Value::from(c.instance()));
     }
     Value::Object(m)
 }
@@ -372,18 +380,21 @@ pub fn container_from_value(v: &Value) -> Result<Container, ParseError> {
         .and_then(Value::as_str)
         .ok_or(ParseError::Shape("container kind"))?;
     let o = fold_legacy_attrs(o, tag, Content::RESERVED_CONTAINERS, "container attrs")?;
+    let instance = o.get("instance").and_then(Value::as_u64).unwrap_or(0);
     match tag {
         "list_item" => Ok(Container::ListItem {
             ordered: o.get("ordered").and_then(Value::as_bool).unwrap_or(false),
             start: o.get("start").and_then(Value::as_u64).unwrap_or(1),
             ordinal: o.get("ordinal").and_then(Value::as_u64).unwrap_or(0),
+            instance,
         }),
-        "quote" => Ok(Container::Quote),
+        "quote" => Ok(Container::Quote { instance }),
         // An unrecognized container round-trips opaque and projects
         // transparently.
         other => Ok(Container::Unknown {
             tag: other.to_string(),
             attrs: bag_from_wire(&o, "attrs", "container attrs")?,
+            instance,
         }),
     }
 }
@@ -867,6 +878,32 @@ pub(crate) fn island_from_value(v: &Value) -> Result<Island, ParseError> {
 
 #[cfg(test)]
 mod tests {
+
+    /// `instance` is written only where it is doing work, so a row stored
+    /// before the field existed decodes, re-encodes, and content-hashes exactly
+    /// as it did: the discriminator costs bytes only in the documents that
+    /// carry an adjacent same-shape sibling.
+    #[test]
+    fn instance_is_absent_from_the_wire_until_it_is_needed() {
+        let plain = r#"{"islands":[],"lines":[{"containers":[{"container":"list_item","ordered":false,"ordinal":0,"start":1}],"kind":"para"},{"containers":[{"container":"list_item","ordered":false,"ordinal":1,"start":1}],"kind":"para"}],"marks":[],"text":"a\nb"}"#;
+        let rt = Content::from_canonical_json(plain).expect("decodes");
+        assert_eq!(rt.to_canonical_json(), plain, "byte layout moved");
+        assert!(rt.lines.iter().all(|l| l.containers[0].instance() == 0));
+
+        // Two adjacent one-item lists: the one shape that spends the key.
+        let two = r#"{"islands":[],"lines":[{"containers":[{"container":"list_item","ordered":false,"ordinal":0,"start":1}],"kind":"para"},{"containers":[{"container":"list_item","instance":1,"ordered":false,"ordinal":0,"start":1}],"kind":"para"}],"marks":[],"text":"a\nb"}"#;
+        let rt = Content::from_canonical_json(two).expect("decodes");
+        assert_eq!(rt.to_canonical_json(), two);
+        assert_eq!(rt.lines[1].containers[0].instance(), 1);
+
+        // Any distinct value a producer picks reads as the same two runs and
+        // rests on the canonical pair.
+        let raw = two.replace(r#""instance":1"#, r#""instance":37"#);
+        let rt2 = Content::from_canonical_json(&raw).expect("decodes");
+        assert_eq!(rt2, rt);
+        assert_eq!(rt2.to_canonical_json(), two);
+    }
+
     use super::*;
     use crate::model::{Fidelity, Line, LineKind};
 
@@ -1109,11 +1146,13 @@ mod tests {
                 ordered: true,
                 start: 3,
                 ordinal: 1,
+                instance: 0,
             },
-            Container::Quote,
+            Container::Quote { instance: 0 },
             Container::Unknown {
                 tag: "indent".into(),
                 attrs: bag(),
+                instance: 0,
             },
         ];
         for c in &containers {
@@ -1166,7 +1205,7 @@ mod tests {
         rt.lines = vec![
             Line {
                 kind: LineKind::Heading { level: 2 },
-                containers: vec![Container::Quote],
+                containers: vec![Container::Quote { instance: 0 }],
                 continues: false,
             },
             Line {
@@ -1281,6 +1320,7 @@ mod tests {
             vec![Container::Unknown {
                 tag: "indent".into(),
                 attrs: serde_json::json!({"depth": 2}),
+                instance: 0,
             }]
         );
         assert_eq!(rt.to_canonical_json(), json);
@@ -1325,6 +1365,7 @@ mod tests {
         rt.lines[0].containers = vec![Container::Unknown {
             tag: "quote".into(),
             attrs: serde_json::json!({}),
+            instance: 0,
         }];
         assert_eq!(
             rt.validate(),
@@ -1410,6 +1451,7 @@ mod tests {
         one.lines[0].containers = vec![Container::Unknown {
             tag: "indent".into(),
             attrs: serde_json::json!({"y": 1, "x": 2}),
+            instance: 0,
         }];
         let mut two = one.clone();
         two.lines[0].kind = LineKind::Unknown {
@@ -1419,6 +1461,7 @@ mod tests {
         two.lines[0].containers = vec![Container::Unknown {
             tag: "indent".into(),
             attrs: serde_json::json!({"x": 2, "y": 1}),
+            instance: 0,
         }];
         assert_eq!(one.to_canonical_json(), two.to_canonical_json());
         one.normalize();
@@ -1474,6 +1517,7 @@ mod tests {
                 ordered: true,
                 start: 3,
                 ordinal: 1,
+                instance: 0,
             }
         );
         let link = serde_json::json!({"start": 0, "end": 1, "type": "link", "attrs": {"url": "u"}});

--- a/crates/content/tests/container_canonical_form.rs
+++ b/crates/content/tests/container_canonical_form.rs
@@ -1,0 +1,146 @@
+//! Exhaustive guard on the container canonical form.
+//!
+//! `Content::normalize` derives `ordinal` and `instance` from run structure, and
+//! the direct-write lane — a client building containers by hand and committing
+//! them through `SetContainers` or a storage decode — is where every shape the
+//! Markdown importer never mints comes from. Two properties, checked over every
+//! container-path sequence in a small space rather than sampled:
+//!
+//! 1. **Idempotence.** `normalize` is the fixed point the canonical
+//!    serialization commits to, so a second pass must change nothing.
+//! 2. **One canonical form per document.** `from_markdown(to_markdown(rt)) == rt`
+//!    for normalized `rt`, which is `export`'s documented contract. A break here
+//!    means two normalized contents project to one markdown, so the model holds
+//!    a distinction it cannot write down — the exact defect class #1359 is
+//!    about, caught on the lane that mints it rather than on an import.
+
+use quillmark_content::model::{Container, Content, Line, LineKind};
+use quillmark_content::{from_markdown, to_markdown};
+
+/// Containers a hand-built path can hold. `Unknown` is excluded from the
+/// round-trip half only — it projects transparently, so Markdown cannot carry
+/// it — but is exercised for idempotence.
+fn alphabet(unknown: bool) -> Vec<Container> {
+    let mut v = Vec::new();
+    for ordered in [false, true] {
+        for ordinal in [0u64, 1] {
+            for instance in [0u64, 1] {
+                v.push(Container::ListItem {
+                    ordered,
+                    start: 1,
+                    ordinal,
+                    instance,
+                });
+            }
+        }
+    }
+    v.push(Container::Quote { instance: 0 });
+    v.push(Container::Quote { instance: 1 });
+    if unknown {
+        v.push(Container::Unknown {
+            tag: "x".into(),
+            attrs: serde_json::Value::Null,
+            instance: 0,
+        });
+    }
+    v
+}
+
+/// Every path of depth 1..=2 over the alphabet.
+fn paths(unknown: bool) -> Vec<Vec<Container>> {
+    let a = alphabet(unknown);
+    let mut out: Vec<Vec<Container>> = a.iter().map(|c| vec![c.clone()]).collect();
+    for outer in &a {
+        for inner in &a {
+            out.push(vec![outer.clone(), inner.clone()]);
+        }
+    }
+    out
+}
+
+fn build(paths: &[&Vec<Container>]) -> Content {
+    let text = (0..paths.len())
+        .map(|i| ((b'a' + i as u8) as char).to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let lines = paths
+        .iter()
+        .map(|p| Line::new(LineKind::Para).with_containers((*p).clone()))
+        .collect();
+    let mut rt = Content::new(text, lines);
+    rt.normalize();
+    rt
+}
+
+#[test]
+fn normalize_is_idempotent_over_every_two_line_path_pair() {
+    let ps = paths(true);
+    let mut n = 0usize;
+    for a in &ps {
+        for b in &ps {
+            let rt = build(&[a, b]);
+            assert_eq!(rt.validate(), Ok(()), "invalid after normalize: {rt:?}");
+            let mut again = rt.clone();
+            again.normalize();
+            assert_eq!(again, rt, "normalize not idempotent for {a:?} then {b:?}");
+            n += 1;
+        }
+    }
+    eprintln!("  pairs checked: {n}");
+    assert!(n > 400);
+}
+
+/// The property the review caught: an inner run must not continue across an
+/// *item* boundary. Two inner lists under two outer items are two lists, so
+/// each restarts at ordinal 0 and neither needs a discriminator — and the
+/// markdown projection has to agree.
+#[test]
+fn every_normalized_pair_is_a_markdown_fixed_point() {
+    let ps = paths(false);
+    let mut broken = Vec::new();
+    let mut n = 0usize;
+    for a in &ps {
+        for b in &ps {
+            let rt = build(&[a, b]);
+            let md = to_markdown(&rt);
+            let back = from_markdown(&md).expect("re-imports");
+            if back != rt {
+                broken.push(format!("{a:?} then {b:?} -> {md:?}"));
+            }
+            n += 1;
+        }
+    }
+    eprintln!("  pairs checked: {n}, broken: {}", broken.len());
+    for b in broken.iter().take(5) {
+        eprintln!("    {b}");
+    }
+    assert!(broken.is_empty(), "{} pairs are not fixed points", broken.len());
+}
+
+/// Three deep, where an item boundary at depth 0 has to reset both the ordinal
+/// and the discriminator at depth 1.
+#[test]
+fn triples_over_the_list_and_quote_alphabet_are_fixed_points() {
+    let ps: Vec<Vec<Container>> = paths(false)
+        .into_iter()
+        .filter(|p| p.len() == 2)
+        .collect();
+    let mut broken = 0usize;
+    let mut n = 0usize;
+    for a in ps.iter().step_by(3) {
+        for b in ps.iter().step_by(3) {
+            for c in ps.iter().step_by(5) {
+                let rt = build(&[a, b, c]);
+                let mut again = rt.clone();
+                again.normalize();
+                assert_eq!(again, rt, "not idempotent: {a:?} {b:?} {c:?}");
+                if from_markdown(&to_markdown(&rt)).unwrap() != rt {
+                    broken += 1;
+                }
+                n += 1;
+            }
+        }
+    }
+    eprintln!("  triples checked: {n}, broken: {broken}");
+    assert_eq!(broken, 0);
+}

--- a/crates/content/tests/properties.proptest-regressions
+++ b/crates/content/tests/properties.proptest-regressions
@@ -12,3 +12,6 @@ cc ff90f800ae8fe6d16e7adb6f38ebcf558488cade231db13d3705afc542faa985 # shrinks to
 cc 5e333ee554d5dea4ec07af36bca02d4e0494549dee880518d7fc5448d81a06d9 # shrinks to md = "# 0. **a**"
 cc 2982cbd9e43f39a2e5cd52a6c20fa4f7f521a65d08764f324d12f768952482a3 # shrinks to md = "| 0 | a |\n| --- | --- |\n| 1 | 2 |\n\n```\na\n```", ins = "a", pos_seed = 616, del_seed = 0, is_delete = false
 cc 2f2838066b598c521a9479d14f0330b1e2cc8988eca221f661b86a6292116257 # shrinks to md = "| a | a |\n| --- | --- |\n| 1 | 2 |", a_seed = 0, b_seed = 0, ins = "a", pos_seed = 0, del_seed = 0, is_delete = false
+cc 200bd7de24162bf4a4b55e632874ab73de96542bb5a763db8fa55dc7317ad079 # shrinks to md = "- ***\n\n  ~~a~~ **00aaa** **a**\n\na0 a\\\na0a0a", a_seed = 0, b_seed = 0, ins = "", pos_seed = 2950, del_seed = 1509, is_delete = true
+cc 4ad60b5a038ffad5e71d6e6d7130158889929223283b33104a4dfeb7012030d3 # shrinks to md = "- a\n- 0\n- 0\n\n```\na\na\n```\n\n- # 0\n\n  0", pos_seed = 0, line_seed = 51, which = 1
+cc e8e7f7b4f04d8b3a756ab61531f0168e49bd8a3fc3d48c1fb1400691706e42a7 # shrinks to md = "1. [a0a0](<ex.com/aa>) **0** a>_你0 `a0aa0`\n2. <u>aa00a</u>\n\n```\n0a00\n```\n\na\\\naa0a 0aa0 a\\\n00aa\n\n**00aaa** ![a](<ex.com/a&>) ![a](<ex.com/aa>)", ins = "", pos_seed = 1598, del_seed = 241, is_delete = true

--- a/crates/core/src/quill/support.rs
+++ b/crates/core/src/quill/support.rs
@@ -114,10 +114,9 @@ fn plural(construct: BlockConstruct, count: usize) -> String {
 /// A container counts once per contiguous **run**, not once per line or per
 /// item: a three-item list is one list, and a multi-paragraph quote is one
 /// quote. A run opens where the previous line carried no like container at that
-/// depth — like meaning same shape, so a sibling item (differing only by
-/// `ordinal`) continues its list rather than opening another. Two adjacent
-/// lists of identical shape therefore count as one, the same non-distinction
-/// the model itself documents for adjacent quotes.
+/// depth — like meaning same run key *and* same `Container::instance`, so a
+/// sibling item (differing only by `ordinal`) continues its list rather than
+/// opening another, while an adjacent list of identical shape opens its own.
 ///
 /// A leaf block counts per block: a rule and a heading are one line each, and a
 /// code fence is counted at the line that opens it.
@@ -130,20 +129,19 @@ fn census(body: &Content) -> BTreeMap<BlockConstruct, usize> {
     use quillmark_content::model::Container;
 
     /// A container's identity for run purposes: everything but which item.
-    fn shape(container: &Container) -> Option<(BlockConstruct, bool, u64)> {
-        match container {
-            Container::ListItem { ordered, start, .. } => {
-                Some((BlockConstruct::List, *ordered, *start))
-            }
-            Container::Quote => Some((BlockConstruct::Quote, false, 0)),
+    fn shape(container: &Container) -> Option<(BlockConstruct, Container, u64)> {
+        let construct = match container {
+            Container::ListItem { .. } => BlockConstruct::List,
+            Container::Quote { .. } => BlockConstruct::Quote,
             // The open set: a container this build does not know names no
             // construct to decline.
-            _ => None,
-        }
+            _ => return None,
+        };
+        Some((construct, container.run_key(), container.instance()))
     }
 
     let mut counts: BTreeMap<BlockConstruct, usize> = BTreeMap::new();
-    let mut prev: Vec<Option<(BlockConstruct, bool, u64)>> = Vec::new();
+    let mut prev: Vec<Option<(BlockConstruct, Container, u64)>> = Vec::new();
 
     for island in &body.islands {
         match KnownIslandType::parse(&island.island_type) {

--- a/crates/quillmark/tests/adjacent_list_numbering.rs
+++ b/crates/quillmark/tests/adjacent_list_numbering.rs
@@ -1,0 +1,53 @@
+//! Two adjacent ordered lists keep their own numbering on the page.
+//!
+//! They reach the emitter as two runs carrying different
+//! `Container::instance`, and the first item of each states its number so
+//! Typst's running counter (`typst-layout::lists`, `item.number` overriding
+//! the running one) restarts with it rather than counting 1 2 3 4.
+
+#![cfg(feature = "typst")]
+use quillmark::{Document, OutputFormat, Quillmark, RenderOptions};
+use quillmark_fixtures::quills_path;
+
+fn svg(body: &str) -> String {
+    let engine = Quillmark::new();
+    let quill = quillmark::quill_from_path(quills_path("table_demo")).expect("load");
+    let md = format!("~~~card-yaml\n$quill: table_demo@0.1.0\n$kind: main\ntitle: T\n~~~\n\n{body}\n");
+    let parsed = Document::parse(&md).expect("parse").document;
+    let r = engine.render(&quill, &parsed,
+        &RenderOptions::default().with_output_format(OutputFormat::Svg)).expect("render");
+    String::from_utf8_lossy(&r.artifacts[0].bytes).to_string()
+}
+
+/// Distinct glyph symbols the page references, as a proxy for which digits were
+/// typeset: 1,2,1,2 uses two digit glyphs; 1,2,3,4 uses four.
+fn glyphs(s: &str) -> std::collections::BTreeSet<String> {
+    let mut out = std::collections::BTreeSet::new();
+    for (i, _) in s.match_indices("<use ") {
+        if let Some(h) = s[i..].find("href=\"#") {
+            let rest = &s[i + h + 7..];
+            if let Some(e) = rest.find('"') { out.insert(rest[..e].to_string()); }
+        }
+    }
+    out
+}
+
+/// Digit glyphs stand in for the numbers on the page: a restart typesets only
+/// `1` and `2`, while one run of four also pulls in `3` and `4`.
+#[test]
+fn adjacent_ordered_lists_number_apart() {
+    // Two adjacent ordered lists, the CommonMark way.
+    let two = svg("1. alpha\n2. bravo\n\n<!-- -->\n\n1. charlie\n2. delta");
+    // One list of four.
+    let four = svg("1. alpha\n2. bravo\n3. charlie\n4. delta");
+    let (g2, g4) = (glyphs(&two), glyphs(&four));
+    assert_eq!(
+        g4.difference(&g2).count(),
+        2,
+        "one run of four should typeset two digits the restart never reaches"
+    );
+    assert!(
+        g2.difference(&g4).next().is_none(),
+        "the restart should typeset no digit the four-item run lacks"
+    );
+}

--- a/prose/canon/CONVERT.md
+++ b/prose/canon/CONVERT.md
@@ -84,7 +84,7 @@ is a lowering bug, never a document's.
 | `MarkKind::Link{url}` | `#link("url")[…]` (`escape_string` on the url) |
 | `MarkKind::Anchor` / `Unknown` | nothing |
 | `Container::ListItem` (bullet) | `- ` |
-| `Container::ListItem` (ordered) | `+ ` auto-numbered; first item emits `N. ` when the list starts at `N ≠ 1` |
+| `Container::ListItem` (ordered) | `+ ` auto-numbered; the run's first item emits `N. `, which restarts Typst's running counter so an adjacent list numbers from its own `start` |
 | `Container::Quote` | `#quote(block: true)[…]` |
 | `Container::Unknown` (open set) | nothing: transparent; its run lowers at the enclosing level, one block, no wrapper |
 | `image` island | `#image("url", alt: "…")`; `alt:` omitted when empty |

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -226,6 +226,19 @@ blank line for quotes. An `Unknown` container has no Markdown syntax at all, so
 that one boundary lives in storage only — the same place its `tag` and `attrs`
 already live.
 
+**A new container owes its projections a separator.** `instance` makes the
+boundary storable; it does not make it *writable*. A container whose Markdown
+spelling cannot separate two adjacent instances has a boundary in storage that
+the projection drops, so `from_markdown(to_markdown(rt)) == rt` fails on
+re-import — the model reads one container where it stored two. Spell the
+separator when the container is specced, not after: a container defined on
+CommonMark §5.1's terms (a per-line marker, blank-line terminated, as
+`Container::Quote` is) gets one for free, because the blank line already ends
+it. One defined on §5.2/§5.3's terms (a list, which a blank line leaves open)
+does not, and needs the marker alternation `Container::ListItem` uses. The same
+obligation falls on the Typst lowering: two adjacent instances must not lower
+into one another's markup.
+
 Unknown *keys* survive in designated carriers only, and the boundary is worth
 stating because it is not the discriminator boundary:
 

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -209,6 +209,23 @@ mark axis' terms, not one step behind it, and both island axes carry their raw
 string rather than rewriting it: a reader that merely opens a document must not
 move its content hash (§ Byte-stability).
 
+**Container identity is path plus contiguity, and `instance` is what completes
+it.** Two adjacent lines sit in the same container iff their whole container
+path is equal, so without a discriminator two adjacent runs of one shape read as
+one: `[Quote], [Quote]` would be a single two-paragraph quote, and two one-item
+lists a single item with an unnumbered continuation paragraph. `instance` is the
+field that breaks that tie, on every container arm including `Unknown`, which is
+why the round-trip above is a *total* promise rather than one holding up to an
+adjacency quotient. `Content::normalize` canonicalizes it to `0`, flipping to
+`1` only where the adjacent preceding sibling run would otherwise weld, so a
+document needing no discriminator carries none and its stored bytes are the
+bytes it had before the field existed (§ Byte-stability). The Markdown
+projection spells the same boundary with the idiom CommonMark already reads: a
+change of bullet char (`-`/`+`) or of ordered delimiter (`.`/`)`) for lists, the
+blank line for quotes. An `Unknown` container has no Markdown syntax at all, so
+that one boundary lives in storage only — the same place its `tag` and `attrs`
+already live.
+
 Unknown *keys* survive in designated carriers only, and the boundary is worth
 stating because it is not the discriminator boundary:
 


### PR DESCRIPTION
Closes #1359. Carries #1363, merged into this branch.

Container identity is **the container path plus contiguity**. Two things were missing from that, and each produced defects nothing could catch:

- The path carried nothing to tell one instance of a shape from the next, so two adjacent runs of equal shape read as one. `[Quote], [Quote]` was a single two-paragraph quote; two one-item lists were a single item whose second line came back an unnumbered continuation paragraph, marker gone.
- `Content::validate` is strictly **per-line**, while every container invariant is a property of a line *pair*. There was no layer that could have caught any of this.

This closes both.

## The four defects

**Markdown import destroyed a marker.** `from_markdown("- a\n\n<!-- -->\n\n- b")` — the CommonMark idiom for spelling two lists apart — produced two `ListItem{ordinal: 0}` paths, which read back as one item of two paragraphs, and `to_markdown` emitted `"- a\n\n  b"`. Every document taking that path lost a marker; no client involved. The module doc promised a *merge*; import did not merge, and what it did instead was worse.

**Two adjacent ordered lists typeset with the wrong numbers.** They reached the Typst emitter as one run — `list_run_end` grouped on `(ordered, start)` and dropped `ordinal` outright — and `+` markers numbered the second list on from the first, so `1. 2.` / `1. 2.` rendered **1 2 3 4**. `list_run_end` is deleted; grouping is now one rule for every container kind (run key plus `instance`), and an ordered run's first item states its number, which restarts Typst's running counter (`typst-layout::lists` takes `item.number` over it).

**A list's `start` was lost through the Markdown projection.** CommonMark reads only a list's *first* number, so `1. a` beside `3. b` re-imported as one list of two items — breaking the `from_markdown(to_markdown(rt)) == rt` fixed point `export` documents. The same-shape multi-item case broke it too: `[0,1,0,1]` re-imported as `[0,1,2,3]`, which #1359 does not name.

**Adjacent `Unknown` containers of equal `(tag, attrs)` merged**, so the open-set promise in `DOCUMENT_STORAGE.md` — that a container this build does not know round-trips untouched — held only up to an adjacency quotient. It is total now.

## How the boundary is spelled

In the model, `instance` on every `Container` arm. In Markdown, the idiom CommonMark already reads: a change of bullet char (`-`/`+`) or of ordered delimiter (`.`/`)`) for lists, the blank line for quotes. Nothing is added to the authored file — no HTML-comment separator.

`+` rather than `*` for the second bullet: `* ***` is four asterisks separated by spaces, which reads as a thematic break and takes the item with it. `alternate_markers_do_not_collide_with_a_rule` pins that.

An `Unknown` container has no Markdown syntax at all, so that one boundary lives in storage only — the same place its `tag` and `attrs` already live.

## The relational rule (was #1363)

A within-block break lives inside one container, and nothing said so. `LineOp::Join` mints the crossing shape whenever it merges two lines of differing paths: the line after the seam keeps `continues: true` while the block it claims to continue is now somewhere else. Found by the existing `apply_line_ops_preserves_validate` property; its seed is checked in.

I first wrote this as a `validate` rejection. The property showed that was wrong — `Join` produces the state legitimately, so rejecting turns an accepted op into a content that cannot be stored. Both projections already read the flag as dead there (`export::emit_block` and `emit::segment_end` each require the depth to match before absorbing a continuation), so clearing it changes nothing observable, which makes it repairable. It takes the line-kind demotion's footing instead:

| lane | treatment |
|---|---|
| `normalize` | clears the flag — the incidental crossing, from `Join` |
| `validate` | `Invariant::ContinuesAcrossContainers` — a hand-built content that skipped `normalize` |
| `LineOp::SetContinues` | `ApplyError::ContinuesAcrossContainers` — the *deliberate* crossing, refused up front |

The rest of that class needs no check, measured rather than assumed: non-canonical ordinals renumber, and a run opening under a fresh parent re-reads correctly. The principle that separates them is **reject what `normalize` cannot repair; repair the rest silently** — which is also why #1359's item 6 is not here.

## Canonical form

`normalize` derives both fields from run structure the stored path already spells:

- `instance` → 0, flipping to 1 only where the adjacent preceding sibling run would otherwise weld. Non-adjacent runs never collide, so two values suffice and three adjacent lists alternate `0, 1, 0` rather than climbing.
- `ordinal` → a gapless 0-based index within its run, so `[5, 9]` and `[0, 1]` stop being two spellings of the same two items, and `[3, 3, 7]` is two items the first of which spans two paragraphs.

**An item boundary is a parent boundary.** Two inner lists under two outer items are two lists, so an inner run restarts its `ordinal` and needs no discriminator against the previous item's inner run. Getting this wrong is what the review round below caught.

A producer may mint any distinct `instance` values it likes; normalize collapses them. `normalize` is already the single funnel — serial decode and every op-apply terminate in it — so one implementation covers every lane and a foreign blob is repaired on read rather than refused.

The weld test is deliberately coarser than the run key for lists, comparing `ordered` alone: `start` is invisible in Markdown, so two lists differing only in `start` still need the discriminator for the marker alternation to carry them apart.

## Review round

A review of this branch found a real defect in `canonicalize_containers`, since fixed in `1c9b981d`. Recording it because the failure mode is instructive: the per-depth run state was reset when the *run* at a depth changed but not when the run continued into its next **item**, so state carried across an item boundary and welded sibling containers living under different items.

Three round trips were lost on normalized, validated content: an inner list's `ordinal` continued across the boundary (`[bullet 0, ordered 5]` / `[bullet 1, ordered 7]` exported `- 1. x` / `- 2. y` and re-imported at `start: 2`); one document had two normalize fixed points; and import minted `instance: 1` on the second quote of `- > a` / `- > b`, spending a wire key on an ordinary nested document against the frugality claim below.

**Idempotence was never affected**, which is why the existing tests passed — what broke was *uniqueness* of the canonical form. The new guard is exhaustive rather than sampled, over every container-path sequence in a small alphabet: 17k pairs for idempotence, 12k pairs and 23k triples for `from_markdown(to_markdown(rt)) == rt` on the direct-write lane, which is where the shapes the importer never mints come from. It fails on 144 pairs and 568 triples without the fix.

The other four areas reviewed — the marker alternation's re-import behaviour under `pulldown_cmark`, the `if first` change in `emit_item`, whether a non-zero `instance` can be dropped or collide in `fold_legacy_attrs`, and whether any reader honours `continues` without checking depth — came back clean.

## Cost

`instance` is written to the wire only when non-zero. A stored row that needs no discriminator — nearly all of them — keeps its exact bytes and its content hash; `instance_is_absent_from_the_wire_until_it_is_needed` pins that a row written before the field existed decodes and re-encodes byte-identically. No schema bump.

**Breaking for a Rust consumer matching `Container` exhaustively**: `Quote` becomes a struct variant and `ListItem`/`Unknown` carry the extra field. On the TypeScript surface `instance` is optional, so a consumer that never writes adjacent same-shape siblings needs no change.

The honest new cost: `instance` is a discriminator a writer must mint. A client that writes `0` everywhere gets the old welding back, silently. That is a real regression in failure mode versus deriving identity from `ordinal` alone, accepted because "expressible but the writer must mint it" beats "not expressible."

## Documentation

`DOCUMENT_STORAGE.md` states the completeness claim positively, and states the obligation a **new** container inherits: `instance` makes an adjacency boundary storable, not *writable*. A container specced on CommonMark §5.1's terms (per-line marker, blank-line terminated, as `Quote` is) gets the separator free from the blank line; one specced on §5.2/§5.3's terms (a list — a blank line leaves it open) needs the marker alternation `ListItem` uses. Directly relevant to #1362, which already satisfies it by citing §5.1 — but by which section it happened to cite, not by rule.

## Verification

- `cargo test --workspace` green, including the property tests that found the `continues` defect.
- `cargo clippy --workspace --all-targets` at 44 warnings, unchanged from `main` (diffed against baseline, not assumed).
- `crates/quillmark/tests/adjacent_list_numbering.rs` renders both bodies through the real Typst pipeline and **fails on `main`**.
- `crates/content/tests/container_canonical_form.rs` is the exhaustive canonical-form guard described above; I verified it fails with the fix reverted.
- The changed TypeScript union type-checks under `tsc --strict`, with `instance` present and absent.
- `scripts/check-canon.mjs` OK.
- The export tests build content **from storage** rather than from an import, since a client writing `Content` directly is the lane that mints these shapes.

New coverage: `adjacent_sibling_containers_keep_their_boundary`, `instance_stays_zero_without_an_adjacent_sibling` (import); `adjacent_sibling_containers_project_and_return`, `adjacent_ordered_lists_keep_their_start`, `alternate_markers_do_not_collide_with_a_rule` (export); `normalize_canonicalizes_container_paths`, `normalize_of_container_paths_is_idempotent`, `continues_across_a_container_boundary_is_cleared` (model); `set_continues_across_a_container_boundary_is_refused`, `join_across_two_paths_leaves_a_valid_content` (ops); `instance_is_absent_from_the_wire_until_it_is_needed` (serial); plus the exhaustive guard.

## Scope deliberately cut

Three pieces of #1359 as filed are not here. `validate` gains no pass over ordinals — a non-canonical ordinal is repairable losslessly, unlike a reserved name. `census` is updated to stay correct but not restructured; its count feeds one diagnostic string. And the shared run rule lives on `Container` itself (`same_run`, `run_key`), consumed by both emitters and `census`, rather than as a separate iterator pinned across a repo boundary by a drift test — `known_names_drift.rs` pins string literals textually and cannot pin an algorithm.

An audit after the first commit found one *run* rule left in the workspace and two plain item-identity loops (`export.rs:154`, `emit.rs:476`), which are the documented rule with no weakening and so no free choice to diverge on. Nothing further was factored.

## Not addressed

#1361 — a container inside a list item lowers at column 0 and terminates the Typst list — is untouched and reproduces on this branch. Note that this PR slightly **widens** it: two adjacent quotes in an item now correctly stay apart in the model and therefore emit two column-0 `#quote(` blocks where they previously merged into one. Both already broke the list; the count doubles. #1361's fix lands on a tidier `try_emit_container` after this, since all three arms now share one run rule and one signature.

Separately, `census` in `crates/core/src/quill/support.rs` compares its per-depth run key without noticing a *different-kind* parent change, so `[Quote, Quote]` followed by `[ListItem, Quote]` counts two quotes rather than three. Pre-existing, not from this PR, and it moves a number in one diagnostic string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmDvNTXNtKpD8biDp8cm8Q