### PR TITLE
fix: settle what `Normalized` promises, and make the lanes around it hold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- fix(typst): **a container inside a list item no longer terminates the list.**
+  The item's continuation indent was applied on the leaf path only, so a fence
+  or a nested list nested while a quote — and any container added later, which
+  lowers transparently — opened at column 0, where Typst ends the enclosing
+  list: the item's remaining blocks came back as top-level paragraphs and the
+  next item started a fresh list, renumbering an ordered one from the quote on.
+  The emitter now opens every block, leaf and container alike, through one
+  indented-line rule carried on the walk, so what the content nests, the markup
+  nests.
+
 - fix(content): **a `continues` line that crosses a container boundary no longer
   survives.** A within-block break lives inside one container, and `LineOp::Join`
   mints the crossing shape whenever it merges two lines of differing paths — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- fix(content): **`to_markdown` no longer aborts the process on a deeply nested
+  content.** `Normalized` states that `normalize` has run, and `normalize`
+  repairs where `validate` rejects: nothing about canonicalization brings a
+  container path under `MAX_NESTING_DEPTH`, so a hand-built `Content` mints a
+  token that `validate` refuses. `export::emit_block` recursed one frame per
+  container level and overflowed the stack a few thousand levels down — a
+  SIGABRT no caller can catch, against a Typst emitter that checks the depth up
+  front and returns `EmitError::NestingTooDeep` for the same input. The walk is
+  now an explicit frame stack, as `json_depth_exceeds` and the quill census
+  already are, so the projection is total over every token its signature
+  accepts. `Normalized`'s docs settle the half the newtype does not close: the
+  token promises canonical, not valid — the mint stays infallible, the codecs go
+  on calling `validate` after it, and a projection that takes one owes totality
+  rather than trust. Only a Rust embedder hand-building a `Content` reaches the
+  shape; every decode lane (`from_markdown`, `from_canonical_value`, storage,
+  WASM, Python) rejects the depth already.
+
 - fix(content): **a `continues` line that crosses a container boundary no longer
   survives.** A within-block break lives inside one container, and `LineOp::Join`
   mints the crossing shape whenever it merges two lines of differing paths — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,15 @@
 ## Unreleased
 
 - fix(typst): **a container inside a list item no longer terminates the list.**
-  The item's continuation indent was applied on the leaf path only, so a fence
-  or a nested list nested while a quote — and any container added later, which
-  lowers transparently — opened at column 0, where Typst ends the enclosing
-  list: the item's remaining blocks came back as top-level paragraphs and the
-  next item started a fresh list, renumbering an ordered one from the quote on.
-  The emitter now opens every block, leaf and container alike, through one
-  indented-line rule carried on the walk, so what the content nests, the markup
-  nests.
+  The item's continuation indent reached its leaf path only, so a quote inside
+  an item opened at column 0 — where Typst ends the enclosing list. The item's
+  later blocks came back as top-level paragraphs and the next item started a
+  fresh list, which renumbers an ordered one from the quote on. A fence and a
+  nested list escaped it by reaching that indented leaf path; a transparent
+  unknown container did not, and neither would any container added later.
+  Indentation is now the walk's rather than each construct's: one rule opens
+  every block, leaf and container alike, at the enclosing list depth, so what
+  the content nests, the markup nests.
 
 - fix(content): **a `continues` line that crosses a container boundary no longer
   survives.** A within-block break lives inside one container, and `LineOp::Join`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+- perf(content): **`serial::to_canonical_value` and `to_canonical_json` take a
+  `Normalized`.**
+  Both cloned the whole content and normalized the copy on every call, on a
+  lane whose callers — the codecs, `Card::body`, the storage DTO — were already
+  holding the canonical form. The token now carries that, so the serialize path
+  spends an encode instead of a deep clone plus a repair pass. `to_canonical_json`
+  moves from `Content` to `Normalized` with it; a caller holding a raw `Content`
+  mints first, which is what the old body did for them silently.
+
+- fix(core): **a document body that `validate` refuses is refused on write, not
+  discovered on read.** `CanonicalContent`'s `Deserialize` parsed, normalized and
+  validated; its `Serialize` validated nothing, and `Card::overwrite_body` takes a
+  caller's content on the canonical-form token alone. A store could therefore
+  accept bytes it could not read back. The serializer now validates too and fails
+  with the invariant, at the boundary that cares and while the caller still holds
+  the value that produced it.
+
+- refactor(content): **the leaf-segment walk is one loop, not two.** `traverse`
+  gains `segment` — the block-opening line plus every following one that
+  continues it at the same nesting — and `export::emit_block` and the Typst
+  emitter's `segment_end` both call it. The fifth duplicated traversal, the one
+  #1364 did not list.
+
 - fix(content): **`to_markdown` no longer aborts the process on a deeply nested
   content.** `Normalized` states that `normalize` has run, and `normalize`
   repairs where `validate` rejects: nothing about canonicalization brings a

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -417,14 +417,7 @@ impl<'a> Emit<'a> {
     }
 
     fn segment_end(&self, range: Range<usize>, depth: usize, i: usize) -> usize {
-        let mut j = i + 1;
-        while j < range.end
-            && self.rt.lines[j].containers.len() == depth
-            && self.rt.lines[j].continues
-        {
-            j += 1;
-        }
-        j
+        quillmark_content::traverse::segment(&self.rt.lines, i..range.end, depth).end
     }
 
     /// An empty paragraph emits nothing; every other block (an empty heading or

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -324,11 +324,10 @@ struct Emit<'a> {
     end_newline: bool,
     /// The prefix every generated line opens with: two spaces per enclosing
     /// list item. Typst ends a list at a block written to column 0, so leaves
-    /// and containers alike open through [`Self::open_line`] instead of each
-    /// path indenting on its own.
+    /// and containers alike open through [`Self::open_line`].
     indent: String,
-    /// Whether the next block opens where `out` already sits — a list item's
-    /// body head, off its marker — rather than on a line of its own.
+    /// Whether the next block opens where `out` already sits: a list item's
+    /// body head, off its marker.
     head_inline: bool,
     /// How far [`Self::overlapping_marks`] has walked `rt.marks`.
     mark_cursor: usize,
@@ -437,9 +436,9 @@ impl<'a> Emit<'a> {
         j
     }
 
-    /// Opens the line a block is about to be written on, at [`Self::indent`],
-    /// ending the current one if prose has reached it. A list item's body head
-    /// is already such a position, so the first block there opens in place.
+    /// Opens a block's line at [`Self::indent`], ending the current one if
+    /// prose has reached it. A list item's body head is already such a
+    /// position, so the first block there opens in place.
     fn open_line(&mut self) {
         if std::mem::take(&mut self.head_inline) {
             return;
@@ -522,8 +521,7 @@ impl<'a> Emit<'a> {
     }
 
     /// The first block flows straight off the marker; each later block is
-    /// preceded by a blank line. Its content sits one level deeper than the
-    /// marker, which [`Self::indent`] carries.
+    /// preceded by a blank line.
     fn emit_item_body(&mut self, range: Range<usize>, content_depth: usize) {
         let mut first_block = true;
         let mut i = range.start;
@@ -548,7 +546,7 @@ impl<'a> Emit<'a> {
     }
 
     /// Separates two blocks of one list item, unless the block just emitted
-    /// closed on one already.
+    /// closed on a blank line of its own.
     fn blank_line(&mut self) {
         if !self.end_newline {
             self.out.push('\n');
@@ -1232,9 +1230,9 @@ mod tests {
     }
 
     /// The blocks Typst's own parser reads as `kind` at the markup's top level,
-    /// as source text. What a list *contains* is the parser's call, not a
-    /// substring's: a container written to column 0 ends the list, and the item
-    /// it belonged to comes back without it.
+    /// as source text. What a list contains is the parser's call: a container
+    /// written to column 0 ends the list, and the item it belonged to comes
+    /// back without it.
     fn top_level(markup: &str, kind: SyntaxKind) -> Vec<String> {
         typst::syntax::parse(markup)
             .children()
@@ -1243,8 +1241,6 @@ mod tests {
             .collect()
     }
 
-    /// A quote inside a list item is the item's, and the item after it is the
-    /// list's second, not a new list's first.
     #[test]
     fn a_quote_in_an_item_stays_in_the_item() {
         let out = emit("- Alpha\n\n  > quoted\n\n  Beta\n\n- Gamma").markup;
@@ -1256,8 +1252,6 @@ mod tests {
         );
     }
 
-    /// The downstream symptom of the same defect: an ordered list renumbers
-    /// from the quote on, because everything after it is a fresh list.
     #[test]
     fn a_quote_in_an_ordered_item_does_not_restart_the_numbering() {
         let out = emit("1. Alpha\n\n   > quoted\n\n   Beta\n\n2. Gamma").markup;
@@ -1273,8 +1267,8 @@ mod tests {
         );
     }
 
-    /// A container this build does not know lowers transparently — and inside
-    /// an item that still has to be inside the item.
+    /// A container this build does not know lowers transparently: no wrapper
+    /// markup, and no move out of the item either.
     #[test]
     fn an_unknown_container_in_an_item_stays_in_the_item() {
         use quillmark_content::model::Line;

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -322,6 +322,14 @@ struct Emit<'a> {
     /// Whether `out` currently ends at a fresh line, tracked so block
     /// separators land consistently.
     end_newline: bool,
+    /// The prefix every generated line opens with: two spaces per enclosing
+    /// list item. Typst ends a list at a block written to column 0, so leaves
+    /// and containers alike open through [`Self::open_line`] instead of each
+    /// path indenting on its own.
+    indent: String,
+    /// Whether the next block opens where `out` already sits — a list item's
+    /// body head, off its marker — rather than on a line of its own.
+    head_inline: bool,
     /// How far [`Self::overlapping_marks`] has walked `rt.marks`.
     mark_cursor: usize,
 }
@@ -348,6 +356,8 @@ impl<'a> Emit<'a> {
             out: String::new(),
             segments: Vec::new(),
             end_newline: true,
+            indent: String::new(),
+            head_inline: false,
             mark_cursor: 0,
         }
     }
@@ -427,6 +437,20 @@ impl<'a> Emit<'a> {
         j
     }
 
+    /// Opens the line a block is about to be written on, at [`Self::indent`],
+    /// ending the current one if prose has reached it. A list item's body head
+    /// is already such a position, so the first block there opens in place.
+    fn open_line(&mut self) {
+        if std::mem::take(&mut self.head_inline) {
+            return;
+        }
+        if !self.end_newline {
+            self.out.push('\n');
+        }
+        self.out.push_str(&self.indent);
+        self.end_newline = true;
+    }
+
     /// An empty paragraph emits nothing; every other block (an empty heading or
     /// code fence included) still renders.
     fn emit_leaf_terminated(&mut self, range: Range<usize>) {
@@ -436,6 +460,7 @@ impl<'a> Emit<'a> {
         if first.kind.projects_as_para() && lo == hi {
             return;
         }
+        self.open_line();
         self.emit_segment(range);
         self.out.push_str("\n\n");
         self.end_newline = true;
@@ -443,10 +468,6 @@ impl<'a> Emit<'a> {
 
     /// The trailing `\n` goes on only when this is the outermost list.
     fn emit_list(&mut self, range: Range<usize>, depth: usize, ordered: bool, start: u64) {
-        if !self.end_newline {
-            self.out.push('\n');
-            self.end_newline = true;
-        }
         let outermost = !self.rt.lines[range.start].containers[..depth]
             .iter()
             .any(|c| matches!(c, Container::ListItem { .. }));
@@ -474,8 +495,7 @@ impl<'a> Emit<'a> {
         start: u64,
         first: bool,
     ) {
-        let indent = "  ".repeat(depth);
-        self.out.push_str(&indent);
+        self.open_line();
         if ordered {
             // Typst runs one counter across adjacent `+` items
             // (`typst-layout::lists` takes `item.number.unwrap_or(number)`), so
@@ -490,7 +510,11 @@ impl<'a> Emit<'a> {
             self.out.push_str("- ");
         }
         self.end_newline = false;
+        self.head_inline = true;
+        self.indent.push_str("  ");
         self.emit_item_body(range, depth + 1);
+        self.indent.truncate(self.indent.len() - 2);
+        self.head_inline = false;
         if !self.end_newline {
             self.out.push('\n');
             self.end_newline = true;
@@ -498,43 +522,50 @@ impl<'a> Emit<'a> {
     }
 
     /// The first block flows straight off the marker; each later block is
-    /// preceded by a blank line and the `2×content_depth` continuation indent.
+    /// preceded by a blank line. Its content sits one level deeper than the
+    /// marker, which [`Self::indent`] carries.
     fn emit_item_body(&mut self, range: Range<usize>, content_depth: usize) {
-        let cont_indent = "  ".repeat(content_depth);
         let mut first_block = true;
         let mut i = range.start;
         while i < range.end {
+            if !first_block {
+                self.blank_line();
+            }
+            first_block = false;
             if let Some(j) = self.try_emit_container(range.clone(), content_depth, i) {
                 i = j;
-                first_block = false;
                 continue;
             }
             let j = self.segment_end(range.clone(), content_depth, i);
-            if !first_block {
-                // The previous block left one `\n`; a second plus the indent
-                // makes the blank line.
-                self.out.push('\n');
-                self.out.push_str(&cont_indent);
-                self.end_newline = false;
-            }
+            self.open_line();
             self.emit_segment(i..j);
             if !self.end_newline {
                 self.out.push('\n');
                 self.end_newline = true;
             }
             i = j;
-            first_block = false;
+        }
+    }
+
+    /// Separates two blocks of one list item, unless the block just emitted
+    /// closed on one already.
+    fn blank_line(&mut self) {
+        if !self.end_newline {
+            self.out.push('\n');
+            self.end_newline = true;
+        }
+        if !self.out.ends_with("\n\n") {
+            self.out.push('\n');
         }
     }
 
     /// `#quote(block: true)[…]`: quotes render structurally, not flattened.
     fn emit_quote(&mut self, range: Range<usize>, depth: usize) {
-        if !self.end_newline {
-            self.out.push('\n');
-        }
+        self.open_line();
         self.out.push_str("#quote(block: true)[\n");
         self.end_newline = true;
         self.emit_block_level(range, depth + 1);
+        self.open_line();
         self.out.push(']');
         self.out.push_str("\n\n");
         self.end_newline = true;
@@ -1006,6 +1037,7 @@ fn table_markup(props: &serde_json::Value) -> String {
 mod tests {
     use super::*;
     use quillmark_content::import::from_markdown;
+    use typst::syntax::SyntaxKind;
 
     fn emit(md: &str) -> Emission {
         let rt = from_markdown(md).expect("import");
@@ -1197,6 +1229,83 @@ mod tests {
                 "non-inline {md:?} must fall back to block lowering"
             );
         }
+    }
+
+    /// The blocks Typst's own parser reads as `kind` at the markup's top level,
+    /// as source text. What a list *contains* is the parser's call, not a
+    /// substring's: a container written to column 0 ends the list, and the item
+    /// it belonged to comes back without it.
+    fn top_level(markup: &str, kind: SyntaxKind) -> Vec<String> {
+        typst::syntax::parse(markup)
+            .children()
+            .filter(|n| n.kind() == kind)
+            .map(|n| n.full_text().to_string())
+            .collect()
+    }
+
+    /// A quote inside a list item is the item's, and the item after it is the
+    /// list's second, not a new list's first.
+    #[test]
+    fn a_quote_in_an_item_stays_in_the_item() {
+        let out = emit("- Alpha\n\n  > quoted\n\n  Beta\n\n- Gamma").markup;
+        let items = top_level(&out, SyntaxKind::ListItem);
+        assert_eq!(items.len(), 2, "the list broke apart: {out:?}");
+        assert!(
+            items[0].contains("quoted") && items[0].contains("Beta"),
+            "the quote or the block after it left the item: {out:?}"
+        );
+    }
+
+    /// The downstream symptom of the same defect: an ordered list renumbers
+    /// from the quote on, because everything after it is a fresh list.
+    #[test]
+    fn a_quote_in_an_ordered_item_does_not_restart_the_numbering() {
+        let out = emit("1. Alpha\n\n   > quoted\n\n   Beta\n\n2. Gamma").markup;
+        let items = top_level(&out, SyntaxKind::EnumItem);
+        assert_eq!(items.len(), 2, "the list broke apart: {out:?}");
+        assert!(
+            items[0].contains("quoted") && items[0].contains("Beta"),
+            "the quote or the block after it left the item: {out:?}"
+        );
+        assert!(
+            !items[1].starts_with("1."),
+            "the second item restated the start: {out:?}"
+        );
+    }
+
+    /// A container this build does not know lowers transparently — and inside
+    /// an item that still has to be inside the item.
+    #[test]
+    fn an_unknown_container_in_an_item_stays_in_the_item() {
+        use quillmark_content::model::Line;
+        let item = || Container::ListItem {
+            ordered: false,
+            start: 1,
+            ordinal: 0,
+            instance: 0,
+        };
+        let roster = Container::Unknown {
+            tag: "roster".to_string(),
+            attrs: serde_json::Value::Null,
+            instance: 0,
+        };
+        let rt = Content::new(
+            "Alpha\nRoster\nBeta".to_string(),
+            vec![
+                Line::new(LineKind::Para).with_containers(vec![item()]),
+                Line::new(LineKind::Para).with_containers(vec![item(), roster]),
+                Line::new(LineKind::Para).with_containers(vec![item()]),
+            ],
+        )
+        .into_normalized();
+        assert_eq!(rt.validate(), Ok(()));
+        let out = emit_content(&rt).unwrap().markup;
+        let items = top_level(&out, SyntaxKind::ListItem);
+        assert_eq!(items.len(), 1, "the item broke apart: {out:?}");
+        assert!(
+            items[0].contains("Roster") && items[0].contains("Beta"),
+            "the container or the block after it left the item: {out:?}"
+        );
     }
 
     // ---- intentional divergence: block quotes render ----

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -733,7 +733,7 @@ mod tests {
             );
             Quill::from_tree(FileTreeNode::Directory { files }).expect("quill")
         };
-        let counts = |rt: &Content| {
+        let counts = |rt: &quillmark_content::Normalized| {
             let json =
                 serde_json::json!({ "body": quillmark_content::serial::to_canonical_value(rt) });
             let q = quill();

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -1394,7 +1394,8 @@ main:
         const TEXT: &str = "Start uline and then a long trailing plain run of text.";
         let region_width = |kind: MarkKind| -> f32 {
             let rt = Content::new(TEXT.to_string(), vec![Line::new(LineKind::Para)])
-                .with_marks(vec![Mark::new(6, 11, kind)]);
+                .with_marks(vec![Mark::new(6, 11, kind)])
+                .into_normalized();
             let q = quill(YAML, PLATE);
             let plate = crate::read_plate(&q).expect("plate");
             let schema = quillmark_core::quill::build_transform_schema(q.config());

--- a/crates/backends/typst/tests/overlap_compile.rs
+++ b/crates/backends/typst/tests/overlap_compile.rs
@@ -18,7 +18,7 @@ fn overlap_content() -> serde_json::Value {
         Mark::new(2, 6, MarkKind::Code),
     ]);
     // No cross-kind overlap invariant exists, so normalize/validate keep it.
-    quillmark_content::serial::to_canonical_value(&rt)
+    quillmark_content::serial::to_canonical_value(&rt.into_normalized())
 }
 
 const YAML: &str = r#"

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -190,18 +190,9 @@ fn emit_block(ctx: &Ctx, range: std::ops::Range<usize>, depth: usize, out: &mut 
                 let child = Frame::open(Some(item.container), item.range, frame.depth + 1);
                 stack.push(child);
             } else {
-                // A leaf block: this line (continues == false) plus every
-                // following line that continues it (a hard-break run, or a code
-                // fence's lines).
-                let mut j = i + 1;
-                while j < frame.range.end
-                    && lines[j].containers.len() == frame.depth
-                    && lines[j].continues
-                {
-                    j += 1;
-                }
-                frame.at = j;
-                emit_leaf_block(ctx, i..j, &mut frame.buf);
+                let seg = crate::traverse::segment(lines, i..frame.range.end, frame.depth);
+                frame.at = seg.end;
+                emit_leaf_block(ctx, seg, &mut frame.buf);
             }
             continue;
         }

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -140,34 +140,80 @@ pub fn line_segments(rt: &Content) -> Vec<Segment> {
     segs
 }
 
+/// One open level of the block walk: the lines of `range` at `depth` not yet
+/// emitted, the markdown emitted for them so far, and the container whose
+/// syntax prefixes that once the level closes (`None` at the root).
+struct Frame<'a> {
+    container: Option<&'a Container>,
+    at: usize,
+    range: std::ops::Range<usize>,
+    depth: usize,
+    first_block: bool,
+    buf: String,
+}
+
+impl<'a> Frame<'a> {
+    fn open(container: Option<&'a Container>, range: std::ops::Range<usize>, depth: usize) -> Self {
+        Frame {
+            container,
+            at: range.start,
+            range,
+            depth,
+            first_block: true,
+            buf: String::new(),
+        }
+    }
+}
+
 /// Emit the lines in `range`, all sharing the container prefix of length
 /// `depth`. Leaf lines (containers.len() == depth) render at this level;
-/// deeper lines are grouped by their `depth`-th container and recursed into.
+/// deeper lines are grouped by their `depth`-th container and open a level of
+/// their own, which [`close_container`] prefixes on the way back out.
+///
+/// A frame stack rather than recursion, for the reason [`Normalized`] states:
+/// the token says canonical, not valid, so a container path reaching here can
+/// nest past [`MAX_NESTING_DEPTH`](crate::MAX_NESTING_DEPTH), and a call frame
+/// per level would abort the process where this returns a projection.
 fn emit_block(ctx: &Ctx, range: std::ops::Range<usize>, depth: usize, out: &mut String) {
     let lines = &ctx.rt.lines;
-    let mut i = range.start;
-    let mut first_block = true;
-    while i < range.end {
-        let line = &lines[i];
-        if line.containers.len() > depth {
-            let item = crate::traverse::items(lines, i..range.end, depth)
-                .next()
-                .expect("a line with a container at `depth` opens an item");
-            block_separator(out, first_block);
-            emit_container(ctx, item.container, item.range.clone(), depth, out);
-            first_block = false;
-            i = item.range.end;
-        } else {
-            // A leaf block: this line (continues == false) plus every following
-            // line that continues it (a hard-break run, or a code fence's lines).
-            let mut j = i + 1;
-            while j < range.end && lines[j].containers.len() == depth && lines[j].continues {
-                j += 1;
+    let mut stack = vec![Frame::open(None, range, depth)];
+    while let Some(frame) = stack.last_mut() {
+        if frame.at < frame.range.end {
+            let i = frame.at;
+            block_separator(&mut frame.buf, frame.first_block);
+            frame.first_block = false;
+            if lines[i].containers.len() > frame.depth {
+                let item = crate::traverse::items(lines, i..frame.range.end, frame.depth)
+                    .next()
+                    .expect("a line with a container at `depth` opens an item");
+                frame.at = item.range.end;
+                let child = Frame::open(Some(item.container), item.range, frame.depth + 1);
+                stack.push(child);
+            } else {
+                // A leaf block: this line (continues == false) plus every
+                // following line that continues it (a hard-break run, or a code
+                // fence's lines).
+                let mut j = i + 1;
+                while j < frame.range.end
+                    && lines[j].containers.len() == frame.depth
+                    && lines[j].continues
+                {
+                    j += 1;
+                }
+                frame.at = j;
+                emit_leaf_block(ctx, i..j, &mut frame.buf);
             }
-            block_separator(out, first_block);
-            emit_leaf_block(ctx, i..j, out);
-            first_block = false;
-            i = j;
+            continue;
+        }
+        let done = stack.pop().expect("`last_mut` just yielded this frame");
+        match stack.last_mut() {
+            Some(parent) => {
+                let key = done
+                    .container
+                    .expect("only the root frame opens without a container");
+                close_container(key, &done.buf, &mut parent.buf);
+            }
+            None => out.push_str(&done.buf),
         }
     }
 }
@@ -181,19 +227,9 @@ fn block_separator(out: &mut String, first_block: bool) {
     }
 }
 
-/// Emit a container run (a list item's block, or a quote's block) by prefixing
-/// each produced line. The inner blocks are emitted into a scratch buffer, then
-/// each of its lines is prefixed.
-fn emit_container(
-    ctx: &Ctx,
-    key: &Container,
-    range: std::ops::Range<usize>,
-    depth: usize,
-    out: &mut String,
-) {
-    let mut inner = String::new();
-    emit_block(ctx, range, depth + 1, &mut inner);
-
+/// Close a container level: prefix each line of `inner`, the block emitted for
+/// it, with the container's markdown syntax.
+fn close_container(key: &Container, inner: &str, out: &mut String) {
     match key {
         Container::ListItem {
             ordered,
@@ -227,16 +263,16 @@ fn emit_container(
                 "+ ".to_string()
             };
             let indent = " ".repeat(marker.len());
-            prefix_lines(&inner, &marker, &indent, out);
+            prefix_lines(inner, &marker, &indent, out);
         }
         Container::Quote { .. } => {
             // `> ` on content lines, `>` on blank lines so paragraphs stay in
             // one quote on re-import.
-            prefix_quote(&inner, out);
+            prefix_quote(inner, out);
         }
         // A container this build does not know has no markdown syntax to prefix
         // with, so it projects transparently and survives via storage.
-        Container::Unknown { .. } => out.push_str(&inner),
+        Container::Unknown { .. } => out.push_str(inner),
     }
 }
 
@@ -1000,6 +1036,21 @@ mod tests {
         let rt = Content::new(text.to_string(), lines).into_normalized();
         rt.validate().expect("stored content validates");
         rt
+    }
+
+    /// The lane [`Normalized`] does not close: a Rust embedder hand-builds a
+    /// content nested past `MAX_NESTING_DEPTH`, which `normalize` cannot repair
+    /// and no mint rejects (`validate` below is the proof of the depth). `DEPTH`
+    /// clears the few-thousand-frame ceiling a recursive walk dies at on a test
+    /// thread's stack.
+    #[test]
+    fn nesting_past_what_validate_allows_projects_rather_than_overflowing() {
+        const DEPTH: usize = 10_000;
+        let mut line = Line::new(LineKind::Para);
+        line.containers = vec![Container::Quote { instance: 0 }; DEPTH];
+        let rt = Content::new("x".to_string(), vec![line]).into_normalized();
+        assert!(rt.validate().is_err(), "the shape `validate` refuses");
+        assert_eq!(to_markdown(&rt), format!("{}x", "> ".repeat(DEPTH)));
     }
 
     fn li(ordinal: u64, instance: u64) -> Vec<Container> {

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -140,9 +140,9 @@ pub fn line_segments(rt: &Content) -> Vec<Segment> {
     segs
 }
 
-/// One open level of the block walk: the lines of `range` at `depth` not yet
-/// emitted, the markdown emitted for them so far, and the container whose
-/// syntax prefixes that once the level closes (`None` at the root).
+/// One open level of the block walk: `at` is the next line of `range` to emit,
+/// `buf` the markdown emitted for the level so far, and `container` the one
+/// whose syntax prefixes `buf` when the level closes (`None` at the root).
 struct Frame<'a> {
     container: Option<&'a Container>,
     at: usize,
@@ -170,10 +170,10 @@ impl<'a> Frame<'a> {
 /// deeper lines are grouped by their `depth`-th container and open a level of
 /// their own, which [`close_container`] prefixes on the way back out.
 ///
-/// A frame stack rather than recursion, for the reason [`Normalized`] states:
-/// the token says canonical, not valid, so a container path reaching here can
-/// nest past [`MAX_NESTING_DEPTH`](crate::MAX_NESTING_DEPTH), and a call frame
-/// per level would abort the process where this returns a projection.
+/// A frame stack, not recursion, for the reason [`Normalized`] states: the
+/// token says canonical, not valid, so a container path reaching here nests
+/// past [`MAX_NESTING_DEPTH`](crate::MAX_NESTING_DEPTH) freely, and a call
+/// frame per level aborts the process where this returns a projection.
 fn emit_block(ctx: &Ctx, range: std::ops::Range<usize>, depth: usize, out: &mut String) {
     let lines = &ctx.rt.lines;
     let mut stack = vec![Frame::open(None, range, depth)];
@@ -1031,9 +1031,8 @@ mod tests {
 
     /// The lane [`Normalized`] does not close: a Rust embedder hand-builds a
     /// content nested past `MAX_NESTING_DEPTH`, which `normalize` cannot repair
-    /// and no mint rejects (`validate` below is the proof of the depth). `DEPTH`
-    /// clears the few-thousand-frame ceiling a recursive walk dies at on a test
-    /// thread's stack.
+    /// and no mint rejects. `DEPTH` clears the few-thousand-frame ceiling a
+    /// test thread's stack holds.
     #[test]
     fn nesting_past_what_validate_allows_projects_rather_than_overflowing() {
         const DEPTH: usize = 10_000;

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -1297,7 +1297,10 @@ mod tests {
             }],
             islands: vec![],
         };
-        assert_eq!(imported.to_canonical_json(), editor.to_canonical_json());
+        assert_eq!(
+            imported.to_canonical_json(),
+            editor.into_normalized().to_canonical_json()
+        );
     }
 
     #[test]

--- a/crates/content/src/lib.rs
+++ b/crates/content/src/lib.rs
@@ -34,7 +34,7 @@ pub use ops::{
 };
 pub use serial::ParseError;
 pub use model::Normalized;
-pub use traverse::{items, runs, Span};
+pub use traverse::{items, runs, segment, Span};
 
 /// Maximum container nesting depth the markdown codecs accept before erroring.
 /// The import guard ([`import::from_markdown`]) and the typst backend's markup

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -625,6 +625,14 @@ pub(crate) fn check_json_depth(v: &JsonValue, what: &'static str) -> Result<(), 
 
 /// Put `v` in canonical key order, rebuilding it only when a key is out of
 /// order, so an untouched tree pays the scan and skips the deep clone.
+///
+/// Both walks below recurse, where the container walks do not, and the split is
+/// the shape of what each descends. A container path is flat memory at any
+/// depth, so nothing but the walk bounds it. A [`JsonValue`] deep enough to
+/// overflow these is deep enough to overflow its own `Drop` in the frame that
+/// built it, so an iterative walk here would tour a value nobody can release.
+/// The bound belongs where such a value enters: `bag_from_wire` before the
+/// decode clone, [`check_json_depth`] in [`Content::validate`].
 pub(crate) fn canonicalize_keys(v: &mut JsonValue) {
     if !is_value_key_sorted(v) {
         *v = sort_keys_owned(std::mem::take(v));
@@ -1822,10 +1830,11 @@ mod tests {
             {"start": 2, "end": 4, "type": "strong"}
         ]));
         b.normalize();
-        assert_eq!(a.to_canonical_json(), b.to_canonical_json());
-        let once = a.to_canonical_json();
+        let canon = |rt: &Content| rt.clone().into_normalized().to_canonical_json();
+        assert_eq!(canon(&a), canon(&b));
+        let once = canon(&a);
         a.normalize();
-        assert_eq!(a.to_canonical_json(), once);
+        assert_eq!(canon(&a), once);
     }
 
     /// A cell is canonicalized in place, so a key this build does not recognize
@@ -1841,7 +1850,10 @@ mod tests {
         rt.normalize();
         assert_eq!(rt.islands[0].props["header"][0]["colspan"], 2);
         assert!(rt.islands[0].props["rows"][0][1].get("colspan").is_none());
-        assert!(rt.to_canonical_json().contains(r#""colspan":2"#));
+        assert!(rt
+            .into_normalized()
+            .to_canonical_json()
+            .contains(r#""colspan":2"#));
     }
 
     #[test]
@@ -1957,9 +1969,10 @@ mod tests {
         assert_eq!(props["header"][1]["text"], serde_json::json!(""));
         assert_eq!(props["rows"][1][0]["text"], serde_json::json!("d e"));
 
-        let once = rt.to_canonical_json();
+        let canon = |rt: &Content| rt.clone().into_normalized().to_canonical_json();
+        let once = canon(&rt);
         rt.normalize();
-        assert_eq!(rt.to_canonical_json(), once);
+        assert_eq!(canon(&rt), once);
     }
 
     #[test]

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -263,6 +263,24 @@ impl Container {
 ///
 /// `normalize` **repairs** rather than rejects, so this states that the value is
 /// canonical, not that its producer meant it.
+///
+/// ## Canonical, not valid
+///
+/// [`validate`](Content::validate) rejects a strictly different set: nothing
+/// normalization does brings a container path under
+/// [`MAX_NESTING_DEPTH`](crate::MAX_NESTING_DEPTH), so a token can hold a
+/// content `validate` refuses. The mint stays infallible on that split —
+/// canonicalizing is total, checking is a separate question, and the codecs are
+/// the ones who answer it, calling `validate` after minting. Every other
+/// producer is a Rust embedder hand-building a [`Content`], and this token does
+/// not speak for them.
+///
+/// A projection taking one may therefore assume only what the mint establishes,
+/// and must be **total over any token**: [`to_markdown`](crate::to_markdown)
+/// walks containers on an explicit stack rather than a call frame per level,
+/// and `emit_content` checks the depth and returns an error. Neither may trust a
+/// bound only `validate` enforces — an unguarded recursion here aborts the
+/// process, which no `Result` can catch.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Normalized(Content);
 

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -266,21 +266,20 @@ impl Container {
 ///
 /// ## Canonical, not valid
 ///
-/// [`validate`](Content::validate) rejects a strictly different set: nothing
+/// [`validate`](Content::validate) rejects a different set: nothing
 /// normalization does brings a container path under
 /// [`MAX_NESTING_DEPTH`](crate::MAX_NESTING_DEPTH), so a token can hold a
-/// content `validate` refuses. The mint stays infallible on that split —
-/// canonicalizing is total, checking is a separate question, and the codecs are
-/// the ones who answer it, calling `validate` after minting. Every other
-/// producer is a Rust embedder hand-building a [`Content`], and this token does
-/// not speak for them.
+/// content `validate` refuses. The mint stays infallible on that split, since
+/// canonicalizing is total and checking is a separate question. The codecs ask
+/// it, calling `validate` after minting; every other producer is a Rust
+/// embedder hand-building a [`Content`], and this token does not speak for them.
 ///
 /// A projection taking one may therefore assume only what the mint establishes,
-/// and must be **total over any token**: [`to_markdown`](crate::to_markdown)
+/// and must be **total over any token**. [`to_markdown`](crate::to_markdown)
 /// walks containers on an explicit stack rather than a call frame per level,
-/// and `emit_content` checks the depth and returns an error. Neither may trust a
-/// bound only `validate` enforces — an unguarded recursion here aborts the
-/// process, which no `Result` can catch.
+/// and `emit_content` checks the depth and returns an error. Neither trusts a
+/// bound only `validate` enforces: an unguarded recursion aborts the process,
+/// which no `Result` can catch.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Normalized(Content);
 
@@ -626,13 +625,12 @@ pub(crate) fn check_json_depth(v: &JsonValue, what: &'static str) -> Result<(), 
 /// Put `v` in canonical key order, rebuilding it only when a key is out of
 /// order, so an untouched tree pays the scan and skips the deep clone.
 ///
-/// Both walks below recurse, where the container walks do not, and the split is
-/// the shape of what each descends. A container path is flat memory at any
-/// depth, so nothing but the walk bounds it. A [`JsonValue`] deep enough to
-/// overflow these is deep enough to overflow its own `Drop` in the frame that
-/// built it, so an iterative walk here would tour a value nobody can release.
-/// The bound belongs where such a value enters: `bag_from_wire` before the
-/// decode clone, [`check_json_depth`] in [`Content::validate`].
+/// Both walks below recurse, where the container walks do not: a container path
+/// is flat memory at any depth, so nothing but the walk bounds it, while a
+/// [`JsonValue`] deep enough to overflow these overflows its own `Drop` in the
+/// frame that built it. The bound belongs where such a value enters —
+/// `bag_from_wire` before the decode clone, [`check_json_depth`] in
+/// [`Content::validate`].
 pub(crate) fn canonicalize_keys(v: &mut JsonValue) {
     if !is_value_key_sorted(v) {
         *v = sort_keys_owned(std::mem::take(v));

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -48,16 +48,21 @@ impl std::fmt::Display for ParseError {
 }
 impl std::error::Error for ParseError {}
 
-impl Content {
-    /// Serialize to canonical JSON bytes. Normalizes a copy first, so the output
-    /// is canonical regardless of the caller's mark/island order, and every
-    /// object key comes out in ascending order at every depth, so the bytes do
-    /// **not** depend on `serde_json`'s `preserve_order` feature in the
-    /// consumer's crate graph.
+impl Normalized {
+    /// Serialize to canonical JSON bytes. Every object key comes out in
+    /// ascending order at every depth, so the bytes do **not** depend on
+    /// `serde_json`'s `preserve_order` feature in the consumer's crate graph.
+    ///
+    /// On [`Normalized`] for the reason that token exists: canonical bytes need
+    /// canonical input, and the mint is where a caller's mark/island order
+    /// settles. Normalizing a copy here would spend a deep clone on every
+    /// serialize, and the lane that decoded this has already paid for it.
     pub fn to_canonical_json(&self) -> String {
         to_canonical_value(self).to_string()
     }
+}
 
+impl Content {
     /// Parse canonical JSON, normalize, and validate. Returns
     /// [`ParseError::Invalid`] for a content that violates its invariants, so
     /// storage cannot silently round-trip a malformed value.
@@ -113,16 +118,14 @@ impl Content {
 }
 
 /// The canonical content form as a structural [`Value`]: the recursively
-/// key-sorted tree [`Content::to_canonical_json`] renders to bytes. A storage
+/// key-sorted tree [`Normalized::to_canonical_json`] renders to bytes. A storage
 /// layer embeds this as a nested object rather than an escaped string;
 /// serializing it with `serde_json` is byte-identical to that JSON, independent
 /// of the consumer's `preserve_order` feature.
-pub fn to_canonical_value(rt: &Content) -> Value {
-    let mut rt = rt.clone();
-    rt.normalize();
+pub fn to_canonical_value(rt: &Normalized) -> Value {
     let mut v = rt.to_value();
     // Scans and returns: the encoders emit their fixed keys in ascending order,
-    // and every opaque bag under them was canonicalized by `normalize`. A key
+    // and every opaque bag under them was canonicalized by the mint. A key
     // inserted out of order is still repaired here, so the freeze holds without
     // the encoders having to be trusted for it.
     canonicalize_keys(&mut v);
@@ -1101,7 +1104,10 @@ mod tests {
         }];
         let mut two = one.clone();
         two.islands[0].props = serde_json::json!({"a": 2, "b": 1}); // keys reversed
-        assert_eq!(one.to_canonical_json(), two.to_canonical_json());
+        assert_eq!(
+            one.into_normalized().to_canonical_json(),
+            two.into_normalized().to_canonical_json()
+        );
     }
 
     /// Every encoder emits its own keys in ascending order, so
@@ -1236,7 +1242,7 @@ mod tests {
     #[test]
     fn golden_bytes_are_feature_independent() {
         // If this string changes, the freeze changed: bump the schema version.
-        let rt = sample();
+        let rt = sample().into_normalized();
         assert_eq!(
             rt.to_canonical_json(),
             r#"{"islands":[],"lines":[{"containers":[],"kind":"para"}],"marks":[{"end":5,"start":0,"type":"emph"},{"end":11,"start":6,"type":"strong"}],"text":"hello world"}"#
@@ -1462,7 +1468,10 @@ mod tests {
             attrs: serde_json::json!({"x": 2, "y": 1}),
             instance: 0,
         }];
-        assert_eq!(one.to_canonical_json(), two.to_canonical_json());
+        assert_eq!(
+            one.clone().into_normalized().to_canonical_json(),
+            two.clone().into_normalized().to_canonical_json()
+        );
         one.normalize();
         two.normalize();
         assert_eq!(one, two, "normalize canonicalizes the live model too");
@@ -1480,6 +1489,7 @@ mod tests {
                 attrs: serde_json::json!({"color": "yellow"}),
             },
         }];
+        let rt = rt.into_normalized();
         let json = rt.to_canonical_json();
         let back = Content::from_canonical_json(&json).unwrap();
         assert_eq!(back.marks[0].kind, rt.marks[0].kind);

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -55,8 +55,7 @@ impl Normalized {
     ///
     /// On [`Normalized`] for the reason that token exists: canonical bytes need
     /// canonical input, and the mint is where a caller's mark/island order
-    /// settles. Normalizing a copy here would spend a deep clone on every
-    /// serialize, and the lane that decoded this has already paid for it.
+    /// settles.
     pub fn to_canonical_json(&self) -> String {
         to_canonical_value(self).to_string()
     }

--- a/crates/content/src/traverse.rs
+++ b/crates/content/src/traverse.rs
@@ -1,6 +1,5 @@
-//! The loops that group adjacent lines: by container ([`runs`], [`items`],
-//! applying the rule [`Container::same_run`] states) and by continuation
-//! ([`segment`]).
+//! The loops that group adjacent lines: by container, applying the rule
+//! [`Container::same_run`] states, and by continuation.
 
 use crate::model::{Container, Line};
 use std::ops::Range;
@@ -53,10 +52,9 @@ pub fn items(lines: &[Line], range: Range<usize>, depth: usize) -> Spans<'_> {
 /// that continues it — a paragraph's hard-break run, or a code fence's lines —
 /// bounded by `range`.
 ///
-/// A continuation counts only at the same nesting, so a `continues` line whose
+/// A continuation counts only at the same nesting: a `continues` line whose
 /// container path differs ends the segment rather than joining across the
-/// boundary. [`Content::normalize`](crate::model::Content::normalize) clears
-/// that flag, and this is the reading that made clearing it unobservable.
+/// boundary.
 pub fn segment(lines: &[Line], range: Range<usize>, depth: usize) -> Range<usize> {
     let end = range.end.min(lines.len());
     let mut j = (range.start + 1).min(end);

--- a/crates/content/src/traverse.rs
+++ b/crates/content/src/traverse.rs
@@ -1,4 +1,6 @@
-//! The one loop that applies the grouping rule [`Container::same_run`] states.
+//! The loops that group adjacent lines: by container ([`runs`], [`items`],
+//! applying the rule [`Container::same_run`] states) and by continuation
+//! ([`segment`]).
 
 use crate::model::{Container, Line};
 use std::ops::Range;
@@ -45,6 +47,23 @@ pub fn items(lines: &[Line], range: Range<usize>, depth: usize) -> Spans<'_> {
         depth,
         same: |a, b| a == b,
     }
+}
+
+/// The segment opening at `range.start`: that line plus every following one
+/// that continues it — a paragraph's hard-break run, or a code fence's lines —
+/// bounded by `range`.
+///
+/// A continuation counts only at the same nesting, so a `continues` line whose
+/// container path differs ends the segment rather than joining across the
+/// boundary. [`Content::normalize`](crate::model::Content::normalize) clears
+/// that flag, and this is the reading that made clearing it unobservable.
+pub fn segment(lines: &[Line], range: Range<usize>, depth: usize) -> Range<usize> {
+    let end = range.end.min(lines.len());
+    let mut j = (range.start + 1).min(end);
+    while j < end && lines[j].containers.len() == depth && lines[j].continues {
+        j += 1;
+    }
+    range.start..j
 }
 
 /// Iterator over [`runs`] or [`items`].
@@ -148,9 +167,31 @@ mod tests {
         assert_eq!(per_item, vec![0..1, 1..2]);
     }
 
+    fn seg(paths: &[Vec<Container>], continues: &[bool], depth: usize) -> Range<usize> {
+        let mut rt = content(paths);
+        for (line, &c) in rt.lines.iter_mut().zip(continues) {
+            line.continues = c;
+        }
+        segment(&rt.lines, 0..rt.lines.len(), depth)
+    }
+
+    #[test]
+    fn a_segment_takes_the_continuations_at_its_own_depth() {
+        assert_eq!(seg(&[vec![], vec![], vec![]], &[false, true, true], 0), 0..3);
+        assert_eq!(seg(&[vec![], vec![], vec![]], &[false, true, false], 0), 0..2);
+    }
+
+    #[test]
+    fn a_continuation_at_another_depth_ends_the_segment() {
+        let paths = &[vec![], vec![li(0, 0)]];
+        assert_eq!(seg(paths, &[false, true], 0), 0..1);
+    }
+
     #[test]
     fn a_range_end_past_the_last_line_is_clamped() {
         let rt = content(&[vec![li(0, 0)]]);
         assert_eq!(spans(runs(&rt.lines, 0..99, 0)), vec![0..1]);
+        assert_eq!(segment(&rt.lines, 0..99, 0), 0..1);
+        assert_eq!(segment(&[], 0..99, 0), 0..0);
     }
 }

--- a/crates/content/tests/properties.rs
+++ b/crates/content/tests/properties.rs
@@ -301,7 +301,10 @@ proptest! {
         let rt = from_markdown(&md).unwrap();
         let mut shuffled = rt.clone().into_content();
         shuffled.marks.reverse();
-        prop_assert_eq!(rt.to_canonical_json(), shuffled.to_canonical_json());
+        prop_assert_eq!(
+            rt.to_canonical_json(),
+            shuffled.into_normalized().to_canonical_json()
+        );
     }
 
     /// Property 3: an anchor over text that survives a rewrite is carried

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -164,8 +164,12 @@ pub type PayloadV0_93_0 = PayloadV0_92_0;
 /// - `Deserialize` parses, normalizes, and validates, so an invalid content is
 ///   rejected at load rather than silently round-tripped.
 ///
-/// The serializer normalizes a copy regardless of its input, so a hand-built
-/// value cannot leak non-canonical bytes.
+/// **Both directions validate.** [`Normalized`] is the canonical-form token,
+/// not a validity one — `normalize` repairs where `validate` rejects, and
+/// `overwrite_body` takes a caller's content on that token alone. Checking only
+/// on the way in would let a store accept bytes it cannot read back; the write
+/// refuses them instead, at the boundary that cares and while a caller still
+/// holds the value that produced them.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CanonicalContent(pub Normalized);
 
@@ -174,6 +178,9 @@ impl Serialize for CanonicalContent {
     where
         S: serde::Serializer,
     {
+        self.0
+            .validate()
+            .map_err(|inv| serde::ser::Error::custom(format!("content invariant: {inv:?}")))?;
         quillmark_content::serial::to_canonical_value(&self.0).serialize(serializer)
     }
 }
@@ -1015,6 +1022,23 @@ This body and the metadata above are an indorsement card.
         let restored: Document = serde_json::from_str(&json).unwrap();
         assert_eq!(doc, restored);
         assert_eq!(doc.to_markdown(), restored.to_markdown());
+    }
+
+    /// A store must not accept bytes it cannot read back. `overwrite_body` takes
+    /// a caller's content on the canonical-form token alone, so an invalid shape
+    /// reaches the DTO, and the serializer is where it stops.
+    #[test]
+    fn an_unreadable_body_is_refused_on_write() {
+        use quillmark_content::model::{Container, Content, Line, LineKind};
+
+        let mut doc = sample();
+        let mut line = Line::new(LineKind::Para);
+        line.containers =
+            vec![Container::Quote { instance: 0 }; quillmark_content::MAX_NESTING_DEPTH + 1];
+        doc.main_mut()
+            .overwrite_body(Content::new("x".to_string(), vec![line]));
+        let err = serde_json::to_string(&doc).expect_err("write refuses what load would reject");
+        assert!(err.to_string().contains("NestingTooDeep"), "{err}");
     }
 
     #[test]

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -158,18 +158,16 @@ pub type PayloadV0_93_0 = PayloadV0_92_0;
 /// frozen canonical serializer (`quillmark_content::serial`) rather than a
 /// hand-mirrored DTO tree that could drift from it:
 ///
-/// - `Serialize` emits the recursively key-sorted structure byte-identical to
-///   `to_canonical_json()` as a **nested JSON object**, never an escaped string,
-///   independent of `preserve_order`.
+/// - `Serialize` validates, then emits the recursively key-sorted structure
+///   byte-identical to `to_canonical_json()` as a **nested JSON object**, never
+///   an escaped string, independent of `preserve_order`.
 /// - `Deserialize` parses, normalizes, and validates, so an invalid content is
 ///   rejected at load rather than silently round-tripped.
 ///
-/// **Both directions validate.** [`Normalized`] is the canonical-form token,
-/// not a validity one — `normalize` repairs where `validate` rejects, and
-/// `overwrite_body` takes a caller's content on that token alone. Checking only
-/// on the way in would let a store accept bytes it cannot read back; the write
-/// refuses them instead, at the boundary that cares and while a caller still
-/// holds the value that produced them.
+/// Both directions check because [`Normalized`] is the canonical-form token and
+/// not a validity one: `normalize` repairs where `validate` rejects, and
+/// `Card::overwrite_body` takes a caller's content on that token alone. A store
+/// that checked only on load would accept bytes it cannot read back.
 #[derive(Debug, Clone, PartialEq)]
 pub struct CanonicalContent(pub Normalized);
 
@@ -1024,9 +1022,8 @@ This body and the metadata above are an indorsement card.
         assert_eq!(doc.to_markdown(), restored.to_markdown());
     }
 
-    /// A store must not accept bytes it cannot read back. `overwrite_body` takes
-    /// a caller's content on the canonical-form token alone, so an invalid shape
-    /// reaches the DTO, and the serializer is where it stops.
+    /// `overwrite_body` takes a caller's content on the canonical-form token
+    /// alone, so an invalid shape reaches the DTO.
     #[test]
     fn an_unreadable_body_is_refused_on_write() {
         use quillmark_content::model::{Container, Content, Line, LineKind};

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -540,7 +540,7 @@ impl QuillConfig {
                         }
                         Ok(())
                     };
-                let commit = |rt: &quillmark_content::Content| -> QuillValue {
+                let commit = |rt: &quillmark_content::Normalized| -> QuillValue {
                     match mode {
                         Leniency::Render => QuillValue::from_json(
                             quillmark_content::serial::to_canonical_value(rt),

--- a/prose/canon/CONVERT.md
+++ b/prose/canon/CONVERT.md
@@ -100,6 +100,12 @@ an escaped source slice.
 divergence from a flat inline pass; a quote's inner blocks lower under the
 block-level discipline.
 
+**Every generated line opens at the enclosing list depth**, two spaces per item.
+Typst ends a list at a block written to column 0, so the indent is one emitter
+rule over leaves and containers alike rather than each construct's own: a quote,
+a nested list, a fence, and a container this build has never heard of all stay
+inside the item that holds them.
+
 Anchor and unknown marks emit nothing; unknown island types emit nothing
 (parallel to the HTML rule at import). An unknown line kind lowers as a
 paragraph and an unknown container as nothing at all: every content vocabulary

--- a/prose/canon/CONVERT.md
+++ b/prose/canon/CONVERT.md
@@ -101,10 +101,8 @@ divergence from a flat inline pass; a quote's inner blocks lower under the
 block-level discipline.
 
 **Every generated line opens at the enclosing list depth**, two spaces per item.
-Typst ends a list at a block written to column 0, so the indent is one emitter
-rule over leaves and containers alike rather than each construct's own: a quote,
-a nested list, a fence, and a container this build has never heard of all stay
-inside the item that holds them.
+Typst ends a list at a block written to column 0, so one emitter rule indents
+leaves and containers alike: what the content nests, the markup nests.
 
 Anchor and unknown marks emit nothing; unknown island types emit nothing
 (parallel to the HTML rule at import). An unknown line kind lowers as a

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -126,6 +126,15 @@ consumer crate graph that lacks the feature. Sortedness is semantic
 serializer commits to one bit pattern); insertion order is semantic
 *outside* it (payload item order is source order, and matters).
 
+**Both directions validate.** `CanonicalContent`'s `Deserialize` parses,
+normalizes and validates, and its `Serialize` validates too. The token a
+body rests on (`Normalized`) states that `Content::normalize` has run, which
+is a weaker claim than validity — `normalize` repairs where `validate`
+rejects, and `Card::overwrite_body` takes a caller's content on that token
+alone. Checking only on load would let a store accept bytes it could not
+read back; the write refuses them instead, as a serializer error, while the
+caller still holds the value that produced them.
+
 The guarantee follows from: struct field order is fixed in the frozen
 DTO tree; `Vec` fields preserve order by definition; the two disciplines
 above each hold at their respective level. No whitespace normalization is

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -126,14 +126,13 @@ consumer crate graph that lacks the feature. Sortedness is semantic
 serializer commits to one bit pattern); insertion order is semantic
 *outside* it (payload item order is source order, and matters).
 
-**Both directions validate.** `CanonicalContent`'s `Deserialize` parses,
-normalizes and validates, and its `Serialize` validates too. The token a
-body rests on (`Normalized`) states that `Content::normalize` has run, which
-is a weaker claim than validity — `normalize` repairs where `validate`
-rejects, and `Card::overwrite_body` takes a caller's content on that token
-alone. Checking only on load would let a store accept bytes it could not
-read back; the write refuses them instead, as a serializer error, while the
-caller still holds the value that produced them.
+**Both directions validate.** `CanonicalContent` checks the body's
+invariants on the way out as well as in, failing the write with a serializer
+error. The token a body rests on (`Normalized`) states that
+`Content::normalize` has run, which is weaker than validity: `normalize`
+repairs where `validate` rejects, and `Card::overwrite_body` takes a
+caller's content on that token alone. A store that checked only on load
+would accept bytes it could not read back.
 
 The guarantee follows from: struct field order is fixed in the frozen
 DTO tree; `Vec` fields preserve order by definition; the two disciplines


### PR DESCRIPTION
Closes #1366. **Also carries #1367** (closes #1361) — see "Merged in" below.

## The decision

The issue left one question open: does `Normalized` promise *canonical*, or *canonical and valid*? Settled as **canonical only**, with the promise made self-enforcing rather than conventional:

> A projection taking a `Normalized` may assume only what the mint establishes, and must be **total over any token**.

`normalize` is total — every `Content` has a canonical form. `validate` is a different predicate that repair cannot produce. Folding them into one fallible mint makes canonicalizing carry an unrelated failure mode, forces an unreachable `Result` on the codec lane that already validates, breaks `From<Content> for Normalized`, and makes `Content::empty().into_normalized()` fallible — all to buy a guarantee the crashing projection did not need. What it needed was to not recurse.

## The crash

`export::emit_block` recursed one frame per container level. A hand-built `Content` mints a token `validate` refuses (nothing normalization does brings a container path under `MAX_NESTING_DEPTH`), and the walk died a few thousand levels down — a SIGABRT no caller can catch, against a Typst emitter that checks the depth up front and returns `EmitError::NestingTooDeep` for the same input.

It now walks an explicit frame stack, matching `json_depth_exceeds` and the quill census. Each frame carries its remaining range, its scratch buffer, and the container whose syntax prefixes that buffer when the level closes; `emit_container` splits into `close_container`, which prefixes an already-emitted block rather than recursing to produce one.

Verified both ways: `nesting_past_what_validate_allows_projects_rather_than_overflowing` builds a 10 000-deep quote path and asserts the projection comes back correct. On the parent commit that same test aborts with `fatal runtime error: stack overflow`.

## Both of the issue's "Not covered" items

**`serial::to_canonical_value` and `to_canonical_json` take a `&Normalized`.** Both cloned the whole content and normalized the copy on every call, on a lane whose callers — the codecs, `Card::body`, the storage DTO — already held the canonical form. `CanonicalContent`'s `Serialize` was paying a deep clone plus a repair pass per body, per save. `to_canonical_json` moves from `Content` to `Normalized` with it; a caller holding a raw `Content` mints first, which is what the old body did for them silently.

**`traverse::segment`** replaces the leaf-segment loop that `export.rs` and `backends/typst/src/emit.rs` each open-coded byte-for-byte — the fifth traversal #1364 did not list.

## A write-side hole the audit turned up

`CanonicalContent::Deserialize` parsed, normalized *and validated*. Its `Serialize` validated nothing, and `Card::overwrite_body` takes a caller's content on the canonical-form token alone — so a store could accept bytes it could not read back. The same normalized-≠-validated split, one layer up. The serializer now validates too, failing with the invariant while the caller still holds the value that caused it. Non-breaking: `serde_json::to_string` already returns `Result`.

## The audit, and one finding deliberately not "fixed"

Container depth is the only place in the workspace where an unbounded logical depth lives in flat memory, which is why this bug keeps recurring there. There are exactly four walkers over it — `export::emit_block`, the Typst emitter, the quill census, `traverse` — and all are now iterative or check up front.

The JSON-bag walkers under `canonicalize_keys` (`is_value_key_sorted`, `sort_keys_owned`) *are* recursive and reachable from `normalize`, so they look like the same bug. Tested rather than assumed: a 20 000-deep `serde_json::Value` builds fine and the iterative guard reads it fine, but **dropping it overflows the stack** in the caller's own frame. Rewriting those walkers would buy an iterative tour of a value nobody can release. The bound belongs where such a value enters — `bag_from_wire`, `check_json_depth` — and it is already there. The recursion stays, and now says why, so the next reader applying the `emit_block` lesson does not churn it.

## Merged in: #1367, "open every block at the enclosing list indent"

Retargeted onto this branch and merged, so this PR closes #1361 too. Its fix and this one both touch `emit.rs` and are independent: `segment_end` delegates to `traverse::segment`, and the indent rule becomes the walk's rather than each construct's. Merged clean, no conflict.

Reviewed before integrating, including reproducing the defect on the pre-fix emitter: for `- Alpha\n\n  > quoted\n\n  Beta\n\n- Gamma`, Typst's parser reads the top-level items as `["- Alpha", "- Gamma"]` — the quote and the block after it having left the item — so the three parser-based tests it adds do fail without the fix. Output spot-checked across nested lists, ordered numbering, fences, a quote as an item's first block, two adjacent quotes in one item, and a list inside a quote; every shape keeps what the content nests.

## Deliberately out of scope

`overwrite_body` stays infallible. Validating there would make it and its wasm/python twins fallible, which is the "make every mint fallible" reading the issue left open and this PR rules against. The serializer guard closes the actual round-trip hole without that break.

Also untouched, per the issue's own scoping: nothing here widens `EmitError` or changes `to_markdown`'s `String` return.

## Checks

Run on the merged tree:

- `cargo test --workspace` green (62 test binaries)
- `cargo clippy --workspace --all-targets` at its prior warning count
- `RUSTDOCFLAGS="-D warnings" cargo doc` clean for `quillmark-content` and `quillmark-core`
- `quillmark-wasm`, `quillmark-python` and `quillmark-fuzz` type-check against the changed signature
- `prose/canon/DOCUMENT_STORAGE.md` and `prose/canon/CONVERT.md` updated for the new invariants