### PR TITLE
A block's role and a mark's reach both stop where the projections do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## Unreleased
+
+- fix(content): **a continuation's line kind is its head's.** Every projection
+  reads a block's role off the line that opens it — `export::emit_leaf_block`,
+  the Typst `emit_segment`, the editor's fold — so a `continues` line carrying a
+  `kind` of its own carried a value nothing renders, down to a `lang` that
+  disagreed along one fence. `normalize` now writes the head's kind onto it, and
+  drops the flag instead where the head's kind contradicts the continuation's
+  own text, a line the head cannot absorb being no continuation of it.
+  `Content::validate` gains `Invariant::ContinuesAcrossKinds` and
+  `LineOp::SetContinues` refuses the deliberate mismatch with
+  `ApplyError::ContinuesAcrossKinds`: the container rule beside it, on the role
+  axis.
+
+- fix(content): **a formatting mark no longer reaches into a code line.** The
+  Markdown fence emits its lines verbatim, the Typst lowering puts them in one
+  `#raw` string literal, and the editor's `code_block` declares `marks: ''`, so
+  a `Strong` over a code line was a range no projection could carry — stored,
+  read back, and removed by the first edit anywhere in the field. `normalize`
+  clips it: a mark spanning a fence keeps its prose sides, one wholly inside
+  keeps nothing. Identity marks are untouched, an anchor on a code line being a
+  comment thread the editor draws as a decoration. `Content::validate` gains
+  `Invariant::FormattingOverCode` and `MarkOp::Add` refuses the deliberate write
+  with `ApplyError::FormattingOverCode`.
+
 ## v0.109.0 - 2026-08-24
 
 - **breaking** content: **`Normalized` is the precondition the projections

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -687,6 +687,13 @@ pub enum Invariant {
     /// that skipped it, the same pairing as
     /// [`LineKindMismatch`](Invariant::LineKindMismatch).
     ContinuesAcrossContainers { line: usize },
+    /// A line has `continues: true` but a different [`LineKind`] than the line
+    /// before it. Every projection reads a block's role off its head alone, so
+    /// the kind this line carries is one nothing renders. `normalize` takes the
+    /// head's;
+    /// [`ContinuesAcrossContainers`](Invariant::ContinuesAcrossContainers) is
+    /// the same rule on the container axis.
+    ContinuesAcrossKinds { line: usize },
     /// An [`MarkKind::Unknown`] reused a reserved built-in `type` name.
     ReservedUnknownTag(String),
     /// A [`LineKind::Unknown`] reused a reserved built-in `kind` name: its
@@ -698,6 +705,10 @@ pub enum Invariant {
     /// A formatting mark edge sits on a `\n` (normalization should have trimmed
     /// it): a hand-built content that skipped `normalize`.
     MarkEdgeOnNewline { at: Usv },
+    /// A formatting mark covers a [`LineKind::Code`] line's text, which the
+    /// markdown fence, the Typst `#raw` and the editor's `code_block` all emit
+    /// verbatim: a range no projection can carry. `normalize` clips it off.
+    FormattingOverCode { at: Usv },
     /// A table island's `aligns` length differs from its column count (the
     /// header width). `normalize` syncs `aligns` to the column count.
     TableAlignsMismatch { aligns: usize, cols: usize },
@@ -894,6 +905,26 @@ impl Content {
                 }
             }
         }
+        // A continuation's `kind` is its head's, `lang` included. Every
+        // projection reads a segment's role off the line that opens it —
+        // `export::emit_leaf_block`, the Typst `emit_segment`, the editor's
+        // fold — so a continuation carrying a kind of its own carries a value
+        // nothing renders. Where the head's kind contradicts the continuation's
+        // *own* text the flag goes instead: a line the head cannot absorb is no
+        // continuation of it. Runs after the demotion above, so the kind
+        // inherited is one its head keeps.
+        let segs: Vec<&str> = self.text.split('\n').collect();
+        for i in 1..self.lines.len() {
+            if !self.lines[i].continues || self.lines[i].kind == self.lines[i - 1].kind {
+                continue;
+            }
+            let head = self.lines[i - 1].kind.clone();
+            if line_kind_mismatch(&head, segs.get(i).copied().unwrap_or_default()).is_some() {
+                self.lines[i].continues = false;
+            } else {
+                self.lines[i].kind = head;
+            }
+        }
         // A table island's props are repaired (padded to one column count, cell
         // `\n` rewritten to a space, cell marks canonicalized) before the key
         // sort, so equal cells serialize to equal bytes and `validate` holds.
@@ -905,6 +936,22 @@ impl Content {
             if let MarkKind::Unknown { attrs, .. } = &mut mark.kind {
                 canonicalize_keys(attrs);
             }
+        }
+        // A formatting mark over a code line's text has no reader: the markdown
+        // fence and the Typst `#raw` emit the segment verbatim, and the
+        // editor's `code_block` declares `marks: ''`. Clip it away — a mark
+        // spanning a fence keeps its prose sides, one wholly inside keeps
+        // nothing — so what is stored is what some projection carries. Runs
+        // after the kind passes, which decide which lines are code, and before
+        // the edge trim, which takes the cut edges off the fence's `\n`s.
+        if self.marks.iter().any(|m| m.kind.is_formatting())
+            && self
+                .lines
+                .iter()
+                .any(|l| matches!(l.kind, LineKind::Code { .. }))
+        {
+            let code = code_ranges(&self.text, &self.lines);
+            self.marks = clip_formatting(std::mem::take(&mut self.marks), &code);
         }
         // A formatting mark's edges never sit on a line boundary: markdown can't
         // bold a `\n`, so two producers that disagree only about whether the
@@ -999,19 +1046,29 @@ impl Content {
         if self.lines.first().is_some_and(|l| l.continues) {
             return Err(Invariant::FirstLineContinues);
         }
-        // The one relational line invariant `validate` carries. Every other
-        // container rule is a property of a line pair too, and `normalize`
-        // settles each: a non-canonical `ordinal` renumbers, a run opening
-        // under a fresh parent re-reads, this flag clears. What is left here is
-        // the assertion that it ran.
+        // The two relational line invariants `validate` carries, both about a
+        // continuation and the head it claims. Every other container rule is a
+        // property of a line pair too, and `normalize` settles each: a
+        // non-canonical `ordinal` renumbers, a run opening under a fresh parent
+        // re-reads, this flag clears, a continuation's kind takes its head's.
+        // What is left here is the assertion that it ran.
         for (i, pair) in self.lines.windows(2).enumerate() {
             if pair[1].continues && pair[1].containers != pair[0].containers {
                 return Err(Invariant::ContinuesAcrossContainers { line: i + 1 });
             }
+            if pair[1].continues && pair[1].kind != pair[0].kind {
+                return Err(Invariant::ContinuesAcrossKinds { line: i + 1 });
+            }
         }
-        // Only the formatting-mark edge test below reads it.
-        let chars: Vec<char> = if self.marks.iter().any(|m| m.kind.is_formatting()) {
+        // Only the formatting-mark tests below read these two.
+        let formatting = self.marks.iter().any(|m| m.kind.is_formatting());
+        let chars: Vec<char> = if formatting {
             self.text.chars().collect()
+        } else {
+            Vec::new()
+        };
+        let code = if formatting {
+            code_ranges(&self.text, &self.lines)
         } else {
             Vec::new()
         };
@@ -1034,6 +1091,13 @@ impl Content {
                 }
                 if m.end > m.start && chars.get(m.end - 1) == Some(&'\n') {
                     return Err(Invariant::MarkEdgeOnNewline { at: m.end - 1 });
+                }
+            }
+            if m.kind.is_formatting() {
+                if let Some(&(s, _)) = code.iter().find(|(s, e)| *s < m.end && m.start < *e) {
+                    return Err(Invariant::FormattingOverCode {
+                        at: m.start.max(s),
+                    });
                 }
             }
             match &m.kind {
@@ -1213,6 +1277,52 @@ fn canonicalize_containers(lines: &mut [Line]) {
     }
 }
 
+/// The USV ranges the [`LineKind::Code`] lines' text occupies, ascending and
+/// disjoint: a `\n` boundary belongs to no segment, so two adjacent code lines
+/// are two ranges. Empty segments carry no range.
+pub(crate) fn code_ranges(text: &str, lines: &[Line]) -> Vec<(Usv, Usv)> {
+    let mut out = Vec::new();
+    let mut at: Usv = 0;
+    for (line, seg) in lines.iter().zip(text.split('\n')) {
+        let len = seg.chars().count();
+        if len > 0 && matches!(line.kind, LineKind::Code { .. }) {
+            out.push((at, at + len));
+        }
+        at += len + 1;
+    }
+    out
+}
+
+/// Every formatting mark minus `code`, identity marks passed through. A mark
+/// wholly inside a fence yields no piece at all; one spanning it yields its two
+/// prose sides.
+pub(crate) fn clip_formatting(marks: Vec<Mark>, code: &[(Usv, Usv)]) -> Vec<Mark> {
+    let mut out = Vec::with_capacity(marks.len());
+    for m in marks {
+        if !m.kind.is_formatting() {
+            out.push(m);
+            continue;
+        }
+        let mut cursor = m.start;
+        for &(s, e) in code {
+            if e <= cursor || s >= m.end {
+                continue;
+            }
+            if s > cursor {
+                out.push(Mark::new(cursor, s, m.kind.clone()));
+            }
+            cursor = e;
+            if cursor >= m.end {
+                break;
+            }
+        }
+        if cursor < m.end {
+            out.push(Mark::new(cursor, m.end, m.kind));
+        }
+    }
+    out
+}
+
 pub(crate) fn normalize_marks(marks: Vec<Mark>) -> Vec<Mark> {
     use std::collections::BTreeMap;
 
@@ -1389,6 +1499,101 @@ mod tests {
         }];
         rt.normalize();
         assert_eq!(rt.lines[0].kind, LineKind::Island);
+        assert_eq!(rt.validate(), Ok(()));
+    }
+
+    /// `normalize` writes the head's kind onto a continuation, `lang` included,
+    /// and `validate` asserts that ran.
+    #[test]
+    fn normalize_gives_a_continuation_its_head_s_kind() {
+        let code = |lang: Option<&str>| LineKind::Code {
+            lang: lang.map(str::to_string),
+        };
+        let mut rt = Content::new(
+            "a\nb\nc".into(),
+            vec![
+                Line::new(code(Some("rust"))),
+                Line::new(LineKind::Para).with_continues(true),
+                Line::new(code(Some("typ"))).with_continues(true),
+            ],
+        );
+        assert_eq!(
+            rt.validate(),
+            Err(Invariant::ContinuesAcrossKinds { line: 1 })
+        );
+        rt.normalize();
+        assert!(rt.lines.iter().all(|l| l.kind == code(Some("rust"))));
+        assert_eq!(rt.validate(), Ok(()));
+
+        // A head whose kind the continuation's own text contradicts absorbs
+        // nothing: the flag goes instead of the kind.
+        let mut rt = Content::new(
+            format!("code\n{ISLAND_SLOT}"),
+            vec![
+                Line::new(code(None)),
+                Line::new(LineKind::Island).with_continues(true),
+            ],
+        );
+        rt.islands = vec![Island {
+            id: "isl-0".into(),
+            island_type: "image".into(),
+            props: serde_json::json!({"alt": "x", "url": "y.png"}),
+            loss: Loss::LOSSLESS,
+        }];
+        rt.normalize();
+        assert!(!rt.lines[1].continues);
+        assert_eq!(rt.lines[1].kind, LineKind::Island);
+        assert_eq!(rt.validate(), Ok(()));
+    }
+
+    /// A demoted head is demoted before it is inherited, so one pass reaches the
+    /// fixed point.
+    #[test]
+    fn continuation_inheritance_is_idempotent_over_a_demoted_head() {
+        let mut rt = Content::new(
+            "text on a rule line\n".into(),
+            vec![
+                Line::new(LineKind::Rule),
+                Line::new(LineKind::Heading { level: 2 }).with_continues(true),
+            ],
+        );
+        rt.normalize();
+        let once = rt.lines.clone();
+        rt.normalize();
+        assert_eq!(rt.lines, once);
+        assert_eq!(rt.lines[0].kind, LineKind::Para);
+        assert_eq!(rt.lines[1].kind, LineKind::Para);
+        assert_eq!(rt.validate(), Ok(()));
+    }
+
+    /// A formatting mark over a fence is a range no projection carries: the
+    /// prose sides survive the clip, the code middle does not.
+    #[test]
+    fn normalize_clips_formatting_off_code_text() {
+        let fence = || LineKind::Code { lang: None };
+        let mut rt = Content::new(
+            "pre\ncode\npost".into(),
+            vec![
+                Line::new(LineKind::Para),
+                Line::new(fence()),
+                Line::new(LineKind::Para),
+            ],
+        );
+        rt.marks = vec![f(0, 13, MarkKind::Strong), f(5, 7, MarkKind::Emph)];
+        assert_eq!(rt.validate(), Err(Invariant::FormattingOverCode { at: 4 }));
+        rt.normalize();
+        assert_eq!(
+            rt.marks,
+            vec![f(0, 3, MarkKind::Strong), f(9, 13, MarkKind::Strong)],
+            "the emph was wholly inside the fence"
+        );
+        assert_eq!(rt.validate(), Ok(()));
+
+        // An anchor is identity, not formatting: a comment on a code line holds.
+        let mut rt = Content::new("code".into(), vec![Line::new(fence())]);
+        rt.marks = vec![f(2, 2, MarkKind::Anchor { id: "c1".into() })];
+        rt.normalize();
+        assert_eq!(rt.marks.len(), 1);
         assert_eq!(rt.validate(), Ok(()));
     }
 

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -331,6 +331,14 @@ pub enum ApplyError {
     /// its container path differs from the previous line's, and a within-block
     /// break lives inside one container.
     ContinuesAcrossContainers { line: usize },
+    /// [`LineOp::SetContinues`] would continue a block with a line of another
+    /// [`LineKind`]: every projection reads a block's role off its head, so the
+    /// continuation's own kind would be a value nothing renders.
+    ContinuesAcrossKinds { line: usize },
+    /// A [`MarkOp::Add`] of a formatting mark reaching into a
+    /// [`LineKind::Code`] line's text, which every projection emits verbatim.
+    /// `at` is the first covered code position.
+    FormattingOverCode { at: Usv },
     /// The text delta's expected base length disagreed with the content:
     /// it was built against a different revision.
     DeltaBaseMismatch {
@@ -480,6 +488,17 @@ impl Content {
                             end: *end,
                             len,
                         });
+                    }
+                    // A fence emits its text verbatim in every projection, so a
+                    // formatting range inside one is a write with no reader.
+                    // The incidental crossing — a splice or a `SetKind` that
+                    // moves a fence under a live mark — is `normalize`'s to
+                    // clip.
+                    if kind.is_formatting() {
+                        let code = crate::model::code_ranges(&self.text, &self.lines);
+                        if let Some(&(s, _)) = code.iter().find(|(s, e)| *s < *end && *start < *e) {
+                            return Err(ApplyError::FormattingOverCode { at: (*start).max(s) });
+                        }
                     }
                     if let MarkKind::Anchor { id } = kind {
                         if id.is_empty() {
@@ -660,6 +679,18 @@ impl Content {
                             .is_some_and(|(l, prev)| l.containers != prev.containers)
                     {
                         return Err(ApplyError::ContinuesAcrossContainers { line: *line });
+                    }
+                    // And the same refusal for the role: a block's kind is its
+                    // head's, so continuing one with a line of another kind
+                    // asks for a reading no projection has.
+                    if *continues
+                        && self
+                            .lines
+                            .get(*line)
+                            .zip(self.lines.get(line.wrapping_sub(1)))
+                            .is_some_and(|(l, prev)| l.kind != prev.kind)
+                    {
+                        return Err(ApplyError::ContinuesAcrossKinds { line: *line });
                     }
                     let l = self.line_mut(*line)?;
                     l.continues = *continues;
@@ -1342,6 +1373,72 @@ mod tests {
             Ok(())
         );
         assert!(rt.lines[1].continues);
+    }
+
+    /// The role half of the same pairing. The incidental crossing — a `SetKind`
+    /// under a live `continues` — is `normalize`'s.
+    #[test]
+    fn set_continues_across_a_line_kind_is_refused() {
+        let mut rt = from_markdown("```\ncode\n```\n\npara").unwrap();
+        let para = rt
+            .lines
+            .iter()
+            .position(|l| l.kind == LineKind::Para)
+            .expect("the paragraph is there");
+        assert_eq!(
+            rt.apply_line_ops(&[LineOp::SetContinues {
+                line: para,
+                continues: true
+            }]),
+            Err(ApplyError::ContinuesAcrossKinds { line: para })
+        );
+
+        let mut rt = from_markdown("a\\\nb").unwrap();
+        assert!(rt.lines[1].continues);
+        assert!(rt
+            .apply_line_ops(&[LineOp::SetKind {
+                line: 0,
+                kind: LineKind::Heading { level: 2 },
+            }])
+            .is_ok());
+        assert_eq!(rt.lines[1].kind, LineKind::Heading { level: 2 });
+        assert_eq!(rt.validate(), Ok(()));
+    }
+
+    /// A formatting mark inside a fence has no reader, so the deliberate write
+    /// is refused; the incidental one — a `SetKind` fencing marked prose — is
+    /// clipped by `normalize`.
+    #[test]
+    fn mark_op_add_over_code_text_is_refused() {
+        let mut rt = from_markdown("```\ncode\n```").unwrap();
+        assert_eq!(
+            rt.apply_mark_ops(&[MarkOp::Add {
+                start: 1,
+                end: 3,
+                kind: MarkKind::Strong,
+            }]),
+            Err(ApplyError::FormattingOverCode { at: 1 })
+        );
+        assert_eq!(
+            rt.apply_mark_ops(&[MarkOp::Add {
+                start: 1,
+                end: 3,
+                kind: MarkKind::Anchor { id: "c1".into() },
+            }]),
+            Ok(()),
+            "an anchor is identity, and a comment on a code line holds"
+        );
+
+        let mut rt = from_markdown("**bold**").unwrap();
+        assert_eq!(rt.marks.len(), 1);
+        assert!(rt
+            .apply_line_ops(&[LineOp::SetKind {
+                line: 0,
+                kind: LineKind::Code { lang: None },
+            }])
+            .is_ok());
+        assert!(rt.marks.is_empty());
+        assert_eq!(rt.validate(), Ok(()));
     }
 
     /// A `Join` merging two lines of differing paths leaves the line after the

--- a/prose/canon/CONVERT.md
+++ b/prose/canon/CONVERT.md
@@ -31,6 +31,12 @@ tree over `lines`; the inline pass sweeps `marks` and islands within each line.
 A **segment** is a maximal run of lines joined by `Line::continues`: one
 paragraph, one heading, one whole code fence, one island line. It is what
 "paragraph-level" means against the content, and the unit a region keys on.
+Its role is its **head** line's: this walk, the Markdown export and the
+editor's fold each read `kind` off the line that opens the segment and off no
+other, down to the `lang` one fence carries. So a continuation's `kind` is the
+head's by construction — `Content::normalize` writes it there, dropping the
+flag instead where the head's kind contradicts the continuation's own text, and
+`Invariant::ContinuesAcrossKinds` asserts that ran.
 
 ## Escape functions
 
@@ -103,6 +109,15 @@ block-level discipline.
 **Every generated line opens at the enclosing list depth**, two spaces per item.
 Typst ends a list at a block written to column 0, so one emitter rule indents
 leaves and containers alike: what the content nests, the markup nests.
+
+**A fence's text carries no formatting.** `#raw` takes one string literal, the
+Markdown fence emits its lines verbatim, and the editor's `code_block` declares
+`marks: ''`, so a `Strong` over a code line is a range with no reader anywhere.
+`Content::normalize` clips one off: a mark spanning a fence keeps its prose
+sides, one wholly inside keeps nothing, and `Invariant::FormattingOverCode`
+asserts that ran. An identity mark is untouched: an anchor on a code line is a
+comment thread the editor draws as a decoration, and this lowering emits nothing
+for one anywhere.
 
 Anchor and unknown marks emit nothing; unknown island types emit nothing
 (parallel to the HTML rule at import). An unknown line kind lowers as a


### PR DESCRIPTION
Two shapes the content model carried that no projection reads. Both land where quillmark-js#501 filed them as open: the store, not the codec.

## A continuation's line kind is its head's

`export::emit_leaf_block`, the Typst `emit_segment` and the editor's fold each take a segment's role off the line that opens it and off no other (`traverse::segment` gathers the run by `continues` and depth, never by kind). So a `continues` line carrying a kind of its own carried a value nothing renders, down to a `lang` that disagreed along one fence.

`normalize` writes the head's kind onto it, and drops the flag instead where the head's kind contradicts the continuation's own text — a line the head cannot absorb is no continuation of it. It runs after the existing demotion pass, so the kind inherited is one its head keeps, and one pass reaches the fixed point.

`validate` gains `Invariant::ContinuesAcrossKinds`, beside `ContinuesAcrossContainers`; `LineOp::SetContinues` refuses the deliberate mismatch with `ApplyError::ContinuesAcrossKinds`.

## A formatting mark stops at a code line

The Markdown fence emits its lines verbatim, the Typst lowering puts them in one `#raw` string literal, and the editor's `code_block` declares `marks: ''`. A `Strong` over code text was stored, read back, and removed by the first edit anywhere in the field: surviving a read was the whole of what it did.

`normalize` clips it — a mark spanning a fence keeps its prose sides, one wholly inside keeps nothing — before the `\n` edge trim, so the cut edges land off the fence's boundaries. Identity marks are untouched: an anchor on a code line is a comment thread the editor draws as a decoration.

`validate` gains `Invariant::FormattingOverCode`; `MarkOp::Add` refuses the deliberate write with `ApplyError::FormattingOverCode`.

## Shape

Both follow the split the model already makes: `normalize` repairs the incidental crossing, `validate` asserts the repair ran, the op channel refuses the deliberate one.

Neither rule moves a shape `from_markdown` produces — markdown cannot bold inside a fence, and `push_code_content` already gives every line of a block the head's kind — so imported and stored content normalizes unchanged. `ApplyError` maps to one code (`edit::content_apply`) with no args, so the added variants are transparent at the boundary.

## Verification

`cargo test --workspace` green (62 binaries), including the `properties.rs` proptests over `apply_line_ops` / `apply_mark_ops` / `apply_text_delta` preserving `validate`, and the container canonical-form fixed-point suites. Five new tests cover the two normalize repairs, the demoted-head idempotence case, and both op refusals with their incidental counterparts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXRmT1mc9ebTMpTz5HCL68

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXRmT1mc9ebTMpTz5HCL68)_