### PR TITLE
Container structure: one traversal, and a type for "normalized"

### DIFF
--- a/crates/backends/pdfform/src/resolve.rs
+++ b/crates/backends/pdfform/src/resolve.rs
@@ -224,7 +224,7 @@ mod tests {
             Some("A bold claim.\nSecond line.")
         );
         let blank =
-            quillmark_content::serial::to_canonical_value(&quillmark_content::Content::empty());
+            quillmark_content::serial::to_canonical_value(&quillmark_content::Normalized::empty());
         assert_eq!(coerce_text(&blank), None);
         assert_eq!(coerce_text(&json!({ "x": 1 })), None);
     }

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -39,7 +39,7 @@
 
 use quillmark_core::error::MAX_NESTING_DEPTH;
 use quillmark_content::island::KnownIslandType;
-use quillmark_content::model::{Container, LineKind, Mark, MarkKind, Content, ISLAND_SLOT};
+use quillmark_content::model::{Container, LineKind, Mark, MarkKind, Content, Normalized, ISLAND_SLOT};
 use std::ops::Range;
 
 /// Neutralizes every markup-special character so document text cannot inject
@@ -272,7 +272,7 @@ impl EmitError {
     }
 }
 
-pub fn emit_content(rt: &Content) -> Result<Emission, EmitError> {
+pub fn emit_content(rt: &Normalized) -> Result<Emission, EmitError> {
     let max_depth = rt
         .lines
         .iter()
@@ -297,7 +297,7 @@ pub fn emit_content(rt: &Content) -> Result<Emission, EmitError> {
 /// Anything not [`is_inline`] falls back to [`emit_content`].
 ///
 /// [`is_inline`]: quillmark_content::Content::is_inline
-pub(crate) fn emit_content_inline(rt: &Content) -> Result<Emission, EmitError> {
+pub(crate) fn emit_content_inline(rt: &Normalized) -> Result<Emission, EmitError> {
     if !rt.is_inline() {
         return emit_content(rt);
     }
@@ -1406,12 +1406,12 @@ mod tests {
     #[test]
     fn overlapping_marks_close_and_reopen() {
         use quillmark_content::model::{Line, Mark};
-        let mut rt = Content::new("abcdef".to_string(), vec![Line::new(LineKind::Para)])
+        let rt = Content::new("abcdef".to_string(), vec![Line::new(LineKind::Para)])
             .with_marks(vec![
                 Mark::new(0, 4, MarkKind::Strong),
                 Mark::new(2, 6, MarkKind::Emph),
             ]);
-        rt.normalize();
+        let rt = rt.into_normalized();
         assert_eq!(rt.validate(), Ok(()));
         let out = emit_content(&rt).unwrap().markup;
         assert_eq!(out, "#strong[ab#emph[cd]]#emph[ef]\n\n");
@@ -1429,7 +1429,7 @@ mod tests {
             attrs: serde_json::Value::Null,
             instance: 0,
         };
-        let mut rt = Content::new(
+        let rt = Content::new(
             "heads up\nsecond".to_string(),
             vec![
                 Line::new(LineKind::Unknown {
@@ -1442,7 +1442,7 @@ mod tests {
                     .with_continues(true),
             ],
         );
-        rt.normalize();
+        let rt = rt.into_normalized();
         assert_eq!(rt.validate(), Ok(()));
         // One block (the `continues` join is a hard break), no wrapper.
         assert_eq!(
@@ -1450,8 +1450,10 @@ mod tests {
             "heads up#linebreak()second\n\n"
         );
         // Inside a known container the known wrapper still renders.
+        let mut rt = rt.into_content();
         rt.lines[0].containers.insert(0, Container::Quote { instance: 0 });
         rt.lines[1].containers.insert(0, Container::Quote { instance: 0 });
+        let rt = rt.into_normalized();
         assert_eq!(
             emit_content(&rt).unwrap().markup,
             "#quote(block: true)[\nheads up#linebreak()second\n\n]\n\n"
@@ -1461,9 +1463,9 @@ mod tests {
     /// Hand-placed `marks` reach the free-overlap shapes import never produces.
     fn emit_marked(text: &str, marks: Vec<Mark>) -> String {
         use quillmark_content::model::Line;
-        let mut rt =
+        let rt =
             Content::new(text.to_string(), vec![Line::new(LineKind::Para)]).with_marks(marks);
-        rt.normalize();
+        let rt = rt.into_normalized();
         assert_eq!(rt.validate(), Ok(()), "content invariants");
         emit_content(&rt).unwrap().markup
     }
@@ -1657,8 +1659,8 @@ mod tests {
         // Source-map integrity: every run's generated slice equals the escape of
         // its content, and the leading `\` is not inside any run.
         use quillmark_content::model::Line;
-        let mut rt = Content::new("= x".to_string(), vec![Line::new(LineKind::Para)]);
-        rt.normalize();
+        let rt = Content::new("= x".to_string(), vec![Line::new(LineKind::Para)]);
+        let rt = rt.into_normalized();
         let ec = emit_content(&rt).unwrap();
         let chars: Vec<char> = rt.text.chars().collect();
         for seg in &ec.segments {

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -387,54 +387,33 @@ impl<'a> Emit<'a> {
     /// `None` for a leaf, leaving the caller to emit it under its own
     /// discipline (top-level terminated vs list item body).
     fn try_emit_container(&mut self, range: Range<usize>, depth: usize, i: usize) -> Option<usize> {
-        match self.rt.lines[i].containers.get(depth).cloned() {
-            Some(key @ Container::ListItem { ordered, start, .. }) => {
-                let j = self.container_run_end(range.clone(), depth, &key, i);
-                self.emit_list(i..j, depth, ordered, start);
+        let rt = self.rt;
+        // A leaf first: `runs` skips a line carrying no container at `depth`,
+        // so without this the run *after* the leaf would swallow it.
+        rt.lines[i].containers.get(depth)?;
+        let run = quillmark_content::traverse::runs(&rt.lines, i..range.end, depth)
+            .next()
+            .expect("a line with a container at `depth` opens a run");
+        let j = run.range.end;
+        match run.container {
+            Container::ListItem { ordered, start, .. } => {
+                self.emit_list(i..j, depth, *ordered, *start);
                 Some(j)
             }
-            Some(key @ Container::Quote { .. }) => {
-                let j = self.container_run_end(range.clone(), depth, &key, i);
+            Container::Quote { .. } => {
                 self.emit_quote(i..j, depth);
                 Some(j)
             }
             // Open set: a container this build does not know is **transparent**,
             // its run lowers at the next depth with no wrapper markup, so the
-            // blocks inside it render where they would without it. Consuming the
-            // whole run here (rather than falling through to the leaf path) keeps
-            // its lines grouped as one block instead of splitting them.
-            Some(key @ Container::Unknown { .. }) => {
-                let j = self.container_run_end(range.clone(), depth, &key, i);
+            // blocks inside it render where they would without it. Consuming
+            // the whole run here keeps its lines grouped as one block instead
+            // of splitting them.
+            _ => {
                 self.emit_block_level(i..j, depth + 1);
                 Some(j)
             }
-            _ => None,
         }
-    }
-
-    /// One container instance's run: the lines whose container at `depth` has
-    /// the same run key (shape without `ordinal`) *and* the same `instance`.
-    ///
-    /// One rule for every container kind. A list's items differ only in
-    /// `ordinal`, which the run key masks, so they group; an adjacent list of
-    /// identical shape carries the other `instance`, so it does not.
-    fn container_run_end(
-        &self,
-        range: Range<usize>,
-        depth: usize,
-        key: &Container,
-        i: usize,
-    ) -> usize {
-        let mut j = i + 1;
-        while j < range.end
-            && self.rt.lines[j]
-                .containers
-                .get(depth)
-                .is_some_and(|c| c.same_run(key) && c.instance() == key.instance())
-        {
-            j += 1;
-        }
-        j
     }
 
     fn segment_end(&self, range: Range<usize>, depth: usize, i: usize) -> usize {
@@ -471,19 +450,13 @@ impl<'a> Emit<'a> {
         let outermost = !self.rt.lines[range.start].containers[..depth]
             .iter()
             .any(|c| matches!(c, Container::ListItem { .. }));
-        let mut k = range.start;
-        while k < range.end {
-            let key = self.rt.lines[k].containers[depth].clone();
-            let mut m = k + 1;
-            while m < range.end && self.rt.lines[m].containers.get(depth) == Some(&key) {
-                m += 1;
-            }
-            let ordinal = match &key {
+        let rt = self.rt;
+        for item in quillmark_content::traverse::items(&rt.lines, range.clone(), depth) {
+            let ordinal = match item.container {
                 Container::ListItem { ordinal, .. } => *ordinal,
                 _ => 0,
             };
-            self.emit_item(k..m, depth, ordered, start, ordinal == 0);
-            k = m;
+            self.emit_item(item.range, depth, ordered, start, ordinal == 0);
         }
         if outermost {
             self.out.push('\n');
@@ -1038,6 +1011,16 @@ mod tests {
         let rt = from_markdown(md).expect("import");
         assert_eq!(rt.validate(), Ok(()), "content invariants for {md:?}");
         emit_content(&rt).expect("emit")
+    }
+
+    #[test]
+    fn a_leaf_before_a_container_run_is_its_own_block() {
+        let out = emit("a\n\n> b").markup;
+        assert!(out.contains('a'), "leaf lost: {out:?}");
+        assert!(
+            out.find('a').unwrap() < out.find("quote").unwrap(),
+            "leaf swallowed into the quote: {out:?}"
+        );
     }
 
     /// The sample set [`runs_map_content_to_generated_bytes`] scans.

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -762,12 +762,12 @@ mod tests {
         // colon, so an unescaped one fails the compile rather than the count.
         use quillmark_content::model::{Container, Line, LineKind, Content};
         let para = |_: usize| Line::new(LineKind::Para);
-        let mut rt = Content::new(
+        let rt = Content::new(
             "= Heading\n- bullet\n+ numbered\n1. dotted\n/ term: desc\n=\n-\n+\n1.\n/"
                 .to_string(),
             (0..10).map(para).collect(),
         );
-        rt.normalize();
+        let rt = rt.into_normalized();
         assert_eq!(rt.validate(), Ok(()), "content invariants");
         assert_eq!(counts(&rt), [0, 0, 0, 0], "paragraph text stays literal");
 
@@ -782,11 +782,11 @@ mod tests {
                 instance: 0,
             }])
         };
-        let mut rt = Content::new(
+        let rt = Content::new(
             "=\n-\n+\n1.\n/".to_string(),
             (0..5).map(item).collect(),
         );
-        rt.normalize();
+        let rt = rt.into_normalized();
         assert_eq!(rt.validate(), Ok(()), "content invariants");
         assert_eq!(counts(&rt), [0, 1, 0, 0], "item text stays literal");
     }

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -1358,7 +1358,7 @@ fn path_from_py(path: &Bound<'_, PyAny>, ctx: &str) -> PyResult<Vec<quillmark::P
 
 fn content_to_py<'py>(
     py: Python<'py>,
-    content: Option<quillmark_content::Content>,
+    content: Option<quillmark_content::Normalized>,
 ) -> PyResult<Option<Bound<'py, PyAny>>> {
     match content {
         None => Ok(None),

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -1945,14 +1945,17 @@ impl Addr {
 /// string. The **storage** lane: content read back out of a document must keep
 /// opening whatever it was written as. Host-authored content goes through
 /// [`js_to_authored_content`].
-fn js_to_content(value: JsValue, ctx: &str) -> Result<quillmark_core::Content, JsValue> {
+fn js_to_content(value: JsValue, ctx: &str) -> Result<quillmark_content::Normalized, JsValue> {
     js_to_content_with(value, ctx, quillmark_content::serial::from_canonical_value)
 }
 
 /// [`js_to_content`] on the **authored** lane. The host is writing this content
 /// now, so `attrs` beside a built-in discriminator is a stale copy of the
 /// built-in list, and is reported instead of silently dropped.
-fn js_to_authored_content(value: JsValue, ctx: &str) -> Result<quillmark_core::Content, JsValue> {
+fn js_to_authored_content(
+    value: JsValue,
+    ctx: &str,
+) -> Result<quillmark_content::Normalized, JsValue> {
     js_to_content_with(value, ctx, quillmark_content::serial::from_authored_value)
 }
 
@@ -1961,8 +1964,8 @@ fn js_to_content_with(
     ctx: &str,
     read: fn(
         &serde_json::Value,
-    ) -> Result<quillmark_core::Content, quillmark_content::serial::ParseError>,
-) -> Result<quillmark_core::Content, JsValue> {
+    ) -> Result<quillmark_content::Normalized, quillmark_content::serial::ParseError>,
+) -> Result<quillmark_content::Normalized, JsValue> {
     let json = js_value_to_json(value, ctx)?;
     if !json.is_object() {
         return Err(WasmError::from(format!(

--- a/crates/content/src/delta.rs
+++ b/crates/content/src/delta.rs
@@ -29,7 +29,7 @@
 //! (the match is lost) drops the anchor: the accepted residual, stated not
 //! hidden.
 
-use crate::model::{Mark, MarkKind, Content};
+use crate::model::{Mark, MarkKind, Content, Normalized};
 use serde::{Deserialize, Serialize};
 use similar::{ChangeTag, TextDiff};
 
@@ -345,8 +345,8 @@ fn push_insert(ops: &mut Vec<Op>, s: &str) {
 pub fn diff_import(
     base: &Content,
     new_markdown: &str,
-) -> Result<(Content, Delta), crate::import::ImportError> {
-    let mut new_rt = crate::import::from_markdown(new_markdown)?;
+) -> Result<(Normalized, Delta), crate::import::ImportError> {
+    let mut new_rt = crate::import::from_markdown(new_markdown)?.into_content();
     let delta = diff(&base.text, &new_rt.text);
 
     let base_chars: Vec<char> = base.text.chars().collect();
@@ -367,8 +367,7 @@ pub fn diff_import(
         }
         // else: detached: the accepted residual drop.
     }
-    new_rt.normalize();
-    Ok((new_rt, delta))
+    Ok((new_rt.into_normalized(), delta))
 }
 
 /// Rebase one anchor through the delta. Returns its new range, or `None` if it
@@ -523,14 +522,14 @@ mod tests {
     #[test]
     fn anchor_rehomed_on_block_move() {
         // Two paragraphs; anchor on the first; the rewrite swaps their order.
-        let mut base = from_markdown("first para here\n\nsecond para here").unwrap();
+        let mut base = from_markdown("first para here\n\nsecond para here").unwrap().into_content();
         // "first para here" is chars 0..15
         base.marks.push(Mark {
             start: 0,
             end: 15,
             kind: MarkKind::Anchor { id: "c1".into() },
         });
-        base.normalize();
+        let base = base.into_normalized();
         let (new_rt, _) = diff_import(&base, "second para here\n\nfirst para here").unwrap();
         let anchor = new_rt
             .marks
@@ -546,14 +545,14 @@ mod tests {
 
     #[test]
     fn anchor_dropped_when_text_deleted() {
-        let mut base = from_markdown("keep this and drop that").unwrap();
+        let mut base = from_markdown("keep this and drop that").unwrap().into_content();
         // Anchor on "drop that" (14..23).
         base.marks.push(Mark {
             start: 14,
             end: 23,
             kind: MarkKind::Anchor { id: "c1".into() },
         });
-        base.normalize();
+        let base = base.into_normalized();
         let (new_rt, _) = diff_import(&base, "keep this").unwrap();
         assert!(
             !new_rt
@@ -566,13 +565,13 @@ mod tests {
 
     #[test]
     fn anchor_not_rehomed_onto_unrelated_survivor() {
-        let mut base = from_markdown("target one to drop\n\nkeep the target two").unwrap();
+        let mut base = from_markdown("target one to drop\n\nkeep the target two").unwrap().into_content();
         base.marks.push(Mark {
             start: 0,
             end: 6, // "target" in the first (deleted) paragraph
             kind: MarkKind::Anchor { id: "c1".into() },
         });
-        base.normalize();
+        let base = base.into_normalized();
         // First paragraph deleted; the second (with its own "target") survives
         // as retained text: the anchor must drop, not jump to it.
         let (new_rt, _) = diff_import(&base, "keep the target two").unwrap();
@@ -625,13 +624,13 @@ mod tests {
 
     #[test]
     fn anchor_survives_between_disjoint_edits() {
-        let mut base = from_markdown("aaaMIDDLEbbb").unwrap();
+        let mut base = from_markdown("aaaMIDDLEbbb").unwrap().into_content();
         base.marks.push(Mark {
             start: 3,
             end: 9,
             kind: MarkKind::Anchor { id: "c1".into() },
         });
-        base.normalize();
+        let base = base.into_normalized();
         let (new_rt, _) = diff_import(&base, "AAAMIDDLEZZZ").unwrap();
         let anchor = new_rt
             .marks
@@ -704,13 +703,13 @@ mod tests {
         // `diff_import` is what a full-document LLM rewrite hits: it must stay
         // fast and still rebase an anchor sitting in shared text.
         let base_text = format!("hello target world-{}-end", filler(30_000, 0));
-        let mut base = from_markdown(&base_text).unwrap();
+        let mut base = from_markdown(&base_text).unwrap().into_content();
         base.marks.push(Mark {
             start: 6,
             end: 12, // "target"
             kind: MarkKind::Anchor { id: "c1".into() },
         });
-        base.normalize();
+        let base = base.into_normalized();
 
         let new_markdown = format!("hello target world-{}-end", filler(30_000, 11));
         let start = std::time::Instant::now();

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -150,19 +150,13 @@ fn emit_block(ctx: &Ctx, range: std::ops::Range<usize>, depth: usize, out: &mut 
     while i < range.end {
         let line = &lines[i];
         if line.containers.len() > depth {
-            // A nested container starts here; gather its run and recurse.
-            let key = &line.containers[depth];
-            let mut j = i + 1;
-            while j < range.end
-                && lines[j].containers.len() > depth
-                && &lines[j].containers[depth] == key
-            {
-                j += 1;
-            }
+            let item = crate::traverse::items(lines, i..range.end, depth)
+                .next()
+                .expect("a line with a container at `depth` opens an item");
             block_separator(out, first_block);
-            emit_container(ctx, key, i..j, depth, out);
+            emit_container(ctx, item.container, item.range.clone(), depth, out);
             first_block = false;
-            i = j;
+            i = item.range.end;
         } else {
             // A leaf block: this line (continues == false) plus every following
             // line that continues it (a hard-break run, or a code fence's lines).

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -26,7 +26,7 @@
 //! adversarial delimiter/break placement.
 
 use crate::island::KnownIslandType;
-use crate::model::{Container, Island, LineKind, Mark, MarkKind, Content, ISLAND_SLOT};
+use crate::model::{Container, Island, LineKind, Mark, MarkKind, Content, Normalized, ISLAND_SLOT};
 
 /// Render a content to markdown. An island projects by **type**: a type this
 /// build knows emits its markdown, any other a placeholder comment.
@@ -35,7 +35,7 @@ use crate::model::{Container, Island, LineKind, Mark, MarkKind, Content, ISLAND_
 /// *describes* fidelity for a consumer to surface, while the type decides
 /// whether a projection exists at all. So a known type stamped with a loss class
 /// this build lacks still emits its table.
-pub fn to_markdown(rt: &Content) -> String {
+pub fn to_markdown(rt: &Normalized) -> String {
     let segments = line_segments(rt);
     let ctx = Ctx {
         rt,
@@ -988,7 +988,7 @@ mod tests {
     /// export∘import is the identity on the content.
     /// A content built by hand, as a client writing `Content` directly builds
     /// one, normalized the way every write lane normalizes it.
-    fn stored(text: &str, containers: Vec<Vec<Container>>) -> Content {
+    fn stored(text: &str, containers: Vec<Vec<Container>>) -> Normalized {
         let lines = containers
             .into_iter()
             .map(|c| {
@@ -997,8 +997,7 @@ mod tests {
                 l
             })
             .collect();
-        let mut rt = Content::new(text.to_string(), lines);
-        rt.normalize();
+        let rt = Content::new(text.to_string(), lines).into_normalized();
         rt.validate().expect("stored content validates");
         rt
     }
@@ -1027,7 +1026,7 @@ mod tests {
     /// a client writing `Content` directly is the lane that mints them.
     #[test]
     fn adjacent_sibling_containers_project_and_return() {
-        let cases: &[(Content, &str)] = &[
+        let cases: &[(Normalized, &str)] = &[
             // Two one-item lists: the shape that used to come back as one item
             // with an unnumbered continuation paragraph.
             (stored("a\nb", vec![li(0, 0), li(0, 1)]), "- a\n\n+ b"),
@@ -1075,14 +1074,16 @@ mod tests {
     /// the item with it — which is why the second bullet is `+`.
     #[test]
     fn alternate_markers_do_not_collide_with_a_rule() {
-        let mut rt = stored("a\n\nb", vec![li(0, 0), li(0, 1), li(1, 1)]);
+        let mut rt = stored("a\n\nb", vec![li(0, 0), li(0, 1), li(1, 1)]).into_content();
         rt.lines[1].kind = LineKind::Rule;
+        let rt = rt.into_normalized();
         rt.validate().expect("validates");
         assert_eq!(to_markdown(&rt), "- a\n\n+ ***\n\n+ b");
         assert_eq!(from_markdown(&to_markdown(&rt)).unwrap(), rt);
 
-        let mut rt = stored("a\n\nb", vec![oli(0, 0), oli(0, 1), oli(1, 1)]);
+        let mut rt = stored("a\n\nb", vec![oli(0, 0), oli(0, 1), oli(1, 1)]).into_content();
         rt.lines[1].kind = LineKind::Rule;
+        let rt = rt.into_normalized();
         assert_eq!(to_markdown(&rt), "1. a\n\n1) ***\n\n2) b");
         assert_eq!(from_markdown(&to_markdown(&rt)).unwrap(), rt);
     }
@@ -1123,9 +1124,9 @@ mod tests {
     /// splits around the slot, keeping both the text and the island.
     #[test]
     fn code_mark_over_island_slot_keeps_the_island() {
-        let mut rt = from_markdown("a ![x](y.png) b").unwrap();
+        let mut rt = from_markdown("a ![x](y.png) b").unwrap().into_content();
         rt.marks.push(Mark { start: 0, end: 5, kind: MarkKind::Code });
-        rt.normalize();
+        let rt = rt.into_normalized();
         assert_eq!(rt.validate(), Ok(()));
         let md = to_markdown(&rt);
         assert_eq!(md, "`a `![x](y.png)` b`");
@@ -1136,7 +1137,7 @@ mod tests {
 
     #[test]
     fn unknown_block_vocabulary_projects_as_prose() {
-        let mut rt = Content {
+        let rt = Content {
             text: "heads up\nstill inside".into(),
             lines: vec![
                 Line {
@@ -1164,13 +1165,14 @@ mod tests {
             marks: vec![Mark { start: 0, end: 5, kind: MarkKind::Strong }],
             islands: vec![],
         };
-        rt.normalize();
+        let rt = rt.into_normalized();
         assert_eq!(rt.validate(), Ok(()));
         assert_eq!(to_markdown(&rt), "**heads** up\n\nstill inside");
         // An unknown container inside a known one adds no prefix of its own.
+        let mut rt = rt.into_content();
         rt.lines[0].containers.insert(0, Container::Quote { instance: 0 });
         rt.lines[1].containers.insert(0, Container::Quote { instance: 0 });
-        assert_eq!(to_markdown(&rt), "> **heads** up\n>\n> still inside");
+        assert_eq!(to_markdown(&rt.into_normalized()), "> **heads** up\n>\n> still inside");
     }
 
     #[test]
@@ -1180,7 +1182,7 @@ mod tests {
             vec![Mark { start: 0, end: 4, kind: MarkKind::Strong }],
         );
         assert_eq!(to_plaintext(&rt), "bold text");
-        let mut rt = Content {
+        let rt = Content {
             text: format!("see {ISLAND_SLOT} here"),
             lines: vec![Line { kind: LineKind::Para, containers: vec![], continues: false }],
             marks: vec![],
@@ -1190,15 +1192,15 @@ mod tests {
                 props: serde_json::Value::Null,
                 loss: Loss::UNREPRESENTABLE,
             }],
-        };
-        rt.normalize();
+        }
+        .into_normalized();
         assert_eq!(to_plaintext(&rt), "see  here");
     }
 
     /// A single-paragraph content with hand-placed `marks`: the free-overlap
     /// shapes an editor produces but markdown import never does.
-    fn marked(text: &str, marks: Vec<Mark>) -> Content {
-        let mut rt = Content {
+    fn marked(text: &str, marks: Vec<Mark>) -> Normalized {
+        let rt = Content {
             text: text.to_string(),
             lines: vec![Line {
                 kind: LineKind::Para,
@@ -1207,8 +1209,8 @@ mod tests {
             }],
             marks,
             islands: vec![],
-        };
-        rt.normalize();
+        }
+        .into_normalized();
         assert_eq!(rt.validate(), Ok(()), "content invariants");
         rt
     }
@@ -1293,8 +1295,9 @@ mod tests {
 
     #[test]
     fn leading_ordered_marker_escaped() {
-        let mut rt = from_markdown("x").unwrap();
+        let mut rt = from_markdown("x").unwrap().into_content();
         rt.text = "1. not a list".into();
+        let rt = rt.into_normalized();
         let md = to_markdown(&rt);
         let back = from_markdown(&md).unwrap();
         assert_eq!(back.lines[0].kind, LineKind::Para);
@@ -1335,13 +1338,13 @@ mod tests {
 
     #[test]
     fn anchor_marks_omitted_but_text_survives() {
-        let mut rt = from_markdown("comment target here").unwrap();
+        let mut rt = from_markdown("comment target here").unwrap().into_content();
         rt.marks.push(Mark {
             start: 8,
             end: 14,
             kind: MarkKind::Anchor { id: "c1".into() },
         });
-        rt.normalize();
+        let rt = rt.into_normalized();
         let md = to_markdown(&rt);
         let rt2 = from_markdown(&md).unwrap();
         assert_eq!(rt2.text, "comment target here");

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -1234,13 +1234,8 @@ mod tests {
         ];
         for (md, runs) in cases {
             let rt = imp(md);
-            let mut seen: Vec<_> = rt
-                .lines
-                .iter()
-                .map(|l| (l.containers[0].run_key(), l.containers[0].instance()))
-                .collect();
-            seen.dedup();
-            assert_eq!(seen.len(), *runs, "{md:?} -> {:?}", rt.lines);
+            let seen = crate::traverse::runs(&rt.lines, 0..rt.lines.len(), 0).count();
+            assert_eq!(seen, *runs, "{md:?} -> {:?}", rt.lines);
             let rt2 = from_markdown(&crate::export::to_markdown(&rt)).unwrap();
             assert_eq!(rt, rt2, "{md:?} is not a fixed point");
         }

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -24,7 +24,7 @@
 //! - **Thematic breaks are `Rule` lines** carrying no text.
 
 use crate::model::{
-    Container, Island, Line, LineKind, Loss, Mark, MarkKind, Content, ISLAND_SLOT,
+    Container, Island, Line, LineKind, Loss, Mark, MarkKind, Content, Normalized, ISLAND_SLOT,
 };
 use crate::island::KnownIslandType;
 use crate::normalize::normalize_markdown;
@@ -62,7 +62,7 @@ impl std::fmt::Display for ImportError {
 impl std::error::Error for ImportError {}
 
 /// Import markdown into a normalized, validated [`Content`] content.
-pub fn from_markdown(markdown: &str) -> Result<Content, ImportError> {
+pub fn from_markdown(markdown: &str) -> Result<Normalized, ImportError> {
     let normalized = normalize_markdown(markdown);
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
@@ -71,9 +71,7 @@ pub fn from_markdown(markdown: &str) -> Result<Content, ImportError> {
 
     let mut b = Builder::new();
     b.run(fixer)?;
-    let mut rt = b.finish();
-    rt.normalize();
-    Ok(rt)
+    Ok(b.finish().into_normalized())
 }
 
 /// Import plain text (literal) into a [`Content`]: the literal-codec sibling of
@@ -86,7 +84,7 @@ pub fn from_markdown(markdown: &str) -> Result<Content, ImportError> {
 /// segments is a within-paragraph break ([`Line::continues`] `true`); a blank
 /// line is a paragraph boundary. The text is stored verbatim, so the round trip
 /// is byte-exact however structure is later re-derived.
-pub fn from_plaintext(s: &str) -> Content {
+pub fn from_plaintext(s: &str) -> Normalized {
     // Boundary cleanup so the content invariants hold; clean plaintext passes
     // through untouched.
     let text: String = s
@@ -111,6 +109,7 @@ pub fn from_plaintext(s: &str) -> Content {
         marks: Vec::new(),
         islands: Vec::new(),
     }
+    .into_normalized()
 }
 
 /// A flat inline accumulator: `text` plus `marks` over local USV offsets, with
@@ -896,13 +895,13 @@ mod tests {
     use super::*;
     use crate::model::LineKind;
 
-    fn imp(md: &str) -> Content {
+    fn imp(md: &str) -> Normalized {
         let rt = from_markdown(md).unwrap();
         assert_eq!(rt.validate(), Ok(()), "invariants for {md:?}");
         rt
     }
 
-    fn imp_plain(s: &str) -> Content {
+    fn imp_plain(s: &str) -> Normalized {
         let rt = from_plaintext(s);
         assert_eq!(rt.validate(), Ok(()), "invariants for {s:?}");
         rt

--- a/crates/content/src/lib.rs
+++ b/crates/content/src/lib.rs
@@ -33,6 +33,7 @@ pub use ops::{
     ApplyError, ChangeBundle, IslandOp, LineOp, MarkOp,
 };
 pub use serial::ParseError;
+pub use model::Normalized;
 pub use traverse::{items, runs, Span};
 
 /// Maximum container nesting depth the markdown codecs accept before erroring.

--- a/crates/content/src/lib.rs
+++ b/crates/content/src/lib.rs
@@ -16,6 +16,7 @@ pub mod model;
 pub mod normalize;
 pub mod ops;
 pub mod serial;
+pub mod traverse;
 pub mod usv;
 
 pub use delta::{diff_import, Assoc, Delta, Op};
@@ -32,6 +33,7 @@ pub use ops::{
     ApplyError, ChangeBundle, IslandOp, LineOp, MarkOp,
 };
 pub use serial::ParseError;
+pub use traverse::{items, runs, Span};
 
 /// Maximum container nesting depth the markdown codecs accept before erroring.
 /// The import guard ([`import::from_markdown`]) and the typst backend's markup

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -211,7 +211,7 @@ impl Container {
     /// Whether these two are the same container shape, `ordinal` and `instance`
     /// aside. Two adjacent lines sit in the same container instance iff this
     /// holds *and* their [`instance`](Self::instance)s are equal, which is what
-    /// [`crate::traverse::runs`] applies for every consumer.
+    /// [`crate::traverse::runs`] applies.
     pub fn same_run(&self, other: &Container) -> bool {
         match (self, other) {
             (
@@ -254,7 +254,7 @@ impl Container {
 }
 
 /// A [`Content`] that [`Content::normalize`] has run on: the precondition both
-/// projections carry, held as a value rather than as a call-site convention.
+/// projections carry.
 ///
 /// Minted only by [`Content::into_normalized`], which the codecs decode
 /// through. Reads borrow through to the [`Content`]; the mutations that
@@ -276,8 +276,8 @@ impl Normalized {
         self.0
     }
 
-    /// The wrapped content, mutably. Every caller must leave it normalized;
-    /// the forwarded `apply_*` in [`crate::ops`] are the ones that do.
+    /// Every caller must leave this normalized; the forwarded `apply_*` in
+    /// [`crate::ops`] are the ones that do.
     pub(crate) fn as_content_mut(&mut self) -> &mut Content {
         &mut self.0
     }
@@ -765,8 +765,8 @@ impl Content {
         }
     }
 
-    /// Normalize and seal. With [`Normalized::empty`], the only mint there is:
-    /// the codecs reach [`Normalized`] through here.
+    /// Normalize and seal. With [`Normalized::empty`], the only mint for
+    /// [`Normalized`]; the codecs decode through here.
     pub fn into_normalized(mut self) -> Normalized {
         self.normalize();
         Normalized(self)

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -253,6 +253,50 @@ impl Container {
     }
 }
 
+/// A [`Content`] that [`Content::normalize`] has run on: the precondition both
+/// projections carry, held as a value rather than as a call-site convention.
+///
+/// Minted only by [`Content::into_normalized`], which the codecs decode
+/// through. Reads borrow through to the [`Content`]; the mutations that
+/// re-establish the invariant are forwarded, and any other one takes
+/// [`into_content`](Self::into_content) and mints again.
+///
+/// `normalize` **repairs** rather than rejects, so this states that the value is
+/// canonical, not that its producer meant it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Normalized(Content);
+
+impl Normalized {
+    /// [`Content::empty`], which is already canonical.
+    pub fn empty() -> Normalized {
+        Normalized(Content::empty())
+    }
+
+    pub fn into_content(self) -> Content {
+        self.0
+    }
+
+    /// The wrapped content, mutably. Every caller must leave it normalized;
+    /// the forwarded `apply_*` in [`crate::ops`] are the ones that do.
+    pub(crate) fn as_content_mut(&mut self) -> &mut Content {
+        &mut self.0
+    }
+}
+
+impl From<Content> for Normalized {
+    fn from(rt: Content) -> Normalized {
+        rt.into_normalized()
+    }
+}
+
+impl std::ops::Deref for Normalized {
+    type Target = Content;
+
+    fn deref(&self) -> &Content {
+        &self.0
+    }
+}
+
 /// A mark over a char range `[start, end)`. `start == end` (zero-width) is legal
 /// only for [`MarkKind::Anchor`]; normalization drops zero-width formatting.
 #[derive(Debug, Clone, PartialEq)]
@@ -719,6 +763,13 @@ impl Content {
             marks: Vec::new(),
             islands: Vec::new(),
         }
+    }
+
+    /// Normalize and seal. With [`Normalized::empty`], the only mint there is:
+    /// the codecs reach [`Normalized`] through here.
+    pub fn into_normalized(mut self) -> Normalized {
+        self.normalize();
+        Normalized(self)
     }
 
     pub fn with_marks(mut self, marks: Vec<Mark>) -> Self {

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -208,9 +208,10 @@ impl Container {
         }
     }
 
-    /// Whether these two share a [`run_key`](Self::run_key), without building
-    /// one: an `Unknown`'s key holds its whole `attrs`, and both the emitters
-    /// and `normalize` ask this once per line.
+    /// Whether these two are the same container shape, `ordinal` and `instance`
+    /// aside. Two adjacent lines sit in the same container instance iff this
+    /// holds *and* their [`instance`](Self::instance)s are equal, which is what
+    /// [`crate::traverse::runs`] applies for every consumer.
     pub fn same_run(&self, other: &Container) -> bool {
         match (self, other) {
             (
@@ -248,27 +249,6 @@ impl Container {
                 a == b
             }
             _ => self.same_run(other),
-        }
-    }
-
-    /// This container's **run key**: its shape with `ordinal` and `instance`
-    /// masked off. Two adjacent lines sit in the same container instance iff
-    /// their run keys *and* instances match; the two emitters and
-    /// `quill::support::census` all group on that pair.
-    pub fn run_key(&self) -> Container {
-        match self {
-            Container::ListItem { ordered, start, .. } => Container::ListItem {
-                ordered: *ordered,
-                start: *start,
-                ordinal: 0,
-                instance: 0,
-            },
-            Container::Quote { .. } => Container::Quote { instance: 0 },
-            Container::Unknown { tag, attrs, .. } => Container::Unknown {
-                tag: tag.clone(),
-                attrs: attrs.clone(),
-                instance: 0,
-            },
         }
     }
 }

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -906,28 +906,44 @@ fn newline_at_line_boundary(text: &str, line: usize) -> Result<Usv, ApplyError> 
     })
 }
 
-/// The mutations that re-establish the invariant, forwarded: each normalizes
-/// before it returns, so the token survives. Any other edit takes
-/// [`Normalized::into_content`].
+/// The mutations that re-establish the invariant, forwarded.
+///
+/// Each normalizes before it returns, on an error too: an op list that fails
+/// partway leaves its earlier ops applied. So the token states that the value
+/// is canonical, not that the edit landed.
+///
+/// Any other edit takes [`into_content`](crate::model::Normalized::into_content).
 impl crate::model::Normalized {
+    fn seal(&mut self, applied: Result<(), ApplyError>) -> Result<(), ApplyError> {
+        if applied.is_err() {
+            self.as_content_mut().normalize();
+        }
+        applied
+    }
+
     pub fn apply_text_delta(&mut self, delta: &Delta) -> Result<(), ApplyError> {
-        self.as_content_mut().apply_text_delta(delta)
+        let applied = self.as_content_mut().apply_text_delta(delta);
+        self.seal(applied)
     }
 
     pub fn apply_mark_ops(&mut self, ops: &[MarkOp]) -> Result<(), ApplyError> {
-        self.as_content_mut().apply_mark_ops(ops)
+        let applied = self.as_content_mut().apply_mark_ops(ops);
+        self.seal(applied)
     }
 
     pub fn apply_island_ops(&mut self, ops: &[IslandOp]) -> Result<(), ApplyError> {
-        self.as_content_mut().apply_island_ops(ops)
+        let applied = self.as_content_mut().apply_island_ops(ops);
+        self.seal(applied)
     }
 
     pub fn apply_line_ops(&mut self, ops: &[LineOp]) -> Result<(), ApplyError> {
-        self.as_content_mut().apply_line_ops(ops)
+        let applied = self.as_content_mut().apply_line_ops(ops);
+        self.seal(applied)
     }
 
     pub fn apply_field_change(&mut self, bundle: &ChangeBundle) -> Result<(), ApplyError> {
-        self.as_content_mut().apply_field_change(bundle)
+        let applied = self.as_content_mut().apply_field_change(bundle);
+        self.seal(applied)
     }
 }
 

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -906,6 +906,31 @@ fn newline_at_line_boundary(text: &str, line: usize) -> Result<Usv, ApplyError> 
     })
 }
 
+/// The mutations that re-establish the invariant, forwarded: each normalizes
+/// before it returns, so the token survives. Any other edit takes
+/// [`Normalized::into_content`].
+impl crate::model::Normalized {
+    pub fn apply_text_delta(&mut self, delta: &Delta) -> Result<(), ApplyError> {
+        self.as_content_mut().apply_text_delta(delta)
+    }
+
+    pub fn apply_mark_ops(&mut self, ops: &[MarkOp]) -> Result<(), ApplyError> {
+        self.as_content_mut().apply_mark_ops(ops)
+    }
+
+    pub fn apply_island_ops(&mut self, ops: &[IslandOp]) -> Result<(), ApplyError> {
+        self.as_content_mut().apply_island_ops(ops)
+    }
+
+    pub fn apply_line_ops(&mut self, ops: &[LineOp]) -> Result<(), ApplyError> {
+        self.as_content_mut().apply_line_ops(ops)
+    }
+
+    pub fn apply_field_change(&mut self, bundle: &ChangeBundle) -> Result<(), ApplyError> {
+        self.as_content_mut().apply_field_change(bundle)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1071,13 +1096,13 @@ mod tests {
 
     #[test]
     fn apply_text_delta_rebases_marks() {
-        let mut rt = from_markdown("hello").unwrap();
+        let mut rt = from_markdown("hello").unwrap().into_content();
         rt.marks.push(Mark {
             start: 1,
             end: 4,
             kind: MarkKind::Strong,
         });
-        rt.normalize();
+        let mut rt = rt.into_normalized();
         let d = diff("hello", "hXello");
         rt.apply_text_delta(&d).unwrap();
         let strong = rt
@@ -1183,7 +1208,7 @@ mod tests {
 
     #[test]
     fn apply_mark_ops_remove_non_formatting_drops_whole() {
-        let mut rt = from_markdown("abcdef").unwrap();
+        let mut rt = from_markdown("abcdef").unwrap().into_content();
         rt.marks.push(Mark {
             start: 0,
             end: 6,
@@ -1192,7 +1217,7 @@ mod tests {
                 attrs: serde_json::json!({}),
             },
         });
-        rt.normalize();
+        let mut rt = rt.into_normalized();
         rt.apply_mark_ops(&[MarkOp::Remove {
             start: 2,
             end: 4,
@@ -1985,14 +2010,14 @@ mod tests {
 
     #[test]
     fn join_line_rebases_marks_to_final_text_coordinates() {
-        let mut rt = from_markdown("ab").unwrap();
+        let mut rt = from_markdown("ab").unwrap().into_content();
         rt.apply_text_delta(&diff("ab", "ab\ncd")).unwrap();
         rt.marks.push(Mark {
             start: 2,
             end: 4,
             kind: MarkKind::Strong,
         });
-        rt.normalize();
+        let mut rt = rt.into_normalized();
         rt.apply_line_ops(&[LineOp::Join { line: 0 }]).unwrap();
         assert_eq!(rt.text, "abcd");
         let strong: Vec<_> = rt

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -19,7 +19,7 @@
 
 use crate::model::{
     canonicalize_keys, Container, Invariant, Island, Line, LineKind, Loss, Mark,
-    MarkKind, Content, Usv,
+    MarkKind, Content, Normalized, Usv,
 };
 use serde_json::{Map, Value};
 use std::borrow::Cow;
@@ -61,7 +61,7 @@ impl Content {
     /// Parse canonical JSON, normalize, and validate. Returns
     /// [`ParseError::Invalid`] for a content that violates its invariants, so
     /// storage cannot silently round-trip a malformed value.
-    pub fn from_canonical_json(s: &str) -> Result<Content, ParseError> {
+    pub fn from_canonical_json(s: &str) -> Result<Normalized, ParseError> {
         let v: Value = serde_json::from_str(s).map_err(|e| ParseError::Json(e.to_string()))?;
         from_canonical_value(&v)
     }
@@ -141,9 +141,8 @@ fn sort_own_keys(m: Map<String, Value>) -> Map<String, Value> {
 /// Parse the canonical content form from a structural [`Value`], normalize, and
 /// validate: the [`Value`]-input counterpart to
 /// [`Content::from_canonical_json`].
-pub fn from_canonical_value(v: &Value) -> Result<Content, ParseError> {
-    let mut rt = Content::from_value(v)?;
-    rt.normalize();
+pub fn from_canonical_value(v: &Value) -> Result<Normalized, ParseError> {
+    let rt = Content::from_value(v)?.into_normalized();
     rt.validate().map_err(ParseError::Invalid)?;
     Ok(rt)
 }
@@ -557,7 +556,7 @@ pub(crate) fn reject_unreadable_mark(v: &Value) -> Result<(), ParseError> {
 /// `install` input, not a blob read back from storage. Same decode, plus the
 /// reserved-name rule on every axis [`Content::validate`] checks: line kinds,
 /// containers, prose marks, and table-cell marks.
-pub fn from_authored_value(v: &Value) -> Result<Content, ParseError> {
+pub fn from_authored_value(v: &Value) -> Result<Normalized, ParseError> {
     reject_reserved_attrs_deep(v)?;
     from_canonical_value(v)
 }

--- a/crates/content/src/traverse.rs
+++ b/crates/content/src/traverse.rs
@@ -1,5 +1,4 @@
-//! Container-run and item traversal: the one loop that applies the grouping
-//! rule [`Container::same_run`] states.
+//! The one loop that applies the grouping rule [`Container::same_run`] states.
 
 use crate::model::{Container, Line};
 use std::ops::Range;
@@ -20,7 +19,7 @@ pub struct Span<'a> {
 ///
 /// Container identity is path plus contiguity, so `range` must be one parent's
 /// span: over a range spanning two parents, two like runs under them read as
-/// one. [`items`] is what bounds a parent, an item being a parent.
+/// one. An [`items`] span is the parent bound to descend through.
 pub fn runs(lines: &[Line], range: Range<usize>, depth: usize) -> Spans<'_> {
     Spans {
         lines,

--- a/crates/content/src/traverse.rs
+++ b/crates/content/src/traverse.rs
@@ -1,0 +1,157 @@
+//! Container-run and item traversal: the one loop that applies the grouping
+//! rule [`Container::same_run`] states.
+
+use crate::model::{Container, Line};
+use std::ops::Range;
+
+/// A maximal span of adjacent lines sharing one container at a depth.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Span<'a> {
+    pub container: &'a Container,
+    pub range: Range<usize>,
+}
+
+/// The container runs at `depth` within `range`: adjacent lines whose container
+/// at `depth` is one instance — same [`Container::same_run`] shape *and* same
+/// [`Container::instance`].
+///
+/// A line carrying no container at `depth` belongs to no run, so it both ends
+/// the run before it and is skipped rather than yielded.
+///
+/// Container identity is path plus contiguity, so `range` must be one parent's
+/// span: over a range spanning two parents, two like runs under them read as
+/// one. [`items`] is what bounds a parent, an item being a parent.
+pub fn runs(lines: &[Line], range: Range<usize>, depth: usize) -> Spans<'_> {
+    Spans {
+        lines,
+        end: range.end.min(lines.len()),
+        at: range.start,
+        depth,
+        same: |a, b| a.same_run(b) && a.instance() == b.instance(),
+    }
+}
+
+/// The items at `depth` within `range`: adjacent lines whose whole container at
+/// `depth` is equal, so a list's items separate while an item spanning several
+/// paragraphs stays whole. Skips a line carrying no container at `depth`, as
+/// [`runs`] does.
+///
+/// An item is a parent: what nests inside one is bounded by its span, never by
+/// its run's.
+pub fn items(lines: &[Line], range: Range<usize>, depth: usize) -> Spans<'_> {
+    Spans {
+        lines,
+        end: range.end.min(lines.len()),
+        at: range.start,
+        depth,
+        same: |a, b| a == b,
+    }
+}
+
+/// Iterator over [`runs`] or [`items`].
+pub struct Spans<'a> {
+    lines: &'a [Line],
+    end: usize,
+    at: usize,
+    depth: usize,
+    same: fn(&Container, &Container) -> bool,
+}
+
+impl<'a> Iterator for Spans<'a> {
+    type Item = Span<'a>;
+
+    fn next(&mut self) -> Option<Span<'a>> {
+        while self.at < self.end && self.lines[self.at].containers.len() <= self.depth {
+            self.at += 1;
+        }
+        if self.at >= self.end {
+            return None;
+        }
+        let start = self.at;
+        let container = &self.lines[start].containers[self.depth];
+        let mut j = start + 1;
+        while j < self.end
+            && self.lines[j]
+                .containers
+                .get(self.depth)
+                .is_some_and(|c| (self.same)(c, container))
+        {
+            j += 1;
+        }
+        self.at = j;
+        Some(Span {
+            container,
+            range: start..j,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Content, LineKind};
+
+    fn li(ordinal: u64, instance: u64) -> Container {
+        Container::ListItem {
+            ordered: false,
+            start: 1,
+            ordinal,
+            instance,
+        }
+    }
+
+    fn content(paths: &[Vec<Container>]) -> Content {
+        let text = vec!["x"; paths.len()].join("\n");
+        let lines = paths
+            .iter()
+            .map(|p| {
+                let mut l = Line::new(LineKind::Para);
+                l.containers = p.clone();
+                l
+            })
+            .collect();
+        Content::new(text, lines)
+    }
+
+    fn spans(it: Spans<'_>) -> Vec<Range<usize>> {
+        it.map(|s| s.range).collect()
+    }
+
+    #[test]
+    fn a_run_spans_its_items_and_an_item_spans_its_paragraphs() {
+        let rt = content(&[vec![li(0, 0)], vec![li(0, 0)], vec![li(1, 0)]]);
+        assert_eq!(spans(runs(&rt.lines, 0..3, 0)), vec![0..3]);
+        assert_eq!(spans(items(&rt.lines, 0..3, 0)), vec![0..2, 2..3]);
+    }
+
+    #[test]
+    fn instance_ends_a_run_that_shape_alone_would_weld() {
+        let rt = content(&[vec![li(0, 0)], vec![li(0, 1)]]);
+        assert_eq!(spans(runs(&rt.lines, 0..2, 0)), vec![0..1, 1..2]);
+    }
+
+    #[test]
+    fn a_line_without_a_container_at_depth_ends_a_run_and_is_skipped() {
+        let rt = content(&[vec![li(0, 0)], vec![], vec![li(0, 0)]]);
+        assert_eq!(spans(runs(&rt.lines, 0..3, 0)), vec![0..1, 2..3]);
+    }
+
+    #[test]
+    fn a_range_bounds_the_parent_two_like_runs_nest_under() {
+        let rt = content(&[
+            vec![li(0, 0), Container::Quote { instance: 0 }],
+            vec![li(1, 0), Container::Quote { instance: 0 }],
+        ]);
+        assert_eq!(spans(runs(&rt.lines, 0..2, 1)), vec![0..2]);
+        let per_item: Vec<_> = items(&rt.lines, 0..2, 0)
+            .flat_map(|item| spans(runs(&rt.lines, item.range, 1)))
+            .collect();
+        assert_eq!(per_item, vec![0..1, 1..2]);
+    }
+
+    #[test]
+    fn a_range_end_past_the_last_line_is_clamped() {
+        let rt = content(&[vec![li(0, 0)]]);
+        assert_eq!(spans(runs(&rt.lines, 0..99, 0)), vec![0..1]);
+    }
+}

--- a/crates/content/tests/container_canonical_form.rs
+++ b/crates/content/tests/container_canonical_form.rs
@@ -14,7 +14,7 @@
 //!    a distinction it cannot write down — the exact defect class #1359 is
 //!    about, caught on the lane that mints it rather than on an import.
 
-use quillmark_content::model::{Container, Content, Line, LineKind};
+use quillmark_content::model::{Container, Content, Line, LineKind, Normalized};
 use quillmark_content::{from_markdown, to_markdown};
 
 /// Containers a hand-built path can hold. `Unknown` is excluded from the
@@ -58,7 +58,7 @@ fn paths(unknown: bool) -> Vec<Vec<Container>> {
     out
 }
 
-fn build(paths: &[&Vec<Container>]) -> Content {
+fn build(paths: &[&Vec<Container>]) -> Normalized {
     let text = (0..paths.len())
         .map(|i| ((b'a' + i as u8) as char).to_string())
         .collect::<Vec<_>>()
@@ -67,9 +67,7 @@ fn build(paths: &[&Vec<Container>]) -> Content {
         .iter()
         .map(|p| Line::new(LineKind::Para).with_containers((*p).clone()))
         .collect();
-    let mut rt = Content::new(text, lines);
-    rt.normalize();
-    rt
+    Content::new(text, lines).into_normalized()
 }
 
 #[test]
@@ -80,8 +78,7 @@ fn normalize_is_idempotent_over_every_two_line_path_pair() {
         for b in &ps {
             let rt = build(&[a, b]);
             assert_eq!(rt.validate(), Ok(()), "invalid after normalize: {rt:?}");
-            let mut again = rt.clone();
-            again.normalize();
+            let again = rt.clone().into_content().into_normalized();
             assert_eq!(again, rt, "normalize not idempotent for {a:?} then {b:?}");
             n += 1;
         }
@@ -131,8 +128,7 @@ fn triples_over_the_list_and_quote_alphabet_are_fixed_points() {
         for b in ps.iter().step_by(3) {
             for c in ps.iter().step_by(5) {
                 let rt = build(&[a, b, c]);
-                let mut again = rt.clone();
-                again.normalize();
+                let again = rt.clone().into_content().into_normalized();
                 assert_eq!(again, rt, "not idempotent: {a:?} {b:?} {c:?}");
                 if from_markdown(&to_markdown(&rt)).unwrap() != rt {
                     broken += 1;

--- a/crates/content/tests/normalized_precondition.rs
+++ b/crates/content/tests/normalized_precondition.rs
@@ -1,0 +1,54 @@
+//! The projections take a [`Normalized`], so the shapes #1364 measured as
+//! validating-but-lying cannot reach them.
+
+use quillmark_content::model::{Container, Content, Line, LineKind};
+use quillmark_content::{from_markdown, to_markdown};
+
+fn li(ordered: bool, ordinal: u64, instance: u64) -> Container {
+    Container::ListItem {
+        ordered,
+        start: 1,
+        ordinal,
+        instance,
+    }
+}
+
+fn built(paths: Vec<Container>) -> Content {
+    let lines = paths
+        .into_iter()
+        .map(|c| {
+            let mut l = Line::new(LineKind::Para);
+            l.containers = vec![c];
+            l
+        })
+        .collect::<Vec<_>>();
+    Content::new("a\nb".to_string(), lines)
+}
+
+/// Two one-item lists at a non-canonical `instance` pair: the markers alternate
+/// on parity, so `0, 2` spells both `- ` and the runs weld on re-import.
+#[test]
+fn an_off_parity_instance_pair_projects_as_two_lists() {
+    let rt = built(vec![li(false, 0, 0), li(false, 0, 2)]);
+    assert_eq!(rt.validate(), Ok(()), "the raw content is valid either way");
+
+    let rt = rt.into_normalized();
+    assert_eq!(to_markdown(&rt), "- a\n\n+ b");
+    assert_eq!(from_markdown(&to_markdown(&rt)).unwrap(), rt);
+}
+
+/// A stored `ordinal` that is not the item's index renumbers, so the bytes a
+/// re-encode produces are the bytes the projection rendered from.
+#[test]
+fn an_off_by_one_ordinal_pair_renumbers_before_it_renders() {
+    let rt = built(vec![li(true, 1, 0), li(true, 2, 0)]).into_normalized();
+    assert_eq!(to_markdown(&rt), "1. a\n\n2. b");
+    assert_eq!(from_markdown(&to_markdown(&rt)).unwrap(), rt);
+}
+
+/// Minting is idempotent: a token's content re-mints to the same token.
+#[test]
+fn re_minting_a_token_changes_nothing() {
+    let rt = built(vec![li(false, 0, 2), li(false, 1, 2)]).into_normalized();
+    assert_eq!(rt.clone().into_content().into_normalized(), rt);
+}

--- a/crates/content/tests/normalized_precondition.rs
+++ b/crates/content/tests/normalized_precondition.rs
@@ -1,5 +1,6 @@
-//! The projections take a [`Normalized`], so the shapes #1364 measured as
-//! validating-but-lying cannot reach them.
+//! A content that `validate` accepts can still project to markdown that
+//! re-imports as a different content. The projections take a [`Normalized`],
+//! so those shapes cannot reach them.
 
 use quillmark_content::model::{Container, Content, Line, LineKind};
 use quillmark_content::{from_markdown, to_markdown};
@@ -51,4 +52,26 @@ fn an_off_by_one_ordinal_pair_renumbers_before_it_renders() {
 fn re_minting_a_token_changes_nothing() {
     let rt = built(vec![li(false, 0, 2), li(false, 1, 2)]).into_normalized();
     assert_eq!(rt.clone().into_content().into_normalized(), rt);
+}
+
+/// The other mint: what it hands out is what `normalize` would produce.
+#[test]
+fn the_empty_mint_is_canonical() {
+    assert_eq!(Content::empty().into_normalized(), quillmark_content::Normalized::empty());
+}
+
+/// An op list that fails partway leaves its earlier ops applied; the token
+/// still holds a canonical value.
+#[test]
+fn a_failed_op_list_leaves_the_token_canonical() {
+    use quillmark_content::model::MarkKind;
+    use quillmark_content::MarkOp;
+
+    let mut rt = from_markdown("**a**b").unwrap();
+    let ops = [
+        MarkOp::Add { start: 0, end: 2, kind: MarkKind::Strong },
+        MarkOp::Add { start: 0, end: 99, kind: MarkKind::Strong },
+    ];
+    assert!(rt.apply_mark_ops(&ops).is_err());
+    assert_eq!((*rt).clone().into_normalized(), rt);
 }

--- a/crates/content/tests/properties.rs
+++ b/crates/content/tests/properties.rs
@@ -184,8 +184,9 @@ proptest! {
             Mark::new(s1, e1, ov_kind(k1i)),
             Mark::new(s2, e2, ov_kind(k2i)),
         ];
-        let mut rt = Content::new(text.clone(), vec![Line::new(LineKind::Para)]).with_marks(marks);
-        rt.normalize();
+        let rt = Content::new(text.clone(), vec![Line::new(LineKind::Para)])
+            .with_marks(marks)
+            .into_normalized();
         prop_assert_eq!(rt.validate(), Ok(()), "hand-built content invalid");
 
         let md = to_markdown(&rt);
@@ -230,8 +231,7 @@ proptest! {
             .chain(std::iter::once('a'))
             .collect();
         let n = text.chars().count();
-        let mut rt = Content::new(text.clone(), vec![Line::new(LineKind::Para)]);
-        rt.normalize();
+        let mut rt = Content::new(text.clone(), vec![Line::new(LineKind::Para)]).into_normalized();
         prop_assume!(rt.validate().is_ok());
         prop_assume!(rt.len_usv() == n);
         // Require the mark-free text to be a fixed point already, so a later
@@ -273,12 +273,12 @@ proptest! {
         // Import trims alt, so match that to stay in the fixed-point domain.
         let alt = alt.trim().to_string();
         let text = "lnk\u{FFFC}".to_string(); // link over "lnk", image slot after
-        let mut rt = Content::new(text, vec![Line::new(LineKind::Para)])
+        let rt = Content::new(text, vec![Line::new(LineKind::Para)])
             .with_marks(vec![Mark::new(0, 3, MarkKind::Link { url: link_url })])
             // The id import mints for the first island, so re-import compares equal.
             .with_islands(vec![Island::new("isl-0".into(), "image".into())
-                .with_props(json!({ "alt": alt, "url": img_url }))]);
-        rt.normalize();
+                .with_props(json!({ "alt": alt, "url": img_url }))])
+            .into_normalized();
         prop_assert_eq!(rt.validate(), Ok(()), "hand-built content invalid");
         let md = to_markdown(&rt);
         let rt2 = from_markdown(&md).unwrap();
@@ -299,7 +299,7 @@ proptest! {
     #[test]
     fn canonical_json_order_insensitive(md in document()) {
         let rt = from_markdown(&md).unwrap();
-        let mut shuffled = rt.clone();
+        let mut shuffled = rt.clone().into_content();
         shuffled.marks.reverse();
         prop_assert_eq!(rt.to_canonical_json(), shuffled.to_canonical_json());
     }
@@ -309,12 +309,12 @@ proptest! {
     #[test]
     fn diff_import_preserves_surviving_anchor(a in "[a-z]{3,8}", b in "[a-z]{3,8}") {
         let base_md = format!("keep {a} here");
-        let mut base = from_markdown(&base_md).unwrap();
+        let mut base = from_markdown(&base_md).unwrap().into_content();
         let start = 5;
         let end = 5 + a.chars().count();
         prop_assert_eq!(&base.text[start..end], a.as_str());
         base.marks.push(Mark::new(start, end, MarkKind::Anchor { id: "c1".into() }));
-        base.normalize();
+        let base = base.into_normalized();
 
         let new_md = format!("{b} keep {a} here");
         let (new_rt, _delta) = diff_import(&base, &new_md).unwrap();
@@ -395,12 +395,12 @@ proptest! {
         is_delete in any::<bool>(),
     ) {
         const ID: &str = "anchor-\u{1f4a1}-42";
-        let mut rt = from_markdown(&md).unwrap();
+        let mut rt = from_markdown(&md).unwrap().into_content();
         let len = rt.len_usv();
         let a = a_seed % (len + 1);
         let b = b_seed % (len + 1);
         rt.marks.push(Mark::new(a.min(b), a.max(b), MarkKind::Anchor { id: ID.into() }));
-        rt.normalize();
+        let mut rt = rt.into_normalized();
         prop_assert_eq!(rt.validate(), Ok(()), "seeded content invalid for {:?}", md);
 
         let len = rt.len_usv();
@@ -577,8 +577,7 @@ proptest! {
             .max(row_cells.iter().map(Vec::len).max().unwrap_or(0));
         prop_assume!(cols >= 1);
 
-        let mut rt = table_content(aligns.clone(), header_cells, row_cells);
-        rt.normalize();
+        let rt = table_content(aligns.clone(), header_cells, row_cells).into_normalized();
         prop_assert_eq!(rt.validate(), Ok(()), "normalized table invalid");
 
         let props = &rt.islands[0].props;

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -12,11 +12,11 @@ use crate::Diagnostic;
 use super::fences::find_metadata_blocks;
 use super::meta::{extract_meta_items, meta_key};
 use super::payload::{Payload, PayloadItem};
-use quillmark_content::Content;
+use quillmark_content::Normalized;
 
 /// The parse-time half of the markdown→content boundary
 /// ([`super::import_body`]): an over-nesting failure becomes a [`ParseError`].
-fn import_body_or_parse_error(md: &str) -> Result<Content, ParseError> {
+fn import_body_or_parse_error(md: &str) -> Result<Normalized, ParseError> {
     super::import_body(md).map_err(|e| ParseError::BodyImport(e.to_string()))
 }
 use super::prescan::{prescan_fence_content, CommentPathSegment, NestedComment, PreItem};

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -39,7 +39,7 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-use quillmark_content::Content;
+use quillmark_content::Normalized;
 
 use super::meta::validate_composable_kind;
 use super::payload::{MetaKey, Payload, PayloadItem};
@@ -167,7 +167,7 @@ pub type PayloadV0_93_0 = PayloadV0_92_0;
 /// The serializer normalizes a copy regardless of its input, so a hand-built
 /// value cannot leak non-canonical bytes.
 #[derive(Debug, Clone, PartialEq)]
-pub struct CanonicalContent(pub Content);
+pub struct CanonicalContent(pub Normalized);
 
 impl Serialize for CanonicalContent {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -1024,9 +1024,9 @@ This body and the metadata above are an indorsement card.
         use quillmark_content::model::{Mark, MarkKind};
 
         let mut doc = sample();
-        let mut content = quillmark_content::import::from_markdown("underlined intro").unwrap();
+        let mut content = quillmark_content::import::from_markdown("underlined intro").unwrap().into_content();
         content.marks.push(Mark::new(0, 10, MarkKind::Underline));
-        content.normalize();
+        let content = content.into_normalized();
         let json = quillmark_content::serial::to_canonical_value(&content);
         let schema = crate::quill::FieldSchema::new(
             "intro".to_string(),

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -691,7 +691,7 @@ impl Card {
         self.remove_meta_namespace(MetaKey::Seed, card_kind)
     }
 
-    /// Overwrite the body with a pre-built [`Content`]: value semantics, no
+    /// Overwrite the body with a pre-built [`Content`](quillmark_content::Content): value semantics, no
     /// markdown import, no diff, no schema check, infallible. A raw `Content`
     /// normalizes on the way in, so what lands is canonical. Anchor fate across
     /// the content lane: **overwrite destroys, [`revise_body`](Self::revise_body)
@@ -700,7 +700,7 @@ impl Card {
         self.body = content.into();
     }
 
-    /// Overwrite a content field's value with a pre-built [`Content`]: the
+    /// Overwrite a content field's value with a pre-built [`Content`](quillmark_content::Content): the
     /// field-level twin of [`overwrite_body`](Self::overwrite_body). Stores the
     /// canonical content JSON (identity and content-only marks intact), no diff,
     /// no schema check. The previous value's anchors are gone. Returns

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -13,7 +13,7 @@ use unicode_normalization::UnicodeNormalization;
 
 use quillmark_content::delta::diff_import;
 use quillmark_content::import::ImportError;
-use quillmark_content::{ApplyError, ChangeBundle, Content, Delta};
+use quillmark_content::{ApplyError, ChangeBundle, Delta, Normalized};
 
 use crate::document::meta::{validate_composable_kind, CardKindError};
 use crate::error::diag_args;
@@ -501,7 +501,7 @@ impl Card {
         payload.set_kind(kind);
         Ok(Card::from_parts(
             payload,
-            quillmark_content::Content::empty(),
+            quillmark_content::Normalized::empty(),
         ))
     }
 
@@ -692,33 +692,38 @@ impl Card {
     }
 
     /// Overwrite the body with a pre-built [`Content`]: value semantics, no
-    /// markdown import, no diff, no schema check, infallible. Anchor fate across
+    /// markdown import, no diff, no schema check, infallible. A raw `Content`
+    /// normalizes on the way in, so what lands is canonical. Anchor fate across
     /// the content lane: **overwrite destroys, [`revise_body`](Self::revise_body)
     /// rebases, [`apply_body_change`](Self::apply_body_change) preserves.**
-    pub fn overwrite_body(&mut self, content: Content) {
-        self.body = content;
+    pub fn overwrite_body(&mut self, content: impl Into<Normalized>) {
+        self.body = content.into();
     }
 
     /// Overwrite a content field's value with a pre-built [`Content`]: the
     /// field-level twin of [`overwrite_body`](Self::overwrite_body). Stores the
-    /// canonical content JSON verbatim (identity and content-only marks intact),
-    /// no diff, no schema check. The previous value's anchors are gone. Returns
+    /// canonical content JSON (identity and content-only marks intact), no diff,
+    /// no schema check. The previous value's anchors are gone. Returns
     /// [`EditError::InvalidFieldName`] for a malformed name.
     ///
     /// Richtext codec: a `plaintext` field rests as its literal string, so an
     /// object landed here departs that field's resting form until the next bound
     /// load ([`Quill::conform`](crate::Quill::conform)) converges it.
-    pub fn overwrite_field(&mut self, name: &str, content: Content) -> Result<(), EditError> {
+    pub fn overwrite_field(
+        &mut self,
+        name: &str,
+        content: impl Into<Normalized>,
+    ) -> Result<(), EditError> {
         if !is_valid_field_name(name) {
             return Err(EditError::InvalidFieldName(name.to_string()));
         }
-        self.store_field_content(name, &content);
+        self.store_field_content(name, &content.into());
         Ok(())
     }
 
     /// Assumes `name` is already validated: every caller checks it or resolves an
     /// existing field first.
-    fn store_field_content(&mut self, name: &str, content: &Content) {
+    fn store_field_content(&mut self, name: &str, content: &Normalized) {
         let canonical = quillmark_content::serial::to_canonical_value(content);
         self.payload_mut()
             .insert_unchecked(name.to_string(), QuillValue::from_json(canonical));
@@ -789,14 +794,14 @@ impl Card {
         &self,
         name: &str,
         body: impl Into<String>,
-    ) -> Result<(Content, Delta), EditError> {
+    ) -> Result<(Normalized, Delta), EditError> {
         if !is_valid_field_name(name) {
             return Err(EditError::InvalidFieldName(name.to_string()));
         }
         let base = match self.field_content(name, Codec::Richtext) {
             Some(Ok(rt)) => rt,
             Some(Err(e)) => return Err(field_decode(name, &[], Codec::Richtext, e)),
-            None => Content::empty(),
+            None => Normalized::empty(),
         };
         diff_import(&base, &body.into()).map_err(EditError::Import)
     }
@@ -938,7 +943,7 @@ impl Card {
                 if !is_valid_field_name(name) {
                     return Err(EditError::InvalidFieldName(name.to_string()));
                 }
-                Content::empty()
+                Normalized::empty()
             }
         };
         content

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -767,7 +767,7 @@ mod tests {
         payload.set_kind("main");
         let mut card = crate::document::Card::from_parts(
             payload,
-            quillmark_content::Content::empty(),
+            quillmark_content::Normalized::empty(),
         );
         let content = quillmark_content::import::from_markdown("Q3 results").expect("content");
         card.store_fill(

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -7,7 +7,7 @@
 use serde::{Deserialize, Serialize};
 
 use quillmark_content::import::{from_markdown as import_markdown, ImportError};
-use quillmark_content::Content;
+use quillmark_content::Normalized;
 
 use crate::error::ParseError;
 use crate::version::QuillReference;
@@ -15,9 +15,9 @@ use crate::Diagnostic;
 
 /// The single markdown→content boundary for card bodies: every path that starts
 /// from an authored markdown string routes through here.
-pub(crate) fn import_body(md: &str) -> Result<Content, ImportError> {
+pub(crate) fn import_body(md: &str) -> Result<Normalized, ImportError> {
     if md.is_empty() {
-        Ok(Content::empty())
+        Ok(Normalized::empty())
     } else {
         import_markdown(md)
     }
@@ -80,7 +80,7 @@ impl Codec {
     pub(crate) fn decode_value(
         self,
         value: &serde_json::Value,
-    ) -> Option<Result<Content, ContentDecodeError>> {
+    ) -> Option<Result<Normalized, ContentDecodeError>> {
         match value {
             serde_json::Value::Object(_) => Some(
                 quillmark_content::serial::from_canonical_value(value)
@@ -102,10 +102,10 @@ impl Codec {
     pub(crate) fn decode_field(
         self,
         value: &serde_json::Value,
-    ) -> Result<Content, ContentDecodeError> {
+    ) -> Result<Normalized, ContentDecodeError> {
         match self.decode_value(value) {
             Some(result) => result,
-            None if value.is_null() => Ok(Content::empty()),
+            None if value.is_null() => Ok(Normalized::empty()),
             None => Err(ContentDecodeError::NotContent(format!(
                 "expected a {} content object or {}",
                 self.name(),
@@ -116,7 +116,7 @@ impl Codec {
 
     /// Project a content back to this codec's text: the inverse of its string
     /// encoding.
-    pub(crate) fn project(self, content: &Content) -> String {
+    pub(crate) fn project(self, content: &Normalized) -> String {
         match self {
             Codec::Richtext => quillmark_content::export::to_markdown(content),
             Codec::Plaintext => quillmark_content::export::to_plaintext(content),
@@ -222,12 +222,12 @@ pub struct Parsed {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Card {
     payload: Payload,
-    body: Content,
+    body: Normalized,
 }
 
 impl Card {
     /// Create a `Card` from its parts without validation.
-    pub(crate) fn from_parts(payload: Payload, body: Content) -> Self {
+    pub(crate) fn from_parts(payload: Payload, body: Normalized) -> Self {
         Self { payload, body }
     }
 
@@ -259,7 +259,7 @@ impl Card {
 
     /// The card body as a [`Content`]: the canonical content model. For the
     /// markdown projection use [`Card::body_markdown`].
-    pub fn body(&self) -> &Content {
+    pub fn body(&self) -> &Normalized {
         &self.body
     }
 
@@ -270,7 +270,7 @@ impl Card {
         quillmark_content::export::to_markdown(&self.body)
     }
 
-    pub(crate) fn body_mut(&mut self) -> &mut Content {
+    pub(crate) fn body_mut(&mut self) -> &mut Normalized {
         &mut self.body
     }
 
@@ -291,7 +291,7 @@ impl Card {
         &self,
         name: &str,
         codec: Codec,
-    ) -> Option<Result<Content, ContentDecodeError>> {
+    ) -> Option<Result<Normalized, ContentDecodeError>> {
         Some(codec.decode_field(self.payload.get(name)?.as_json()))
     }
 
@@ -387,7 +387,7 @@ impl Document {
         // it in); match that shape so a blank document round-trips equal.
         payload.set_kind("main");
         Self {
-            main: Card::from_parts(payload, Content::empty()),
+            main: Card::from_parts(payload, Normalized::empty()),
             cards: Vec::new(),
         }
     }

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -216,7 +216,7 @@ pub struct Parsed {
 }
 
 /// A single card-yaml block (root or composable). `body` is the content
-/// ([`Content`]) form of the prose after the closing fence: the empty content
+/// ([`Content`](quillmark_content::Content)) form of the prose after the closing fence: the empty content
 /// when none follows; check `card.body().is_blank()`. Markdown is a projection:
 /// [`Card::body_markdown`] re-emits it.
 #[derive(Debug, Clone, PartialEq)]
@@ -257,7 +257,7 @@ impl Card {
         &mut self.payload
     }
 
-    /// The card body as a [`Content`]: the canonical content model. For the
+    /// The card body as a [`Content`](quillmark_content::Content): the canonical content model. For the
     /// markdown projection use [`Card::body_markdown`].
     pub fn body(&self) -> &Normalized {
         &self.body

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -1548,7 +1548,7 @@ fn test_to_plate_json_kindless_card_omits_kind() {
         .document;
     doc.cards_vec_mut().push(Card::from_parts(
         Payload::new(),
-        quillmark_content::Content::empty(),
+        quillmark_content::Normalized::empty(),
     ));
 
     let json = doc.to_plate_json();

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -314,9 +314,9 @@ fn test_replace_body_reports_import_error() {
 fn test_overwrite_body_sets_directly() {
     use quillmark_content::model::{Mark, MarkKind};
 
-    let mut content = quillmark_content::import::from_markdown("underlined body").unwrap();
+    let mut content = quillmark_content::import::from_markdown("underlined body").unwrap().into_content();
     content.marks.push(Mark::new(0, 10, MarkKind::Underline));
-    content.normalize();
+    let content = content.into_normalized();
 
     let mut card = Card::new("note").unwrap();
     card.overwrite_body(content.clone());
@@ -332,9 +332,9 @@ fn test_overwrite_body_sets_directly() {
 fn test_overwrite_field_sets_directly() {
     use quillmark_content::model::{Mark, MarkKind};
 
-    let mut content = quillmark_content::import::from_markdown("underlined intro").unwrap();
+    let mut content = quillmark_content::import::from_markdown("underlined intro").unwrap().into_content();
     content.marks.push(Mark::new(0, 10, MarkKind::Underline));
-    content.normalize();
+    let content = content.into_normalized();
 
     let mut card = Card::new("note").unwrap();
     card.overwrite_field("intro", content.clone()).unwrap();
@@ -343,7 +343,7 @@ fn test_overwrite_field_sets_directly() {
     assert!(read.marks.iter().any(|m| matches!(m.kind, MarkKind::Underline)));
 
     assert_eq!(
-        card.overwrite_field("$bad", quillmark_content::Content::empty())
+        card.overwrite_field("$bad", quillmark_content::Normalized::empty())
             .unwrap_err()
             .code(),
         "edit::invalid_field_name"
@@ -358,11 +358,15 @@ fn test_revise_field_diff_imports_and_returns_delta() {
     let delta = card.revise_field("intro", "hello target world").unwrap();
     assert!(!delta.ops.is_empty());
 
-    let mut base = card.field_content("intro", Codec::Richtext).unwrap().unwrap();
+    let mut base = card
+        .field_content("intro", Codec::Richtext)
+        .unwrap()
+        .unwrap()
+        .into_content();
     // 6..12 is "target".
     base.marks
         .push(Mark::new(6, 12, MarkKind::Anchor { id: "c1".into() }));
-    base.normalize();
+    let base = base.into_normalized();
     card.overwrite_field("intro", base).unwrap();
     card.revise_field("intro", "why keep the target here").unwrap();
     let read = card.field_content("intro", Codec::Richtext).unwrap().unwrap();
@@ -396,11 +400,15 @@ fn test_revise_field_checked_preserves_anchors_and_enforces_inline() {
         .unwrap();
     assert!(!delta.ops.is_empty());
 
-    let mut base = card.field_content("subject", Codec::Richtext).unwrap().unwrap();
+    let mut base = card
+        .field_content("subject", Codec::Richtext)
+        .unwrap()
+        .unwrap()
+        .into_content();
     // 6..12 is "target".
     base.marks
         .push(Mark::new(6, 12, MarkKind::Anchor { id: "c1".into() }));
-    base.normalize();
+    let base = base.into_normalized();
     card.overwrite_field("subject", base).unwrap();
     card.revise_field_checked("subject", "why keep the target here", &inline)
         .unwrap();
@@ -431,9 +439,9 @@ fn test_revise_field_checked_preserves_anchors_and_enforces_inline() {
 fn test_commit_field_richtext_content_object_reads_back() {
     use quillmark_content::model::{Mark, MarkKind};
 
-    let mut content = quillmark_content::import::from_markdown("underlined intro").unwrap();
+    let mut content = quillmark_content::import::from_markdown("underlined intro").unwrap().into_content();
     content.marks.push(Mark::new(0, 10, MarkKind::Underline));
-    content.normalize();
+    let content = content.into_normalized();
     let json = quillmark_content::serial::to_canonical_value(&content);
 
     let mut card = Card::new("note").unwrap();
@@ -670,10 +678,10 @@ fn test_revise_body_returns_delta_and_updates_body() {
 fn test_revise_body_rebases_anchor() {
     use quillmark_content::model::{Mark, MarkKind};
 
-    let mut base = quillmark_content::import::from_markdown("keep the target word").unwrap();
+    let mut base = quillmark_content::import::from_markdown("keep the target word").unwrap().into_content();
     // Anchor over "target" (chars 9..15).
     base.marks.push(Mark::new(9, 15, MarkKind::Anchor { id: "c1".into() }));
-    base.normalize();
+    let base = base.into_normalized();
     let mut card = Card::new("note").unwrap();
     card.overwrite_body(base);
 

--- a/crates/core/src/document/tests/emit_tests.rs
+++ b/crates/core/src/document/tests/emit_tests.rs
@@ -214,7 +214,7 @@ fn empty_map_emits_inline_braces() {
     let mut p = Payload::from_index_map(payload);
     p.set_quill("test".parse().unwrap());
     p.set_kind("main");
-    let main = Card::from_parts(p, quillmark_content::Content::empty());
+    let main = Card::from_parts(p, quillmark_content::Normalized::empty());
     let doc = crate::document::Document::from_main_and_cards(main, vec![]);
 
     let md = doc.to_markdown();
@@ -255,7 +255,7 @@ fn nested_map_keys_with_structural_chars_emit_valid_yaml() {
     let mut p = Payload::from_index_map(payload);
     p.set_quill("test".parse().unwrap());
     p.set_kind("main");
-    let main = Card::from_parts(p, quillmark_content::Content::empty());
+    let main = Card::from_parts(p, quillmark_content::Normalized::empty());
     let doc = Document::from_main_and_cards(main, vec![]);
 
     let md = doc.to_markdown();

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -22,7 +22,7 @@ use super::payload::{MetaKey, Payload, PayloadItem};
 use super::Card;
 use crate::value::{PathSegment, QuillValue};
 use crate::version::QuillReference;
-use quillmark_content::Content;
+use quillmark_content::Normalized;
 
 /// One entry in a [`CardWire`]'s `payload_items`: a user field or a comment.
 /// The `$` system entries are hoisted onto [`CardWire`] itself, never here.
@@ -290,7 +290,7 @@ impl TryFrom<CardWire> for Card {
 /// re-serialized card) is deserialized and validated; a **markdown string** (an
 /// LLM / markdown writer) is imported. `null`/absent is the empty content; any
 /// other shape is an invalid `$body`.
-fn body_from_wire(body: &JsonValue) -> Result<Content, WireError> {
+fn body_from_wire(body: &JsonValue) -> Result<Normalized, WireError> {
     let invalid = |reason: String| WireError::InvalidField {
         key: "$body".to_string(),
         reason,
@@ -298,7 +298,7 @@ fn body_from_wire(body: &JsonValue) -> Result<Content, WireError> {
     match super::Codec::Richtext.decode_value(body) {
         Some(result) => result.map_err(|e| invalid(e.into_message())),
         None => match body {
-            JsonValue::Null => Ok(Content::empty()),
+            JsonValue::Null => Ok(Normalized::empty()),
             other => Err(invalid(format!(
                 "expected a richtext content object or a markdown string, got {}",
                 match other {
@@ -348,7 +348,7 @@ mod tests {
             fill: false,
             nested_comments: Vec::new(),
         }]);
-        let card = Card::from_parts(payload, quillmark_content::Content::empty());
+        let card = Card::from_parts(payload, quillmark_content::Normalized::empty());
 
         let wire = CardWire::from(&card);
         let as_json = serde_json::to_value(&wire).unwrap();
@@ -373,9 +373,9 @@ mod tests {
         use quillmark_content::model::{Mark, MarkKind};
 
         let mut card = Card::new("note").unwrap();
-        let mut content = quillmark_content::import::from_markdown("underlined intro").unwrap();
+        let mut content = quillmark_content::import::from_markdown("underlined intro").unwrap().into_content();
         content.marks.push(Mark::new(0, 10, MarkKind::Underline));
-        content.normalize();
+        let content = content.into_normalized();
         let json = quillmark_content::serial::to_canonical_value(&content);
         let schema = crate::quill::FieldSchema::new(
             "intro".to_string(),
@@ -425,7 +425,7 @@ mod tests {
         let mut payload = Payload::from_index_map(Default::default());
         payload.set_quill("memo@1.2.3".parse().unwrap());
         payload.set_kind("main");
-        let card = Card::from_parts(payload, quillmark_content::Content::empty());
+        let card = Card::from_parts(payload, quillmark_content::Normalized::empty());
 
         let wire = CardWire::from(&card);
         assert_eq!(wire.quill.as_deref(), Some("memo@1.2.3"));

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -99,7 +99,7 @@ fn build_main_card(card: &CardSchema, quill_ref: &str, description: Option<&str>
         // re-emits it via `to_markdown`. The empty-content fallback is defensive:
         // a placeholder or a load-validated example never over-nests.
         crate::document::import_body(&body_text(card, "main"))
-            .unwrap_or_else(|_| quillmark_content::Content::empty()),
+            .unwrap_or_else(|_| quillmark_content::Normalized::empty()),
     )
 }
 
@@ -119,7 +119,7 @@ fn build_card(card: &CardSchema) -> Card {
     Card::from_parts(
         Payload::from_items(items),
         crate::document::import_body(&body_text(card, &card.name))
-            .unwrap_or_else(|_| quillmark_content::Content::empty()),
+            .unwrap_or_else(|_| quillmark_content::Normalized::empty()),
     )
 }
 

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -1044,7 +1044,7 @@ card_kinds:
         let mut main = Payload::new();
         main.set_quill("fills_test@1.0.0".parse().unwrap());
         main.set_kind("main");
-        let main = Card::from_parts(main, quillmark_content::Content::empty());
+        let main = Card::from_parts(main, quillmark_content::Normalized::empty());
 
         let mut unknown = Card::new("mystery").unwrap();
         unknown
@@ -1052,7 +1052,7 @@ card_kinds:
             .unwrap();
 
         let mut kindless =
-            Card::from_parts(Payload::new(), quillmark_content::Content::empty());
+            Card::from_parts(Payload::new(), quillmark_content::Normalized::empty());
         kindless
             .store_fill("memo", QuillValue::from_json(json!(null)))
             .unwrap();

--- a/crates/core/src/quill/fill.rs
+++ b/crates/core/src/quill/fill.rs
@@ -74,7 +74,7 @@ pub fn blank(field: &FieldSchema) -> QuillValue {
         // richtext or plaintext field with a content the backend can lower. The
         // empty content is single-`Para`, so it satisfies `inline` and is `plain`.
         FieldType::RichText { .. } | FieldType::PlainText { .. } => {
-            quillmark_content::serial::to_canonical_value(&quillmark_content::Content::empty())
+            quillmark_content::serial::to_canonical_value(&quillmark_content::Normalized::empty())
         }
         // String / Date / DateTime: `""` is the schema-valid blank for all three
         // (an empty string lowers to `none`, the absent-date sentinel).

--- a/crates/core/src/quill/resolved.rs
+++ b/crates/core/src/quill/resolved.rs
@@ -405,7 +405,7 @@ card_kinds:
         let mut payload = Payload::from_index_map(map);
         payload.set_quill("fs_test@1.0".parse().unwrap());
         payload.set_kind("main");
-        let main = Card::from_parts(payload, quillmark_content::Content::empty());
+        let main = Card::from_parts(payload, quillmark_content::Normalized::empty());
         let doc = Document::from_main_and_cards(main, Vec::new());
         let states = quill.resolve(&doc);
 

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -4,7 +4,7 @@
 //! `!must_fill` marker, so seeding and the blueprint stamp the same cells and a
 //! fresh seed reads as incomplete exactly where a blank document does.
 
-use quillmark_content::Content;
+use quillmark_content::Normalized;
 
 use super::Quill;
 use crate::quill::{CardSchema, FieldType, VARIANT_DISCRIMINANT_KEY};
@@ -29,7 +29,7 @@ use crate::{Card, Document, Payload, QuillReference, QuillValue, SeedOverlay};
 /// is what makes the two agree; a schema-aware writer that left non-canonical
 /// rest would recreate the construction-dependent divergence internally, moving
 /// a hash on a seed → store → load → conform cycle nobody edited.
-fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, Content) {
+fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, Normalized) {
     // Drive by `schema.fields` (declaration order), so the result is in
     // declaration order natively: no merge-then-sort. An overlay key naming no
     // schema field is skipped: it is never iterated here.
@@ -65,18 +65,18 @@ fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, C
     // when bodies are enabled for the kind.
     let body = if schema.body_enabled() {
         if let Some(overlay_body) = overlay.and_then(|o| o.body.clone()) {
-            crate::document::import_body(&overlay_body).unwrap_or_else(|_| Content::empty())
+            crate::document::import_body(&overlay_body).unwrap_or_else(|_| Normalized::empty())
         } else if let Some(content) = schema.body.as_ref().and_then(|b| b.example_content.as_ref()) {
             quillmark_content::serial::from_canonical_value(content.as_json())
-                .unwrap_or_else(|_| Content::empty())
+                .unwrap_or_else(|_| Normalized::empty())
         } else if let Some(example) = schema.body.as_ref().and_then(|b| b.example.as_ref()) {
             // Fallback for a schema built outside the loader (no cached content).
-            crate::document::import_body(example).unwrap_or_else(|_| Content::empty())
+            crate::document::import_body(example).unwrap_or_else(|_| Normalized::empty())
         } else {
-            Content::empty()
+            Normalized::empty()
         }
     } else {
-        Content::empty()
+        Normalized::empty()
     };
 
     (Payload::from_items(items), body)

--- a/crates/core/src/quill/support.rs
+++ b/crates/core/src/quill/support.rs
@@ -113,10 +113,12 @@ fn plural(construct: BlockConstruct, count: usize) -> String {
 ///
 /// A container counts once per contiguous **run**, not once per line or per
 /// item: a three-item list is one list, and a multi-paragraph quote is one
-/// quote. A run opens where the previous line carried no like container at that
-/// depth — like meaning same run key *and* same `Container::instance`, so a
-/// sibling item (differing only by `ordinal`) continues its list rather than
-/// opening another, while an adjacent list of identical shape opens its own.
+/// quote. `quillmark_content::traverse` decides where a run opens, so a sibling
+/// item (differing only by `ordinal`) continues its list rather than opening
+/// another, while an adjacent list of identical shape opens its own.
+///
+/// Runs nest by *item*, an item being a parent: a quote in each of two list
+/// items is two quotes, however alike the two paths look.
 ///
 /// A leaf block counts per block: a rule and a heading are one line each, and a
 /// code fence is counted at the line that opens it.
@@ -127,21 +129,38 @@ fn plural(construct: BlockConstruct, count: usize) -> String {
 /// not typeset either.
 fn census(body: &Content) -> BTreeMap<BlockConstruct, usize> {
     use quillmark_content::model::Container;
+    use quillmark_content::traverse::{items, runs};
 
-    /// A container's identity for run purposes: everything but which item.
-    fn shape(container: &Container) -> Option<(BlockConstruct, Container, u64)> {
-        let construct = match container {
-            Container::ListItem { .. } => BlockConstruct::List,
-            Container::Quote { .. } => BlockConstruct::Quote,
+    fn construct(container: &Container) -> Option<BlockConstruct> {
+        match container {
+            Container::ListItem { .. } => Some(BlockConstruct::List),
+            Container::Quote { .. } => Some(BlockConstruct::Quote),
             // The open set: a container this build does not know names no
             // construct to decline.
-            _ => return None,
-        };
-        Some((construct, container.run_key(), container.instance()))
+            _ => None,
+        }
+    }
+
+    /// Count the runs at `depth` within `range`, then recurse per *item*: an
+    /// item is a parent, so two like runs under two items are two runs.
+    fn count(
+        lines: &[quillmark_content::model::Line],
+        range: std::ops::Range<usize>,
+        depth: usize,
+        counts: &mut BTreeMap<BlockConstruct, usize>,
+    ) {
+        for run in runs(lines, range, depth) {
+            if let Some(construct) = construct(run.container) {
+                *counts.entry(construct).or_insert(0) += 1;
+            }
+            for item in items(lines, run.range, depth) {
+                count(lines, item.range, depth + 1, counts);
+            }
+        }
     }
 
     let mut counts: BTreeMap<BlockConstruct, usize> = BTreeMap::new();
-    let mut prev: Vec<Option<(BlockConstruct, Container, u64)>> = Vec::new();
+    count(&body.lines, 0..body.lines.len(), 0, &mut counts);
 
     for island in &body.islands {
         match KnownIslandType::parse(&island.island_type) {
@@ -154,18 +173,8 @@ fn census(body: &Content) -> BTreeMap<BlockConstruct, usize> {
     }
 
     for line in &body.lines {
-        let here: Vec<_> = line.containers.iter().map(shape).collect();
-        for (depth, shape) in here.iter().enumerate() {
-            let Some((construct, _, _)) = shape else {
-                continue;
-            };
-            if prev.get(depth) != Some(shape) {
-                *counts.entry(*construct).or_insert(0) += 1;
-            }
-        }
-        prev = here;
-
-        // Islands are already counted; every other block kind counts here.
+        // Islands and containers are already counted; every other block kind
+        // counts here.
         let construct = match &line.kind {
             LineKind::Heading { .. } => Some(BlockConstruct::Heading),
             LineKind::Rule => Some(BlockConstruct::Rule),
@@ -177,4 +186,38 @@ fn census(body: &Content) -> BTreeMap<BlockConstruct, usize> {
         }
     }
     counts
+}
+
+#[cfg(test)]
+mod census_tests {
+    use super::*;
+
+    fn count(md: &str, construct: BlockConstruct) -> usize {
+        let body = quillmark_content::from_markdown(md).unwrap();
+        census(&body).get(&construct).copied().unwrap_or(0)
+    }
+
+    #[test]
+    fn a_run_counts_once_however_many_lines_or_items_it_spans() {
+        assert_eq!(count("- a\n- b\n- c", BlockConstruct::List), 1);
+        assert_eq!(count("> a\n>\n> b", BlockConstruct::Quote), 1);
+    }
+
+    #[test]
+    fn two_adjacent_runs_of_one_shape_count_twice() {
+        assert_eq!(count("- a\n\n+ b", BlockConstruct::List), 2);
+        assert_eq!(count("> a\n\n<!-- -->\n\n> b", BlockConstruct::Quote), 2);
+    }
+
+    #[test]
+    fn an_item_bounds_what_nests_inside_it() {
+        assert_eq!(count("- > a\n\n- > b", BlockConstruct::Quote), 2);
+        assert_eq!(count("- > a\n\n- > b", BlockConstruct::List), 1);
+        assert_eq!(count("- - a\n\n- - b", BlockConstruct::List), 3);
+    }
+
+    #[test]
+    fn a_run_bounds_what_nests_inside_it() {
+        assert_eq!(count("> - a\n\n<!-- -->\n\n> - b", BlockConstruct::List), 2);
+    }
 }

--- a/crates/core/src/quill/support.rs
+++ b/crates/core/src/quill/support.rs
@@ -141,26 +141,28 @@ fn census(body: &Content) -> BTreeMap<BlockConstruct, usize> {
         }
     }
 
-    /// Count the runs at `depth` within `range`, then recurse per *item*: an
-    /// item is a parent, so two like runs under two items are two runs.
+    /// A worklist, not recursion: nothing validates `body`'s nesting depth
+    /// before this walk.
     fn count(
         lines: &[quillmark_content::model::Line],
         range: std::ops::Range<usize>,
-        depth: usize,
         counts: &mut BTreeMap<BlockConstruct, usize>,
     ) {
-        for run in runs(lines, range, depth) {
-            if let Some(construct) = construct(run.container) {
-                *counts.entry(construct).or_insert(0) += 1;
-            }
-            for item in items(lines, run.range, depth) {
-                count(lines, item.range, depth + 1, counts);
+        let mut work = vec![(range, 0)];
+        while let Some((range, depth)) = work.pop() {
+            for run in runs(lines, range, depth) {
+                if let Some(construct) = construct(run.container) {
+                    *counts.entry(construct).or_insert(0) += 1;
+                }
+                for item in items(lines, run.range, depth) {
+                    work.push((item.range, depth + 1));
+                }
             }
         }
     }
 
     let mut counts: BTreeMap<BlockConstruct, usize> = BTreeMap::new();
-    count(&body.lines, 0..body.lines.len(), 0, &mut counts);
+    count(&body.lines, 0..body.lines.len(), &mut counts);
 
     for island in &body.islands {
         match KnownIslandType::parse(&island.island_type) {
@@ -214,6 +216,17 @@ mod census_tests {
         assert_eq!(count("- > a\n\n- > b", BlockConstruct::Quote), 2);
         assert_eq!(count("- > a\n\n- > b", BlockConstruct::List), 1);
         assert_eq!(count("- - a\n\n- - b", BlockConstruct::List), 3);
+    }
+
+    /// `overwrite_body` never validates, so the walk sees whatever depth a
+    /// client built.
+    #[test]
+    fn unvalidated_depth_does_not_overflow_the_stack() {
+        use quillmark_content::model::{Container, Content, Line, LineKind};
+        let mut line = Line::new(LineKind::Para);
+        line.containers = vec![Container::Quote { instance: 0 }; 200_000];
+        let body = Content::new("x".to_string(), vec![line]);
+        assert_eq!(census(&body).get(&BlockConstruct::Quote), Some(&200_000));
     }
 
     #[test]

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2739,8 +2739,8 @@ fn inline_plaintext_rejects_multiline_document_value() {
 #[test]
 fn plaintext_wire_content_with_marks_is_rejected_not_stripped() {
     let config = quill_with_field("    subject:\n      type: plaintext\n").expect("loads");
-    let mut rt = quillmark_content::from_markdown("a **bold** word").unwrap();
-    rt.normalize();
+    let rt = quillmark_content::from_markdown("a **bold** word").unwrap().into_content();
+    let rt = rt.into_normalized();
     let mut fields: indexmap::IndexMap<String, QuillValue> = indexmap::IndexMap::new();
     fields.insert(
         "subject".to_string(),

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -844,7 +844,7 @@ main:
         let mut p = Payload::from_index_map(payload);
         p.set_quill("test_quill".parse().unwrap());
         p.set_kind("main");
-        let main = Card::from_parts(p, quillmark_content::Content::empty());
+        let main = Card::from_parts(p, quillmark_content::Normalized::empty());
         Document::from_main_and_cards(main, cards)
     }
 

--- a/crates/core/src/reader.rs
+++ b/crates/core/src/reader.rs
@@ -84,23 +84,23 @@ impl<'a> TypedReader<'a> {
         read_field(self.doc.main(), Some(&self.config.main.fields), name)
     }
 
-    /// Read a main-card content field as its [`Content`], decoded through the
-    /// codec its declared type names: the [`Content`] twin of [`get`](Self::get).
+    /// Read a main-card content field as its [`Content`](quillmark_content::Content), decoded through the
+    /// codec its declared type names: the [`Content`](quillmark_content::Content) twin of [`get`](Self::get).
     /// Total over the storage form, so a canonical content object and an
-    /// authored string both read back as a [`Content`].
+    /// authored string both read back as a [`Content`](quillmark_content::Content).
     ///
     /// `Ok(None)` when the field is absent;
     /// [`EditError::UnknownField`] for a name the schema does not declare;
     /// [`EditError::FieldNotContent`] for a declared type that is not a content
-    /// leaf (an `integer` has no [`Content`] even when it holds a string, and an
-    /// `array<richtext>` carries content without having one [`Content`]);
+    /// leaf (an `integer` has no [`Content`](quillmark_content::Content) even when it holds a string, and an
+    /// `array<richtext>` carries content without having one [`Content`](quillmark_content::Content));
     /// [`EditError::FieldDecode`] when the stored value decodes under
     /// neither encoding.
     pub fn get_content(&self, name: &str) -> Result<Option<Normalized>, EditError> {
         self.get_content_at(name, &[])
     }
 
-    /// Read the [`Content`] *nested inside* a composite field at `at`: an
+    /// Read the [`Content`](quillmark_content::Content) *nested inside* a composite field at `at`: an
     /// `array<richtext>` element, an `object`'s content property, a leaf under
     /// both (`cells[1].notes`), or a variant's cell.
     /// [`get_content`](Self::get_content) is the empty path.
@@ -176,7 +176,7 @@ impl CardReader<'_> {
         read_field(self.card, self.schema.map(|s| &s.fields), name)
     }
 
-    /// Read a content field on this card as its [`Content`]: the card twin
+    /// Read a content field on this card as its [`Content`](quillmark_content::Content): the card twin
     /// of [`TypedReader::get_content`], carrying the same outcomes.
     pub fn get_content(&self, name: &str) -> Result<Option<Normalized>, EditError> {
         self.get_content_at(name, &[])
@@ -221,12 +221,12 @@ fn read_field(
     }
 }
 
-/// The shared [`Content`] dispatch behind every `get_content` /
+/// The shared [`Content`](quillmark_content::Content) dispatch behind every `get_content` /
 /// `get_content_at`, the whole-field read being the empty `at`.
 /// [`EditError::FieldNotContent`] is answered from the schema before the payload
-/// is read: whether an address has a [`Content`] is a declared-type fact, so a
+/// is read: whether an address has a [`Content`](quillmark_content::Content) is a declared-type fact, so a
 /// `string` holding markdown-looking text is not content, and an
-/// `array<richtext>` has no single [`Content`] while each of its elements does.
+/// `array<richtext>` has no single [`Content`](quillmark_content::Content) while each of its elements does.
 fn read_content(
     card: &Card,
     fields_schema: Option<&IndexMap<String, FieldSchema>>,

--- a/crates/core/src/reader.rs
+++ b/crates/core/src/reader.rs
@@ -35,7 +35,7 @@
 //! those surfaces construct one per call from the quill handle.
 
 use indexmap::IndexMap;
-use quillmark_content::Content;
+use quillmark_content::Normalized;
 
 use crate::document::edit::field_decode;
 use crate::document::{Card, Codec, Document, EditError};
@@ -96,7 +96,7 @@ impl<'a> TypedReader<'a> {
     /// `array<richtext>` carries content without having one [`Content`]);
     /// [`EditError::FieldDecode`] when the stored value decodes under
     /// neither encoding.
-    pub fn get_content(&self, name: &str) -> Result<Option<Content>, EditError> {
+    pub fn get_content(&self, name: &str) -> Result<Option<Normalized>, EditError> {
         self.get_content_at(name, &[])
     }
 
@@ -128,7 +128,7 @@ impl<'a> TypedReader<'a> {
         &self,
         name: &str,
         at: &[PathSegment],
-    ) -> Result<Option<Content>, EditError> {
+    ) -> Result<Option<Normalized>, EditError> {
         read_content(self.doc.main(), Some(&self.config.main.fields), name, at)
     }
 
@@ -178,7 +178,7 @@ impl CardReader<'_> {
 
     /// Read a content field on this card as its [`Content`]: the card twin
     /// of [`TypedReader::get_content`], carrying the same outcomes.
-    pub fn get_content(&self, name: &str) -> Result<Option<Content>, EditError> {
+    pub fn get_content(&self, name: &str) -> Result<Option<Normalized>, EditError> {
         self.get_content_at(name, &[])
     }
 
@@ -188,7 +188,7 @@ impl CardReader<'_> {
         &self,
         name: &str,
         at: &[PathSegment],
-    ) -> Result<Option<Content>, EditError> {
+    ) -> Result<Option<Normalized>, EditError> {
         read_content(self.card, self.schema.map(|s| &s.fields), name, at)
     }
 
@@ -232,7 +232,7 @@ fn read_content(
     fields_schema: Option<&IndexMap<String, FieldSchema>>,
     name: &str,
     at: &[PathSegment],
-) -> Result<Option<Content>, EditError> {
+) -> Result<Option<Normalized>, EditError> {
     let field = fields_schema
         .and_then(|m| m.get(name))
         .ok_or_else(|| EditError::unknown_field(name))?;

--- a/prose/canon/CONVERT.md
+++ b/prose/canon/CONVERT.md
@@ -16,7 +16,7 @@ this page documents how the backend lowers the content it produces.
 ## Pipeline
 
 ```
-emit_content(&Content) -> Result<Emission, EmitError>
+emit_content(&Normalized) -> Result<Emission, EmitError>
   ├─ block walk    lines → headings, paragraphs, code fences, lists, quotes, islands
   ├─ mark sweep    anchored marks → nested #strong[…] / #emph[…] / #link(…)[…] / …
   └─ source map    per-segment (content ↔ gen) windows + one (content, gen) pair per run


### PR DESCRIPTION
Closes #1364. Both halves, as five commits.

## 1. One container traversal (`b6aa4ee`, `03011fa`)

`quillmark_content::traverse` holds the loop that applies the rule `Container::same_run` states:

- `runs(lines, range, depth)` — adjacent lines whose container at `depth` is one instance (same `same_run` shape *and* same `instance`).
- `items(lines, range, depth)` — adjacent lines whose whole container at `depth` is equal.

Both yield `Span { container, range }` and skip a line carrying no container at `depth`. Container identity is path plus contiguity, so `range` bounds a parent: two like runs under two parents read as one over a range spanning both.

The four sites #1364 lists consume it — `emit.rs` `try_emit_container` and `emit_list`, `export.rs` `emit_block`, `quill::support::census`. `Container::run_key` is deleted with them; its one non-test caller was `census`, and it returned a `Container` with a fabricated `ordinal` and `instance`.

### This fixed a live bug

`census` compared each depth against a flat `prev` vector, so a nested run whose *parent* changed still compared equal — the item-boundary defect `1c9b981d` fixed in `canonicalize_containers`, which `census` could not inherit while it kept its own loop. Before:

```
- > a

- > b        census: {List: 1, Quote: 1}
```

Two block quotes, counted as one. The count reaches users through the "unsupported construct" diagnostic, so a quill declining block quotes reported one where a body held two. `census` now walks per item; four tests pin run, item, and parent boundaries.

## 2. `Normalized` (`7c9b644`)

The projections' precondition was *normalized*, not *valid*, and it appeared nowhere in the type system. `Content::new` is `pub` and does not normalize; `to_markdown` and `emit_content` took a bare `&Content`. Measured on `main`:

```
Content::new, two one-item list runs at instance 0 and instance 2
  validate:  Ok(())
  markdown:  "- a\n\n- b"      both markers even, so both are `- `
  re-import: one list of two items — not the original

stored ordinal 1, 2 (canonical is 0, 1)
  validate:  Ok(())
  markdown:  "2. a\n\n3. b", re-encodes to "1. a\n\n2. b"
```

`pub struct Normalized(Content)` closes it:

- `Deref` carries every read through, so a caller reads a `Normalized` where it read a `Content`.
- `Content::into_normalized` is the only mint. `to_markdown` and `emit_content` take a `&Normalized`, so an uncanonicalized content cannot reach either.
- The `apply_*` mutations normalize before they return, so they forward and keep the token. Any other edit takes `into_content` and mints again.
- The codecs decode through the mint and `Card` stores its body as one, so a projection of a decoded or stored content pays no second pass.

Both measured shapes are pinned in `crates/content/tests/normalized_precondition.rs`.

### Behaviour changes

- `overwrite_body` / `overwrite_field` canonicalize a hand-built `Content` on the way in rather than storing it verbatim. Both docs say so.
- `from_plaintext` now normalizes. It produces container-free `Para` lines, so the pass is a no-op; it is there so the type holds by construction.

## 3. Review fixes (`69ff827`)

An adversarial review of the first three commits confirmed three defects, all fixed here:

- **The token's guarantee did not hold on error paths.** `Content::apply_*` mutates op-by-op and returns before its terminal `normalize`, so an op list failing partway left a non-canonical value inside a `Normalized` — two overlapping `Strong` marks that normalize unions stayed unmerged, and projecting that token emitted non-canonical markdown. The forwarders re-normalize on the error path. Pinned by `a_failed_op_list_leaves_the_token_canonical`.
- **`census` could overflow the stack.** It recursed one frame per nesting level, and nothing validates what it walks: `Card::overwrite_body` never calls `validate`, so a hand-built 200 000-deep body aborted the process. It now walks a worklist. Pinned by `unvalidated_depth_does_not_overflow_the_stack`.
- **`cargo doc -Dwarnings` was red.** `Content` doc links outlived the imports that resolved them — 12 unresolved links. They now carry their crate path.

## 4. Prose pass (`cc7cc50`)

`dense-prose` over everything the branch adds.

## Surface

`to_plaintext` still takes `&Content` — it reads only `rt.text`, so it does not need the guarantee, and `Deref` coercion means callers are unchanged.

The bindings cost 13 lines across both, all type annotations. Nothing host-visible changes: `js_to_content` already routed through `from_canonical_value`, one line above the projection that needed the token.

One canon line moves: `prose/canon/CONVERT.md` names the emitter's argument type, now `&Normalized`. Nothing else in `prose/canon/` goes stale — the model contract does not move, the Rust surface stops taking it on trust.

## Verification

- `cargo test --workspace`: 62 suites, 0 failures.
- `cargo clippy --workspace --all-targets`: 0 errors; no new warnings.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --locked --workspace`: clean.
- `cargo check -p quillmark-wasm --target wasm32-unknown-unknown`: clean.

The npm WASM suite could not run here — the installed `wasm-bindgen-cli` is 0.2.122 against `Cargo.lock`'s 0.2.118. That mismatch predates this branch; the wasm32 type-check covers what this diff could affect. Python was not built: its change is one type annotation in a private helper that the workspace build type-checked.

## Reviewer's eye

The shared iterators skip a leading line with no container at `depth`. That broke `try_emit_container`'s leaf detection — the run *after* a leaf swallowed it — until an explicit leaf check went in. `facade_surface::preview_regions_spell_through_the_facade` caught it; `a_leaf_before_a_container_run_is_its_own_block` now pins it directly. It is the sharp edge of the extraction.

## Known limits

- **`Normalized` is not `validated`.** `into_normalized` repairs; it does not reject. `export::to_markdown`'s recursion is still depth-unguarded, so `overwrite_body` of a pathologically deep hand-built `Content` followed by `body_markdown()` can still overflow — pre-existing on `main`, unchanged here, and the same class as the `census` fix above. Closing it goes at the emitters' documented `validate` contract, which is wider than this PR.
- `to_canonical_value` clone-and-normalizes even for input that is already a `Normalized`, so serialize paths pay a redundant pass. The "no second pass" claim above holds for the projections.
- A fifth duplicated traversal #1364 does not list: the leaf-segment loop is byte-identical in `export.rs` and `emit.rs`. Same class, outside the scope proposal 1 names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013n9bMapnSHbMR6SEtq9WzD