### PR TITLE
fix(typst): open every block at the enclosing list indent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- fix(typst): **a container inside a list item no longer terminates the list.**
+  The item's continuation indent was applied on the leaf path only, so a fence
+  or a nested list nested while a quote — and any container added later, which
+  lowers transparently — opened at column 0, where Typst ends the enclosing
+  list: the item's remaining blocks came back as top-level paragraphs and the
+  next item started a fresh list, renumbering an ordered one from the quote on.
+  The emitter now opens every block, leaf and container alike, through one
+  indented-line rule carried on the walk, so what the content nests, the markup
+  nests.
+
 - fix(content): **a `continues` line that crosses a container boundary no longer
   survives.** A within-block break lives inside one container, and `LineOp::Join`
   mints the crossing shape whenever it merges two lines of differing paths — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,15 @@
 ## Unreleased
 
 - fix(typst): **a container inside a list item no longer terminates the list.**
-  The item's continuation indent was applied on the leaf path only, so a fence
-  or a nested list nested while a quote — and any container added later, which
-  lowers transparently — opened at column 0, where Typst ends the enclosing
-  list: the item's remaining blocks came back as top-level paragraphs and the
-  next item started a fresh list, renumbering an ordered one from the quote on.
-  The emitter now opens every block, leaf and container alike, through one
-  indented-line rule carried on the walk, so what the content nests, the markup
-  nests.
+  The item's continuation indent reached its leaf path only, so a quote inside
+  an item opened at column 0 — where Typst ends the enclosing list. The item's
+  later blocks came back as top-level paragraphs and the next item started a
+  fresh list, which renumbers an ordered one from the quote on. A fence and a
+  nested list escaped it by reaching that indented leaf path; a transparent
+  unknown container did not, and neither would any container added later.
+  Indentation is now the walk's rather than each construct's: one rule opens
+  every block, leaf and container alike, at the enclosing list depth, so what
+  the content nests, the markup nests.
 
 - fix(content): **a `continues` line that crosses a container boundary no longer
   survives.** A within-block break lives inside one container, and `LineOp::Join`

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -324,11 +324,10 @@ struct Emit<'a> {
     end_newline: bool,
     /// The prefix every generated line opens with: two spaces per enclosing
     /// list item. Typst ends a list at a block written to column 0, so leaves
-    /// and containers alike open through [`Self::open_line`] instead of each
-    /// path indenting on its own.
+    /// and containers alike open through [`Self::open_line`].
     indent: String,
-    /// Whether the next block opens where `out` already sits — a list item's
-    /// body head, off its marker — rather than on a line of its own.
+    /// Whether the next block opens where `out` already sits: a list item's
+    /// body head, off its marker.
     head_inline: bool,
     /// How far [`Self::overlapping_marks`] has walked `rt.marks`.
     mark_cursor: usize,
@@ -437,9 +436,9 @@ impl<'a> Emit<'a> {
         j
     }
 
-    /// Opens the line a block is about to be written on, at [`Self::indent`],
-    /// ending the current one if prose has reached it. A list item's body head
-    /// is already such a position, so the first block there opens in place.
+    /// Opens a block's line at [`Self::indent`], ending the current one if
+    /// prose has reached it. A list item's body head is already such a
+    /// position, so the first block there opens in place.
     fn open_line(&mut self) {
         if std::mem::take(&mut self.head_inline) {
             return;
@@ -522,8 +521,7 @@ impl<'a> Emit<'a> {
     }
 
     /// The first block flows straight off the marker; each later block is
-    /// preceded by a blank line. Its content sits one level deeper than the
-    /// marker, which [`Self::indent`] carries.
+    /// preceded by a blank line.
     fn emit_item_body(&mut self, range: Range<usize>, content_depth: usize) {
         let mut first_block = true;
         let mut i = range.start;
@@ -548,7 +546,7 @@ impl<'a> Emit<'a> {
     }
 
     /// Separates two blocks of one list item, unless the block just emitted
-    /// closed on one already.
+    /// closed on a blank line of its own.
     fn blank_line(&mut self) {
         if !self.end_newline {
             self.out.push('\n');
@@ -1232,9 +1230,9 @@ mod tests {
     }
 
     /// The blocks Typst's own parser reads as `kind` at the markup's top level,
-    /// as source text. What a list *contains* is the parser's call, not a
-    /// substring's: a container written to column 0 ends the list, and the item
-    /// it belonged to comes back without it.
+    /// as source text. What a list contains is the parser's call: a container
+    /// written to column 0 ends the list, and the item it belonged to comes
+    /// back without it.
     fn top_level(markup: &str, kind: SyntaxKind) -> Vec<String> {
         typst::syntax::parse(markup)
             .children()
@@ -1243,8 +1241,6 @@ mod tests {
             .collect()
     }
 
-    /// A quote inside a list item is the item's, and the item after it is the
-    /// list's second, not a new list's first.
     #[test]
     fn a_quote_in_an_item_stays_in_the_item() {
         let out = emit("- Alpha\n\n  > quoted\n\n  Beta\n\n- Gamma").markup;
@@ -1256,8 +1252,6 @@ mod tests {
         );
     }
 
-    /// The downstream symptom of the same defect: an ordered list renumbers
-    /// from the quote on, because everything after it is a fresh list.
     #[test]
     fn a_quote_in_an_ordered_item_does_not_restart_the_numbering() {
         let out = emit("1. Alpha\n\n   > quoted\n\n   Beta\n\n2. Gamma").markup;
@@ -1273,8 +1267,8 @@ mod tests {
         );
     }
 
-    /// A container this build does not know lowers transparently — and inside
-    /// an item that still has to be inside the item.
+    /// A container this build does not know lowers transparently: no wrapper
+    /// markup, and no move out of the item either.
     #[test]
     fn an_unknown_container_in_an_item_stays_in_the_item() {
         use quillmark_content::model::Line;

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -322,6 +322,14 @@ struct Emit<'a> {
     /// Whether `out` currently ends at a fresh line, tracked so block
     /// separators land consistently.
     end_newline: bool,
+    /// The prefix every generated line opens with: two spaces per enclosing
+    /// list item. Typst ends a list at a block written to column 0, so leaves
+    /// and containers alike open through [`Self::open_line`] instead of each
+    /// path indenting on its own.
+    indent: String,
+    /// Whether the next block opens where `out` already sits — a list item's
+    /// body head, off its marker — rather than on a line of its own.
+    head_inline: bool,
     /// How far [`Self::overlapping_marks`] has walked `rt.marks`.
     mark_cursor: usize,
 }
@@ -348,6 +356,8 @@ impl<'a> Emit<'a> {
             out: String::new(),
             segments: Vec::new(),
             end_newline: true,
+            indent: String::new(),
+            head_inline: false,
             mark_cursor: 0,
         }
     }
@@ -427,6 +437,20 @@ impl<'a> Emit<'a> {
         j
     }
 
+    /// Opens the line a block is about to be written on, at [`Self::indent`],
+    /// ending the current one if prose has reached it. A list item's body head
+    /// is already such a position, so the first block there opens in place.
+    fn open_line(&mut self) {
+        if std::mem::take(&mut self.head_inline) {
+            return;
+        }
+        if !self.end_newline {
+            self.out.push('\n');
+        }
+        self.out.push_str(&self.indent);
+        self.end_newline = true;
+    }
+
     /// An empty paragraph emits nothing; every other block (an empty heading or
     /// code fence included) still renders.
     fn emit_leaf_terminated(&mut self, range: Range<usize>) {
@@ -436,6 +460,7 @@ impl<'a> Emit<'a> {
         if first.kind.projects_as_para() && lo == hi {
             return;
         }
+        self.open_line();
         self.emit_segment(range);
         self.out.push_str("\n\n");
         self.end_newline = true;
@@ -443,10 +468,6 @@ impl<'a> Emit<'a> {
 
     /// The trailing `\n` goes on only when this is the outermost list.
     fn emit_list(&mut self, range: Range<usize>, depth: usize, ordered: bool, start: u64) {
-        if !self.end_newline {
-            self.out.push('\n');
-            self.end_newline = true;
-        }
         let outermost = !self.rt.lines[range.start].containers[..depth]
             .iter()
             .any(|c| matches!(c, Container::ListItem { .. }));
@@ -474,8 +495,7 @@ impl<'a> Emit<'a> {
         start: u64,
         first: bool,
     ) {
-        let indent = "  ".repeat(depth);
-        self.out.push_str(&indent);
+        self.open_line();
         if ordered {
             // Typst runs one counter across adjacent `+` items
             // (`typst-layout::lists` takes `item.number.unwrap_or(number)`), so
@@ -490,7 +510,11 @@ impl<'a> Emit<'a> {
             self.out.push_str("- ");
         }
         self.end_newline = false;
+        self.head_inline = true;
+        self.indent.push_str("  ");
         self.emit_item_body(range, depth + 1);
+        self.indent.truncate(self.indent.len() - 2);
+        self.head_inline = false;
         if !self.end_newline {
             self.out.push('\n');
             self.end_newline = true;
@@ -498,43 +522,50 @@ impl<'a> Emit<'a> {
     }
 
     /// The first block flows straight off the marker; each later block is
-    /// preceded by a blank line and the `2×content_depth` continuation indent.
+    /// preceded by a blank line. Its content sits one level deeper than the
+    /// marker, which [`Self::indent`] carries.
     fn emit_item_body(&mut self, range: Range<usize>, content_depth: usize) {
-        let cont_indent = "  ".repeat(content_depth);
         let mut first_block = true;
         let mut i = range.start;
         while i < range.end {
+            if !first_block {
+                self.blank_line();
+            }
+            first_block = false;
             if let Some(j) = self.try_emit_container(range.clone(), content_depth, i) {
                 i = j;
-                first_block = false;
                 continue;
             }
             let j = self.segment_end(range.clone(), content_depth, i);
-            if !first_block {
-                // The previous block left one `\n`; a second plus the indent
-                // makes the blank line.
-                self.out.push('\n');
-                self.out.push_str(&cont_indent);
-                self.end_newline = false;
-            }
+            self.open_line();
             self.emit_segment(i..j);
             if !self.end_newline {
                 self.out.push('\n');
                 self.end_newline = true;
             }
             i = j;
-            first_block = false;
+        }
+    }
+
+    /// Separates two blocks of one list item, unless the block just emitted
+    /// closed on one already.
+    fn blank_line(&mut self) {
+        if !self.end_newline {
+            self.out.push('\n');
+            self.end_newline = true;
+        }
+        if !self.out.ends_with("\n\n") {
+            self.out.push('\n');
         }
     }
 
     /// `#quote(block: true)[…]`: quotes render structurally, not flattened.
     fn emit_quote(&mut self, range: Range<usize>, depth: usize) {
-        if !self.end_newline {
-            self.out.push('\n');
-        }
+        self.open_line();
         self.out.push_str("#quote(block: true)[\n");
         self.end_newline = true;
         self.emit_block_level(range, depth + 1);
+        self.open_line();
         self.out.push(']');
         self.out.push_str("\n\n");
         self.end_newline = true;
@@ -1006,6 +1037,7 @@ fn table_markup(props: &serde_json::Value) -> String {
 mod tests {
     use super::*;
     use quillmark_content::import::from_markdown;
+    use typst::syntax::SyntaxKind;
 
     fn emit(md: &str) -> Emission {
         let rt = from_markdown(md).expect("import");
@@ -1197,6 +1229,83 @@ mod tests {
                 "non-inline {md:?} must fall back to block lowering"
             );
         }
+    }
+
+    /// The blocks Typst's own parser reads as `kind` at the markup's top level,
+    /// as source text. What a list *contains* is the parser's call, not a
+    /// substring's: a container written to column 0 ends the list, and the item
+    /// it belonged to comes back without it.
+    fn top_level(markup: &str, kind: SyntaxKind) -> Vec<String> {
+        typst::syntax::parse(markup)
+            .children()
+            .filter(|n| n.kind() == kind)
+            .map(|n| n.full_text().to_string())
+            .collect()
+    }
+
+    /// A quote inside a list item is the item's, and the item after it is the
+    /// list's second, not a new list's first.
+    #[test]
+    fn a_quote_in_an_item_stays_in_the_item() {
+        let out = emit("- Alpha\n\n  > quoted\n\n  Beta\n\n- Gamma").markup;
+        let items = top_level(&out, SyntaxKind::ListItem);
+        assert_eq!(items.len(), 2, "the list broke apart: {out:?}");
+        assert!(
+            items[0].contains("quoted") && items[0].contains("Beta"),
+            "the quote or the block after it left the item: {out:?}"
+        );
+    }
+
+    /// The downstream symptom of the same defect: an ordered list renumbers
+    /// from the quote on, because everything after it is a fresh list.
+    #[test]
+    fn a_quote_in_an_ordered_item_does_not_restart_the_numbering() {
+        let out = emit("1. Alpha\n\n   > quoted\n\n   Beta\n\n2. Gamma").markup;
+        let items = top_level(&out, SyntaxKind::EnumItem);
+        assert_eq!(items.len(), 2, "the list broke apart: {out:?}");
+        assert!(
+            items[0].contains("quoted") && items[0].contains("Beta"),
+            "the quote or the block after it left the item: {out:?}"
+        );
+        assert!(
+            !items[1].starts_with("1."),
+            "the second item restated the start: {out:?}"
+        );
+    }
+
+    /// A container this build does not know lowers transparently — and inside
+    /// an item that still has to be inside the item.
+    #[test]
+    fn an_unknown_container_in_an_item_stays_in_the_item() {
+        use quillmark_content::model::Line;
+        let item = || Container::ListItem {
+            ordered: false,
+            start: 1,
+            ordinal: 0,
+            instance: 0,
+        };
+        let roster = Container::Unknown {
+            tag: "roster".to_string(),
+            attrs: serde_json::Value::Null,
+            instance: 0,
+        };
+        let rt = Content::new(
+            "Alpha\nRoster\nBeta".to_string(),
+            vec![
+                Line::new(LineKind::Para).with_containers(vec![item()]),
+                Line::new(LineKind::Para).with_containers(vec![item(), roster]),
+                Line::new(LineKind::Para).with_containers(vec![item()]),
+            ],
+        )
+        .into_normalized();
+        assert_eq!(rt.validate(), Ok(()));
+        let out = emit_content(&rt).unwrap().markup;
+        let items = top_level(&out, SyntaxKind::ListItem);
+        assert_eq!(items.len(), 1, "the item broke apart: {out:?}");
+        assert!(
+            items[0].contains("Roster") && items[0].contains("Beta"),
+            "the container or the block after it left the item: {out:?}"
+        );
     }
 
     // ---- intentional divergence: block quotes render ----

--- a/prose/canon/CONVERT.md
+++ b/prose/canon/CONVERT.md
@@ -100,6 +100,12 @@ an escaped source slice.
 divergence from a flat inline pass; a quote's inner blocks lower under the
 block-level discipline.
 
+**Every generated line opens at the enclosing list depth**, two spaces per item.
+Typst ends a list at a block written to column 0, so the indent is one emitter
+rule over leaves and containers alike rather than each construct's own: a quote,
+a nested list, a fence, and a container this build has never heard of all stay
+inside the item that holds them.
+
 Anchor and unknown marks emit nothing; unknown island types emit nothing
 (parallel to the HTML rule at import). An unknown line kind lowers as a
 paragraph and an unknown container as nothing at all: every content vocabulary

--- a/prose/canon/CONVERT.md
+++ b/prose/canon/CONVERT.md
@@ -101,10 +101,8 @@ divergence from a flat inline pass; a quote's inner blocks lower under the
 block-level discipline.
 
 **Every generated line opens at the enclosing list depth**, two spaces per item.
-Typst ends a list at a block written to column 0, so the indent is one emitter
-rule over leaves and containers alike rather than each construct's own: a quote,
-a nested list, a fence, and a container this build has never heard of all stay
-inside the item that holds them.
+Typst ends a list at a block written to column 0, so one emitter rule indents
+leaves and containers alike: what the content nests, the markup nests.
 
 Anchor and unknown marks emit nothing; unknown island types emit nothing
 (parallel to the HTML rule at import). An unknown line kind lowers as a


### PR DESCRIPTION
Closes #1361.

## The defect

`emit_item_body` applied the item's continuation indent on its **leaf** path only. The container path returns before that (`try_emit_container`), leaving each container to indent itself, and they disagreed: `emit_list` indented, `emit_quote` and the transparent `Container::Unknown` path did not. A quote inside a list item therefore opened `#quote(…)` at column 0, where Typst ends the enclosing list — the item's later blocks came back as top-level paragraphs and the next item started a fresh list, which renumbers an ordered one from the quote on.

A fence and a nested list escaped it by reaching the indented leaf path, which is why the downstream report found the quote alone at fault. Any container added later would have landed the same way.

## The fix

Indentation is the walk's rather than each construct's. `Emit` carries two pieces of state:

- `indent` — the prefix a generated line opens with, two spaces per enclosing item, pushed and popped by `emit_item`.
- `head_inline` — the one position a block opens in place: a list item's body head, off its marker.

One `open_line` writes it, and every block goes through it: `emit_leaf_terminated`, `emit_item`, `emit_quote` (both its opening line and its `]`), and the leaves under a transparent container. The per-path indent writes in `emit_list` / `emit_item` / `emit_item_body` are gone, and a `blank_line` helper handles block separation without the doubled blank line the old quote path left behind.

The issue's repro now emits:

```
- Item one first block

  Item one second block

  #quote(block: true)[
  quoted in item one

  ]

  Item one third block
- Item two
```

## Tests

Three, asserting through Typst's own parser rather than substrings. `top_level(markup, kind)` returns the `ListItem` / `EnumItem` nodes Typst reads at the markup's top level, so "the quote left the item" is the parser's verdict, not a `contains`:

- `a_quote_in_an_item_stays_in_the_item`
- `a_quote_in_an_ordered_item_does_not_restart_the_numbering` — the downstream symptom
- `an_unknown_container_in_an_item_stays_in_the_item` — a hand-built `Container::Unknown`, standing in for a container that does not exist yet

Run over the pre-fix output byte-for-byte, the helper returns `["- Alpha", "- Gamma"]`, neither carrying the quote or the block after it: the tests fail on the old emitter.

`cargo test --workspace` is green (62 binaries, 0 failures); clippy adds no new warnings. `prose/canon/CONVERT.md` gains the indentation invariant.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpQMboS5DThXxndR7M4u7u)_