### PR TITLE
fix(content): clear a `continues` that crosses a container boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- fix(content): **a `continues` line that crosses a container boundary no longer
+  survives.** A within-block break lives inside one container, and `LineOp::Join`
+  mints the crossing shape whenever it merges two lines of differing paths — the
+  line after the seam keeps continuing across it. Both projections already read
+  the flag as dead there (`export::emit_block` and `emit::segment_end` each
+  require the depth to match before absorbing a continuation), so `normalize`
+  now clears it, which states what was already true and changes nothing
+  observable. `Content::validate` gains `Invariant::ContinuesAcrossContainers`
+  to catch a hand-built content that skipped `normalize`, and
+  `LineOp::SetContinues` refuses the *deliberate* crossing up front with
+  `ApplyError::ContinuesAcrossContainers` — the same repair-or-refuse split the
+  line-kind rule already makes. This was the one relational line invariant
+  nothing checked: `validate` is otherwise strictly per-line, while every
+  container rule is a property of a line pair.
+
 - fix(content): **two adjacent containers of one shape are no longer read as
   one.** Container identity is the container path plus contiguity, and the path
   carried nothing to tell one instance from the next, so two adjacent runs of

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -633,6 +633,12 @@ pub enum Invariant {
     BadHeadingLevel(u8),
     /// The first line has `continues: true` (nothing precedes it to continue).
     FirstLineContinues,
+    /// A line has `continues: true` but sits in a different container path than
+    /// the line before it, so the block it claims to continue is not the block
+    /// above. `normalize` clears the flag; this catches a hand-built content
+    /// that skipped it, the same pairing as
+    /// [`LineKindMismatch`](Invariant::LineKindMismatch).
+    ContinuesAcrossContainers { line: usize },
     /// An [`MarkKind::Unknown`] reused a reserved built-in `type` name.
     ReservedUnknownTag(String),
     /// A [`LineKind::Unknown`] reused a reserved built-in `kind` name: its
@@ -800,6 +806,20 @@ impl Content {
     /// serialization commits to.
     pub fn normalize(&mut self) {
         canonicalize_containers(&mut self.lines);
+        // A `continues` line whose container path differs from the line above
+        // claims to continue a block it is not in. `Join` mints these by
+        // merging two lines of differing paths, leaving the *next* line
+        // continuing across the seam. Both projections already read the flag as
+        // dead there — `export::emit_block` and `emit::segment_end` both
+        // require the depth to match before they absorb a continuation — so
+        // clearing it changes nothing observable and states what is already
+        // true. Same treatment, and the same reason, as the line-kind demotion
+        // below; a *deliberate* one is refused up front by the op channel.
+        for i in 1..self.lines.len() {
+            if self.lines[i].continues && self.lines[i].containers != self.lines[i - 1].containers {
+                self.lines[i].continues = false;
+            }
+        }
         // A splice writes text, never kinds: typing into a table line leaves it
         // `Island` over prose, joining a fence to an image line leaves it `Code`
         // over a slot, and export reads the kind and not the text, so the
@@ -923,6 +943,16 @@ impl Content {
         }
         if self.lines.first().is_some_and(|l| l.continues) {
             return Err(Invariant::FirstLineContinues);
+        }
+        // The one relational line invariant `validate` carries. Every other
+        // container rule is a property of a line pair too, and `normalize`
+        // settles each: a non-canonical `ordinal` renumbers, a run opening
+        // under a fresh parent re-reads, this flag clears. What is left here is
+        // the assertion that it ran.
+        for (i, pair) in self.lines.windows(2).enumerate() {
+            if pair[1].continues && pair[1].containers != pair[0].containers {
+                return Err(Invariant::ContinuesAcrossContainers { line: i + 1 });
+            }
         }
         // Only the formatting-mark edge test below reads it.
         let chars: Vec<char> = if self.marks.iter().any(|m| m.kind.is_formatting()) {
@@ -1573,6 +1603,67 @@ mod tests {
             );
             assert_eq!(once, twice);
         }
+    }
+
+    /// A within-block break lives inside one container. `Join` mints the
+    /// crossing shape by merging two lines of differing paths, which leaves the
+    /// *next* line continuing across the seam; `normalize` clears it, and
+    /// `validate` asserts that it ran.
+    #[test]
+    fn continues_across_a_container_boundary_is_cleared() {
+        let mut rt = Content::new(
+            "a\nb".to_string(),
+            vec![
+                Line::new(LineKind::Para),
+                Line::new(LineKind::Para)
+                    .with_containers(vec![Container::Quote { instance: 0 }])
+                    .with_continues(true),
+            ],
+        );
+        assert_eq!(
+            rt.validate(),
+            Err(Invariant::ContinuesAcrossContainers { line: 1 }),
+            "a hand-built content that skipped normalize is caught"
+        );
+        rt.normalize();
+        assert!(!rt.lines[1].continues, "normalize clears it");
+        assert_eq!(rt.validate(), Ok(()));
+
+        // Equal-length but different containers is the same crossing: two list
+        // items are two blocks, and a hard break does not span them.
+        let li = |ordinal| {
+            vec![Container::ListItem {
+                ordered: false,
+                start: 1,
+                ordinal,
+                instance: 0,
+            }]
+        };
+        let mut rt = Content::new(
+            "a\nb".to_string(),
+            vec![
+                Line::new(LineKind::Para).with_containers(li(0)),
+                Line::new(LineKind::Para)
+                    .with_containers(li(1))
+                    .with_continues(true),
+            ],
+        );
+        rt.normalize();
+        assert!(!rt.lines[1].continues);
+
+        // The within-container break is untouched: same path, flag kept.
+        let mut rt = Content::new(
+            "a\nb".to_string(),
+            vec![
+                Line::new(LineKind::Para).with_containers(li(0)),
+                Line::new(LineKind::Para)
+                    .with_containers(li(0))
+                    .with_continues(true),
+            ],
+        );
+        rt.normalize();
+        assert!(rt.lines[1].continues, "a hard break inside one item survives");
+        assert_eq!(rt.validate(), Ok(()));
     }
 
     #[test]

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -327,6 +327,10 @@ pub enum ApplyError {
     /// nothing before it to continue. Refused because `normalize` does not
     /// repair it.
     FirstLineContinues,
+    /// [`LineOp::SetContinues`] would make a line continue a block it is not in:
+    /// its container path differs from the previous line's, and a within-block
+    /// break lives inside one container.
+    ContinuesAcrossContainers { line: usize },
     /// The text delta's expected base length disagreed with the content:
     /// it was built against a different revision.
     DeltaBaseMismatch {
@@ -643,6 +647,19 @@ impl Content {
                 LineOp::SetContinues { line, continues } => {
                     if *line == 0 && *continues {
                         return Err(ApplyError::FirstLineContinues);
+                    }
+                    // The same refusal one line further on: nothing precedes
+                    // line 0 to continue, and the line before *this* one is a
+                    // block in a different container, which is no more
+                    // continuable.
+                    if *continues
+                        && self
+                            .lines
+                            .get(*line)
+                            .zip(self.lines.get(line.wrapping_sub(1)))
+                            .is_some_and(|(l, prev)| l.containers != prev.containers)
+                    {
+                        return Err(ApplyError::ContinuesAcrossContainers { line: *line });
                     }
                     let l = self.line_mut(*line)?;
                     l.continues = *continues;
@@ -1256,6 +1273,50 @@ mod tests {
             })
         );
         assert_eq!(tbl.lines[0].kind, LineKind::Island);
+    }
+
+    /// The deliberate crossing is refused up front, where the incidental one
+    /// (a `Join` across two paths) is repaired by `normalize`: the same split
+    /// the line-kind rule makes.
+    #[test]
+    fn set_continues_across_a_container_boundary_is_refused() {
+        let mut rt = from_markdown("- a\n\npara").unwrap();
+        assert_ne!(rt.lines[0].containers, rt.lines[1].containers);
+        assert_eq!(
+            rt.apply_line_ops(&[LineOp::SetContinues {
+                line: 1,
+                continues: true
+            }]),
+            Err(ApplyError::ContinuesAcrossContainers { line: 1 })
+        );
+
+        // Inside one container it is an ordinary hard break.
+        let mut rt = from_markdown("- a\n\n  b").unwrap();
+        assert_eq!(rt.lines[0].containers, rt.lines[1].containers);
+        assert_eq!(
+            rt.apply_line_ops(&[LineOp::SetContinues {
+                line: 1,
+                continues: true
+            }]),
+            Ok(())
+        );
+        assert!(rt.lines[1].continues);
+    }
+
+    /// A `Join` merging two lines of differing paths leaves the line after the
+    /// seam continuing across it. The op is accepted and the content is still
+    /// storable, which is what putting the repair in `normalize` rather than
+    /// `validate` buys.
+    #[test]
+    fn join_across_two_paths_leaves_a_valid_content() {
+        let mut rt = from_markdown("- a\n\npara\\\nbroken").unwrap();
+        let seam = rt
+            .lines
+            .iter()
+            .position(|l| l.continues)
+            .expect("the hard break is there");
+        assert!(rt.apply_line_ops(&[LineOp::Join { line: seam - 2 }]).is_ok());
+        assert_eq!(rt.validate(), Ok(()), "the join left a storable content");
     }
 
     #[test]

--- a/crates/content/tests/properties.proptest-regressions
+++ b/crates/content/tests/properties.proptest-regressions
@@ -12,3 +12,6 @@ cc ff90f800ae8fe6d16e7adb6f38ebcf558488cade231db13d3705afc542faa985 # shrinks to
 cc 5e333ee554d5dea4ec07af36bca02d4e0494549dee880518d7fc5448d81a06d9 # shrinks to md = "# 0. **a**"
 cc 2982cbd9e43f39a2e5cd52a6c20fa4f7f521a65d08764f324d12f768952482a3 # shrinks to md = "| 0 | a |\n| --- | --- |\n| 1 | 2 |\n\n```\na\n```", ins = "a", pos_seed = 616, del_seed = 0, is_delete = false
 cc 2f2838066b598c521a9479d14f0330b1e2cc8988eca221f661b86a6292116257 # shrinks to md = "| a | a |\n| --- | --- |\n| 1 | 2 |", a_seed = 0, b_seed = 0, ins = "a", pos_seed = 0, del_seed = 0, is_delete = false
+cc 200bd7de24162bf4a4b55e632874ab73de96542bb5a763db8fa55dc7317ad079 # shrinks to md = "- ***\n\n  ~~a~~ **00aaa** **a**\n\na0 a\\\na0a0a", a_seed = 0, b_seed = 0, ins = "", pos_seed = 2950, del_seed = 1509, is_delete = true
+cc 4ad60b5a038ffad5e71d6e6d7130158889929223283b33104a4dfeb7012030d3 # shrinks to md = "- a\n- 0\n- 0\n\n```\na\na\n```\n\n- # 0\n\n  0", pos_seed = 0, line_seed = 51, which = 1
+cc e8e7f7b4f04d8b3a756ab61531f0168e49bd8a3fc3d48c1fb1400691706e42a7 # shrinks to md = "1. [a0a0](<ex.com/aa>) **0** a>_你0 `a0aa0`\n2. <u>aa00a</u>\n\n```\n0a00\n```\n\na\\\naa0a 0aa0 a\\\n00aa\n\n**00aaa** ![a](<ex.com/a&>) ![a](<ex.com/aa>)", ins = "", pos_seed = 1598, del_seed = 241, is_delete = true

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -226,6 +226,19 @@ blank line for quotes. An `Unknown` container has no Markdown syntax at all, so
 that one boundary lives in storage only — the same place its `tag` and `attrs`
 already live.
 
+**A new container owes its projections a separator.** `instance` makes the
+boundary storable; it does not make it *writable*. A container whose Markdown
+spelling cannot separate two adjacent instances has a boundary in storage that
+the projection drops, so `from_markdown(to_markdown(rt)) == rt` fails on
+re-import — the model reads one container where it stored two. Spell the
+separator when the container is specced, not after: a container defined on
+CommonMark §5.1's terms (a per-line marker, blank-line terminated, as
+`Container::Quote` is) gets one for free, because the blank line already ends
+it. One defined on §5.2/§5.3's terms (a list, which a blank line leaves open)
+does not, and needs the marker alternation `Container::ListItem` uses. The same
+obligation falls on the Typst lowering: two adjacent instances must not lower
+into one another's markup.
+
 Unknown *keys* survive in designated carriers only, and the boundary is worth
 stating because it is not the discriminator boundary:
 


### PR DESCRIPTION
Stacked on #1360 — base is that branch, so this diff is one commit. GitHub retargets to `main` when #1360 merges.

Closes the enforcement gap behind #1359 rather than any of its defects. `Content::validate` is strictly per-line, while **every** container invariant is a property of a line *pair* — which is why the adjacency defects had no layer that could have caught them. This adds the one check that class actually needs.

## The defect

A within-block break lives inside one container, and nothing said so. `LineOp::Join` mints the crossing shape whenever it merges two lines of differing container paths: the line after the seam keeps `continues: true` while the block it claims to continue is now somewhere else.

Found by the existing `apply_line_ops_preserves_validate` property, on `md = "- a\n- 0\n- 0\n\n```\na\na\n```\n\n- # 0\n\n  0"` with a `Join` across the list/fence seam.

## Repair, not rejection

I first wrote this as a `validate` rejection on the `FirstLineContinues` precedent. The property test showed that was wrong: `Join` produces the state legitimately, so rejecting turns an accepted op into a content that cannot be stored — a landmine, not a check.

Both projections already read the flag as dead there. `export::emit_block` and `emit::segment_end` each require the depth to match before absorbing a continuation, so a `continues` across a boundary is already ignored by everything downstream. Clearing it changes nothing observable and states what was already true, which makes it repairable without guessing — and repairable is what decides the treatment.

So it takes the line-kind demotion's footing, right beside it in `normalize`:

| lane | treatment |
|---|---|
| `normalize` | clears the flag (the incidental crossing, from `Join`) |
| `validate` | `Invariant::ContinuesAcrossContainers` — a hand-built content that skipped `normalize` |
| `LineOp::SetContinues` | `ApplyError::ContinuesAcrossContainers` — the *deliberate* crossing, refused up front |

That is exactly the repair-or-refuse split `LineKind` already makes, including the op channel refusing what `normalize` would otherwise silently fix.

## Why the rest of the class needs no check

The other relational container rules are all repairable and `normalize` already settles each — measured, not assumed:

| state | `validate` before | outcome |
|---|---|---|
| ordinals `[9, 4]` | Ok | `normalize` renumbers → `[0, 1]` |
| a child run continuing across a parent boundary | Ok | `normalize` re-reads it correctly |
| `continues` across a container boundary | Ok | **nothing repaired it** ← this PR |

This is also why I still recommend against #1359's item 6 (rejecting non-canonical ordinals in the authored lane): the principle that separates these is *reject what `normalize` cannot repair, repair the rest silently*, and non-canonical ordinals fall on the repair side.

## Also: the projection obligation a new container inherits

`instance` (#1360) makes an adjacency boundary **storable**; it does not make it **writable**. A container whose Markdown spelling cannot separate two adjacent instances has a boundary in storage that the projection drops, and `from_markdown(to_markdown(rt)) == rt` fails on re-import.

`DOCUMENT_STORAGE.md` now states that as a rule for whatever container lands next. A container specced on CommonMark **§5.1**'s terms (per-line marker, blank-line terminated, as `Container::Quote` is) gets the separator free, because the blank line already ends it. One specced on **§5.2/§5.3**'s terms (a list, which a blank line leaves open) does not, and needs the marker alternation `Container::ListItem` uses.

This is directly relevant to #1362, which defines `: ` by reference to §5.1 and therefore already satisfies it — but by which section it happened to cite, not by rule. Written down so the next one does not have to be lucky.

## What I checked and did not change

Auditing the grouping rules after #1360, one *run* rule remains in the workspace (`Container::same_run`/`run_key`, consumed by the Typst emitter and `census`), and the two remaining loops — `export.rs:154` and `emit.rs:476` — are plain whole-container equality, which is item identity: the documented rule, with no weakening and so no free choice to diverge on. I had previously called that layer partially done; it is complete, and I have not manufactured work to match the earlier framing. Factoring the two 3-line item loops into a cross-crate helper would add a dependency for no risk reduction.

## Verification

- `cargo test --workspace` green, including the property tests that found this.
- `cargo clippy --workspace --all-targets` at 44 warnings, unchanged from baseline.
- `scripts/check-canon.mjs` OK.
- New coverage: `continues_across_a_container_boundary_is_cleared` (model), `set_continues_across_a_container_boundary_is_refused` and `join_across_two_paths_leaves_a_valid_content` (ops) — the last pins that the accepted `Join` still yields a storable content, which is what putting the repair in `normalize` rather than `validate` buys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmDvNTXNtKpD8biDp8cm8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmDvNTXNtKpD8biDp8cm8Q)_