### PR TITLE
fix(core): validate refuses only what the render floor refuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
   the render door validated the *coerced* one, so five of seven types had values
   that rendered and were fatally `validation::type_mismatch` at once — a bare
   scalar for an `array`, `"3"` for an `integer`, `1` for a `boolean`, a
-  length-1 array for a `string` or `date`. `airmark`'s `usaf_memo@0.2` starter
-  template wrote `letterhead_caption` as a bare scalar, and every document
-  seeded from it audited as fatally invalid while rendering correctly.
+  length-1 array for a `string` or `date`. `airmark`'s `usaf_memo@0.2` declares
+  `letterhead_caption` as an `array`, and the bare scalar a starter template
+  spells it with — a valid spelling of a one-element list — audited as fatally
+  invalid across every document seeded from it, each rendering correctly.
 
   `validate_value` now conforms each document value through `conform_value` at
   `Leniency::Render` before judging it, so a type has one predicate and **a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## Unreleased
+
+- fix(core): **`Quill::validate` refuses only what the render floor refuses.**
+  Validation ran its own read-side type dispatch over the authored value while
+  the render door validated the *coerced* one, so five of seven types had values
+  that rendered and were fatally `validation::type_mismatch` at once — a bare
+  scalar for an `array`, `"3"` for an `integer`, `1` for a `boolean`, a
+  length-1 array for a `string` or `date`. `airmark`'s `usaf_memo@0.2` starter
+  template wrote `letterhead_caption` as a bare scalar, and every document
+  seeded from it audited as fatally invalid while rendering correctly.
+
+  `validate_value` now conforms each document value through `conform_value` at
+  `Leniency::Render` before judging it, so a type has one predicate and **a
+  fatal `validation::*` diagnostic means the document does not render**.
+  Conforming runs per node, so one refused element no longer mistypes its
+  siblings: `counts: [true, "abc"]` under `integer` items is one mismatch, at
+  `counts[1]`. Two consequences for a consumer routing on codes: a value the
+  floor adopts raises nothing where it previously raised
+  `validation::type_mismatch`, and a bare scalar the floor stringifies into an
+  `enum` field is now domain-checked on that string, so `grade: 5` against
+  `values: [alpha, beta]` is `validation::enum_violation` where it was
+  previously silent — the diagnostic the render door already raised. Schema
+  literals (`example:`, `default:`) stay strict.
+
 ## v0.109.1 - 2026-08-24
 
 - fix(typst): **a `field-region` claim around inline content no longer widens

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -219,6 +219,13 @@ impl Quill {
     /// `validation::must_fill` warning, the only non-fatal one; the rest are
     /// blockers.
     ///
+    /// **A blocker here means the document does not render.** Values are judged
+    /// in the form the render floor builds from them, so a bare scalar for an
+    /// `array`, `"3"` for an `integer`, or a length-1 array for a `string` are
+    /// valid: what an author may write is one question, answered by the floor
+    /// (`conform_value` at `Leniency::Render`), and every surface asks it. The
+    /// leniencies are listed under `prose/canon/SCHEMAS.md` §"Type coercion".
+    ///
     /// `validation::must_fill` has **two triggers**, covering disjoint failures
     /// under one code: a `!must_fill` marker the document carries
     /// (`validate_fills`), and a schema-side must-fill cell nobody authored

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -220,11 +220,10 @@ impl Quill {
     /// blockers.
     ///
     /// **A blocker here means the document does not render.** Values are judged
-    /// in the form the render floor builds from them, so a bare scalar for an
-    /// `array`, `"3"` for an `integer`, or a length-1 array for a `string` are
-    /// valid: what an author may write is one question, answered by the floor
-    /// (`conform_value` at `Leniency::Render`), and every surface asks it. The
-    /// leniencies are listed under `prose/canon/SCHEMAS.md` §"Type coercion".
+    /// in the form the render floor builds from them (`conform_value` at
+    /// `Leniency::Render`), so a bare scalar for an `array`, `"3"` for an
+    /// `integer`, and a length-1 array for a `string` are valid. The leniencies
+    /// are listed under `prose/canon/SCHEMAS.md` §"Type coercion".
     ///
     /// `validation::must_fill` has **two triggers**, covering disjoint failures
     /// under one code: a `!must_fill` marker the document carries

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -301,9 +301,12 @@ impl QuillConfig {
     /// `Write` is the strict typed-write commit driving
     /// [`Card::commit_field`](crate::document::Card::commit_field).
     ///
-    /// Validation keeps its own read-only dispatch (`validation::validate_value`),
-    /// synced with this via the shared helpers `scalar_as_string` /
-    /// `Codec::Richtext.decode_value`.
+    /// The **one** per-type dispatch: `validation::validate_value` conforms a
+    /// document value through here at `Render` before judging it, so a type has
+    /// one predicate rather than a write-side and a read-side pair to keep in
+    /// step. What validation adds is the arbitration this cannot carry — the
+    /// enum domain, the datetime grammar, indexed element paths — over the value
+    /// the floor built.
     pub(crate) fn conform_value(
         value: &QuillValue,
         field_schema: &super::FieldSchema,

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -295,18 +295,16 @@ impl QuillConfig {
         super::validation::validate_typed_document(self, doc)
     }
 
-    /// The one write-side per-type dispatch: given a value, a field's schema,
-    /// and a [`Leniency`] mode, validate/normalize the value to the canonical
-    /// form the type stores. `Render` is the render floor's forgiving coercion;
-    /// `Write` is the strict typed-write commit driving
+    /// The one per-type dispatch: given a value, a field's schema, and a
+    /// [`Leniency`] mode, validate/normalize the value to the canonical form the
+    /// type stores. `Render` is the render floor's forgiving coercion; `Write`
+    /// is the strict typed-write commit driving
     /// [`Card::commit_field`](crate::document::Card::commit_field).
     ///
-    /// The **one** per-type dispatch: `validation::validate_value` conforms a
-    /// document value through here at `Render` before judging it, so a type has
-    /// one predicate rather than a write-side and a read-side pair to keep in
-    /// step. What validation adds is the arbitration this cannot carry — the
-    /// enum domain, the datetime grammar, indexed element paths — over the value
-    /// the floor built.
+    /// `validation::validate_value` conforms a document value through here at
+    /// `Render` before judging it, so a type has one predicate. What validation
+    /// adds is the arbitration this cannot carry — the enum domain, the datetime
+    /// grammar, indexed element paths — over the value the floor built.
     pub(crate) fn conform_value(
         value: &QuillValue,
         field_schema: &super::FieldSchema,

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -428,16 +428,12 @@ enum ValueContext {
 /// recursing into array elements / object properties. `ctx` selects the few
 /// document-only behaviors (see [`ValueContext`]).
 ///
-/// A document value is judged in the form the render floor would build from it,
-/// not as authored: `conform_value` at `Leniency::Render` runs first and its
-/// result is the subject of every check below. Validity is therefore
-/// renderability, and `Quill::validate` cannot refuse a document `compile_data`
-/// accepts. A value the floor itself refuses is judged as authored, where the
-/// type check reports it; conforming per node rather than per field keeps one
-/// refused element from mistyping its siblings.
-///
-/// A variant-bearing field is peeled before this, as `conform_value` peels it,
-/// so its bare-scalar spelling reports at its own path.
+/// A document value is judged in the form the render floor builds from it, not
+/// as authored: `conform_value` at `Leniency::Render` runs first. Validity is
+/// therefore renderability — `Quill::validate` cannot refuse a document
+/// `compile_data` accepts. A value the floor refuses is judged as authored,
+/// where the type check reports it. Conforming runs per node rather than per
+/// field, so one refused element does not mistype its siblings.
 ///
 /// Schema literals are judged as written: an `example:`/`default:` is the
 /// blueprint's own text, and coercing it would let the blueprint emit a
@@ -455,11 +451,10 @@ fn validate_value(
         return vec![];
     }
 
-    // Peeled before conforming, as `conform_value` peels it: the floor would
-    // normalize the bare scalar (`classification: CUI`) into its container, and
-    // the domain violation would then report at `<path>.value`, a key the author
-    // never wrote. `validate_variant` reads both shapes and conforms each live
-    // cell through the recursion below.
+    // Peeled before conforming, as `conform_value` peels it: the floor turns the
+    // bare scalar (`classification: CUI`) into its container, which would move a
+    // domain violation to `<path>.value`, a key the author never wrote.
+    // `validate_variant` reads both shapes and conforms each live cell.
     if field.is_variant_bearing() {
         return validate_variant(field, value, path, ctx);
     }

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -427,6 +427,21 @@ enum ValueContext {
 /// `path`, checking type compatibility, enum membership, datetime format, and
 /// recursing into array elements / object properties. `ctx` selects the few
 /// document-only behaviors (see [`ValueContext`]).
+///
+/// A document value is judged in the form the render floor would build from it,
+/// not as authored: `conform_value` at `Leniency::Render` runs first and its
+/// result is the subject of every check below. Validity is therefore
+/// renderability, and `Quill::validate` cannot refuse a document `compile_data`
+/// accepts. A value the floor itself refuses is judged as authored, where the
+/// type check reports it; conforming per node rather than per field keeps one
+/// refused element from mistyping its siblings.
+///
+/// A variant-bearing field is peeled before this, as `conform_value` peels it,
+/// so its bare-scalar spelling reports at its own path.
+///
+/// Schema literals are judged as written: an `example:`/`default:` is the
+/// blueprint's own text, and coercing it would let the blueprint emit a
+/// spelling it then teaches authors to write.
 fn validate_value(
     field: &FieldSchema,
     value: &QuillValue,
@@ -440,35 +455,39 @@ fn validate_value(
         return vec![];
     }
 
+    // Peeled before conforming, as `conform_value` peels it: the floor would
+    // normalize the bare scalar (`classification: CUI`) into its container, and
+    // the domain violation would then report at `<path>.value`, a key the author
+    // never wrote. `validate_variant` reads both shapes and conforms each live
+    // cell through the recursion below.
     if field.is_variant_bearing() {
         return validate_variant(field, value, path, ctx);
     }
 
+    let conformed = match ctx {
+        ValueContext::Document => super::QuillConfig::conform_value(
+            value,
+            field,
+            &path.to_string(),
+            super::config::Leniency::Render,
+        )
+        .ok(),
+        ValueContext::SchemaLiteral => None,
+    };
+    let value = conformed.as_ref().unwrap_or(value);
+
     let mut errors = Vec::new();
 
     let type_valid = match field.r#type {
-        // In a document a bare bool/number is type-valid as a string (the
-        // coercion layer adopts it): in lockstep with `conform_value`
-        // via `scalar_as_string`. Schema literals stay strict so the blueprint
-        // keeps quoting ambiguous string literals.
         // Enum is string-valued data (domain membership is checked separately
         // below), so it is type-valid exactly where a string is.
-        FieldType::String | FieldType::Enum => {
-            value.as_str().is_some()
-                || (ctx == ValueContext::Document
-                    && super::config::scalar_as_string(value.as_json()).is_some())
-        }
-        // Post-coercion (Document) a richtext/plaintext value is a canonical
-        // content object; an authored `default`/`example` (Schema) is a string
-        // (markdown for richtext, literal for plaintext). Accept both shapes:
-        // the content's own invariants were enforced at coercion, and a bare
-        // scalar still stringifies. The plaintext-specific plain constraint is
+        FieldType::String | FieldType::Enum => value.as_str().is_some(),
+        // A conformed richtext/plaintext value is a canonical content object;
+        // an authored `default`/`example` is a string (markdown for richtext,
+        // literal for plaintext). The plaintext-specific plain constraint is
         // checked in the shape pass below, parallel to the inline check.
         FieldType::RichText { .. } | FieldType::PlainText { .. } => {
-            value.as_json().is_object()
-                || value.as_str().is_some()
-                || (ctx == ValueContext::Document
-                    && super::config::scalar_as_string(value.as_json()).is_some())
+            value.as_json().is_object() || value.as_str().is_some()
         }
         FieldType::Integer => {
             let json = value.as_json();
@@ -644,10 +663,11 @@ fn validate_value(
 /// downstream reads it (`Quill::validate` reports it as
 /// `validation::out_of_variant`, a warning).
 ///
-/// Both authored shapes reach here, because validation runs before coercion: the
-/// bare scalar (`classification: CUI`) and the container. The scalar is checked
-/// as the discriminant it stands for, at the container's own path — the path an
-/// author who wrote a scalar can act on.
+/// Both authored shapes reach here: the container, and the bare scalar
+/// (`classification: CUI`) a schema literal rests in and a document value the
+/// floor refused falls back to. The scalar is checked as the discriminant it
+/// stands for, at the container's own path — the path an author who wrote a
+/// scalar can act on.
 fn validate_variant(
     field: &FieldSchema,
     value: &QuillValue,

--- a/crates/quillmark/tests/validate_test.rs
+++ b/crates/quillmark/tests/validate_test.rs
@@ -111,3 +111,199 @@ fn validate_warns_on_must_fill_marker() {
          got paths: {marked:?}"
     );
 }
+
+/// The render floor's leniencies, one per row of the type table. A value the
+/// floor adopts is valid; `validate` and the render door give one verdict.
+const LENIENT: &str = r#"
+quill:
+  name: lenient
+  version: "1.0"
+  backend: typst
+  description: Render-floor leniencies
+
+main:
+  fields:
+    caption:
+      type: array
+      items:
+        type: string
+    verified:
+      type: boolean
+    count:
+      type: integer
+    ratio:
+      type: number
+    heading:
+      type: string
+    grade:
+      type: enum
+      values: [alpha, beta]
+    signed_on:
+      type: date
+    prose:
+      type: richtext
+    literal:
+      type: plaintext
+"#;
+
+fn lenient_doc(fields: &str) -> Document {
+    let md = format!("~~~card-yaml\n$quill: lenient\n$kind: main\n{fields}~~~\n");
+    Document::parse(&md).unwrap().document
+}
+
+#[test]
+fn validate_accepts_every_value_the_render_floor_adopts() {
+    let quill = quill_from_yaml(LENIENT);
+    // Row by row: a bare scalar for an array, a number for a boolean, numeric
+    // strings for integer/number, a bare scalar and a length-1 array for a
+    // string, a length-1 array for a date, a bare scalar for content.
+    let doc = lenient_doc(
+        "caption: DEPARTMENT OF THE AIR FORCE\n\
+         verified: 1\n\
+         count: \"3\"\n\
+         ratio: \"1.5\"\n\
+         heading: [ONE LINE]\n\
+         grade: alpha\n\
+         signed_on: [\"2026-08-25\"]\n\
+         prose: 7\n\
+         literal: true\n",
+    );
+
+    let diags = quill.validate(&doc);
+    assert!(
+        diags.is_empty(),
+        "every value here is one the render floor adopts; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (&d.code, &d.path))
+            .collect::<Vec<_>>()
+    );
+    assert!(quill.dry_run(&doc).is_ok(), "and the render door agrees");
+}
+
+#[test]
+fn validate_refuses_what_the_render_floor_refuses() {
+    let quill = quill_from_yaml(LENIENT);
+    // A non-numeric string, a word that is not a boolean, and an object where
+    // the type cannot stringify one: no floor adopts these, so each is fatal.
+    for (field, value) in [
+        ("count", "not-a-number"),
+        ("ratio", "not-a-number"),
+        ("verified", "yes"),
+    ] {
+        let doc = lenient_doc(&format!("{field}: \"{value}\"\n"));
+        let diags = quill.validate(&doc);
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.code.as_deref() == Some("validation::type_mismatch")
+                    && d.path.as_deref() == Some(&format!("main.{field}")[..])),
+            "`{field}: {value}` should be a type_mismatch; got: {:?}",
+            diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+        );
+        assert!(
+            quill.dry_run(&doc).is_err(),
+            "`{field}: {value}` does not render either"
+        );
+    }
+
+    let doc = lenient_doc("heading:\n  a: 1\n");
+    assert!(
+        quill
+            .validate(&doc)
+            .iter()
+            .any(|d| d.code.as_deref() == Some("validation::type_mismatch")
+                && d.path.as_deref() == Some("main.heading")),
+        "an object is not a string the floor can build"
+    );
+    assert!(quill.dry_run(&doc).is_err());
+}
+
+#[test]
+fn validate_reports_a_refused_element_without_mistyping_its_siblings() {
+    let quill = quill_from_yaml(
+        r#"
+quill:
+  name: elems
+  version: "1.0"
+  backend: typst
+  description: element-wise conformance
+main:
+  fields:
+    counts:
+      type: array
+      items:
+        type: integer
+"#,
+    );
+    // `true` is a value the floor adopts for an integer; `"abc"` is not.
+    let md = "~~~card-yaml\n$quill: elems\n$kind: main\ncounts: [true, \"abc\"]\n~~~\n";
+    let doc = Document::parse(md).unwrap().document;
+
+    let mismatched: Vec<_> = quill
+        .validate(&doc)
+        .into_iter()
+        .filter(|d| d.code.as_deref() == Some("validation::type_mismatch"))
+        .filter_map(|d| d.path)
+        .collect();
+    assert_eq!(
+        mismatched,
+        vec!["main.counts[1]".to_string()],
+        "only the element the floor refused is a mismatch"
+    );
+}
+
+#[test]
+fn validate_checks_the_enum_domain_of_a_scalar_the_floor_stringifies() {
+    let quill = quill_from_yaml(LENIENT);
+    // `5` reaches the render floor as the string `"5"`, which is out of domain:
+    // the value error the floor's own validation raises, raised here too.
+    let doc = lenient_doc("grade: 5\n");
+
+    let diags = quill.validate(&doc);
+    let diag = diags
+        .iter()
+        .find(|d| d.code.as_deref() == Some("validation::enum_violation"))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected enum_violation; got: {:?}",
+                diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+            )
+        });
+    assert_eq!(diag.path.as_deref(), Some("main.grade"));
+    assert!(quill.dry_run(&doc).is_err());
+}
+
+#[test]
+fn validate_reports_a_bare_variant_scalar_at_the_path_its_author_wrote() {
+    let quill = quill_from_yaml(
+        r#"
+quill:
+  name: variants
+  version: "1.0"
+  backend: typst
+  description: variant-bearing enum
+main:
+  fields:
+    classification:
+      type: enum
+      values: [cui, secret]
+      default: ""
+      variants:
+        cui:
+          caveat:
+            type: string
+"#,
+    );
+    // The bare scalar is the spelling of a world with nothing filled in. The
+    // floor normalizes it into `{value: …}`; the diagnostic names the field.
+    let md = "~~~card-yaml\n$quill: variants\n$kind: main\nclassification: bogus\n~~~\n";
+    let doc = Document::parse(md).unwrap().document;
+
+    let diag = quill
+        .validate(&doc)
+        .into_iter()
+        .find(|d| d.code.as_deref() == Some("validation::enum_violation"))
+        .expect("expected an enum_violation");
+    assert_eq!(diag.path.as_deref(), Some("main.classification"));
+}

--- a/crates/quillmark/tests/validate_test.rs
+++ b/crates/quillmark/tests/validate_test.rs
@@ -154,9 +154,6 @@ fn lenient_doc(fields: &str) -> Document {
 #[test]
 fn validate_accepts_every_value_the_render_floor_adopts() {
     let quill = quill_from_yaml(LENIENT);
-    // Row by row: a bare scalar for an array, a number for a boolean, numeric
-    // strings for integer/number, a bare scalar and a length-1 array for a
-    // string, a length-1 array for a date, a bare scalar for content.
     let doc = lenient_doc(
         "caption: DEPARTMENT OF THE AIR FORCE\n\
          verified: 1\n\
@@ -184,8 +181,7 @@ fn validate_accepts_every_value_the_render_floor_adopts() {
 #[test]
 fn validate_refuses_what_the_render_floor_refuses() {
     let quill = quill_from_yaml(LENIENT);
-    // A non-numeric string, a word that is not a boolean, and an object where
-    // the type cannot stringify one: no floor adopts these, so each is fatal.
+    // No floor adopts these.
     for (field, value) in [
         ("count", "not-a-number"),
         ("ratio", "not-a-number"),
@@ -256,8 +252,7 @@ main:
 #[test]
 fn validate_checks_the_enum_domain_of_a_scalar_the_floor_stringifies() {
     let quill = quill_from_yaml(LENIENT);
-    // `5` reaches the render floor as the string `"5"`, which is out of domain:
-    // the value error the floor's own validation raises, raised here too.
+    // `5` reaches the render floor as the string `"5"`, which is out of domain.
     let doc = lenient_doc("grade: 5\n");
 
     let diags = quill.validate(&doc);
@@ -295,8 +290,8 @@ main:
             type: string
 "#,
     );
-    // The bare scalar is the spelling of a world with nothing filled in. The
-    // floor normalizes it into `{value: …}`; the diagnostic names the field.
+    // The floor normalizes the bare scalar into `{value: …}`; the diagnostic
+    // names the field the author wrote, not the key the floor minted.
     let md = "~~~card-yaml\n$quill: variants\n$kind: main\nclassification: bogus\n~~~\n";
     let doc = Document::parse(md).unwrap().document;
 

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -91,8 +91,7 @@ families:
   surface; the render pipeline blank-fills instead of warning on incomplete
   documents. A **fatal** row here means the document does not render: values
   are judged in the form the render floor builds from them
-  ([SCHEMAS.md](SCHEMAS.md) § "Type coercion"), so this surface and the render
-  door give one verdict.
+  ([SCHEMAS.md](SCHEMAS.md) § "Type coercion").
 - **`plate::unsupported_construct`: declined-construct warnings.** A quill
   names, per body (`BodyCardSchema.unsupported`), the block constructs its
   plate does not typeset; `Quill::unsupported_constructs` walks a document's

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -82,12 +82,17 @@ families:
   is repairable. The walk is stateless, so a repeat conform re-emits the
   identical set. Its scope is the content fields: a field whose type tree bears
   no content leaf never enters the walk, so a scalar the strict write would
-  refuse raises no `conform::*` warning and reaches `validation::*` instead.
+  refuse raises no `conform::*` warning. It reaches `validation::*` only if the
+  *render floor* also refuses it (`validation::type_mismatch`); the floor is
+  more lenient than the write, and what it adopts is valid.
 - **Validation warnings**: `Quill::validate(doc)` returns every
   `validation::*` diagnostic, mixing severities; `validation::must_fill` and
   the `$seed` checks are the non-fatal ones. This is the editor-facing
   surface; the render pipeline blank-fills instead of warning on incomplete
-  documents.
+  documents. A **fatal** row here means the document does not render: values
+  are judged in the form the render floor builds from them
+  ([SCHEMAS.md](SCHEMAS.md) § "Type coercion"), so this surface and the render
+  door give one verdict.
 - **`plate::unsupported_construct`: declined-construct warnings.** A quill
   names, per body (`BodyCardSchema.unsupported`), the block constructs its
   plate does not typeset; `Quill::unsupported_constructs` walks a document's
@@ -340,7 +345,7 @@ Three outcomes, and the wire tells them apart only with this table in hand, sinc
 
 `parse::missing_quill` looks code-determined and is not: it picks one of three sentences by re-reading the source, and no field records which.
 
-Every `conform::*` row is reachable only through the content-field walk, so the family is narrower than its `edit::*` twin. `conform::field_coercion_failed` fires for a scalar nested inside a content-bearing field: an `array` of `richtext`, an `object` with a `richtext` property. A top-level scalar never reaches it, and its refusal surfaces as `validation::format_violation` or `validation::type_mismatch`.
+Every `conform::*` row is reachable only through the content-field walk, so the family is narrower than its `edit::*` twin. `conform::field_coercion_failed` fires for a scalar nested inside a content-bearing field: an `array` of `richtext`, an `object` with a `richtext` property. A top-level scalar never reaches it: it surfaces as `validation::format_violation` or `validation::type_mismatch` where the render floor refuses it too, and nowhere where the floor adopts it.
 
 ### Scope
 

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -201,11 +201,14 @@ Scalar → content is the lossy direction: the stored string enters the codec's 
 
 **Coercion is the type predicate; validation reads its result.** `validate_value`
 conforms each document value through `conform_value` at `Leniency::Render`
-before judging it, so a type has one predicate rather than a write-side and a
-read-side pair to keep in step, and **a fatal `validation::*` diagnostic means
-the document does not render**. The value a document rests at is a separate
-question from the value the floor builds: `letterhead_caption: HEADQUARTERS`
-rests as the authored scalar and is valid, because the floor wraps it.
+before judging it, so a type has one predicate. **A fatal `validation::*`
+diagnostic means the document does not render.**
+
+The value a document rests at is a separate question from the value the floor
+builds. `letterhead_caption: HEADQUARTERS` rests as the authored scalar and is
+valid, because the floor wraps it: a bare scalar is a spelling of a one-element
+list, and the schema is what disambiguates it. Landing a document at a canonical
+resting form is `Quill::conform`'s job, not validation's.
 
 Conforming runs per node, so an element the floor refuses does not mistype its
 siblings: `counts: [true, "abc"]` under `integer` items is one mismatch, at

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -198,6 +198,29 @@ Scalar → content is the lossy direction: the stored string enters the codec's 
 - Returns `Result<IndexMap<String, QuillValue>, CoercionError>`
 - Coerces top-level fields and per-card fields to their declared types
 - Fails fast (`Err`) on the first value that cannot be coerced
+
+**Coercion is the type predicate; validation reads its result.** `validate_value`
+conforms each document value through `conform_value` at `Leniency::Render`
+before judging it, so a type has one predicate rather than a write-side and a
+read-side pair to keep in step, and **a fatal `validation::*` diagnostic means
+the document does not render**. The value a document rests at is a separate
+question from the value the floor builds: `letterhead_caption: HEADQUARTERS`
+rests as the authored scalar and is valid, because the floor wraps it.
+
+Conforming runs per node, so an element the floor refuses does not mistype its
+siblings: `counts: [true, "abc"]` under `integer` items is one mismatch, at
+`counts[1]`. A value the floor refuses outright is judged as authored, where the
+type check reports it.
+
+Validation adds the arbitration coercion cannot carry — the enum domain, the
+datetime grammar, indexed element paths, the inline/plain content shapes — over
+the value the floor built. A scalar the floor stringifies into an enum field is
+therefore domain-checked on that string: `grade: 5` is `enum_violation`, not
+`type_mismatch`.
+
+Schema literals (`example:`, `default:`) are judged as written, uncoerced: the
+blueprint would otherwise emit a spelling it then teaches authors to write.
+
 Coercion rules per type:
 
 | Type | Rule |


### PR DESCRIPTION
Closes #1377.

## The mechanism

Not two tables that drifted — an ordering difference. `compile_data` → `coerce_and_validate` validates the **coerced** value; `Quill::validate` validated the **authored** one, with two of coercion's leniencies hand-replicated via `scalar_as_string` and the rest missing.

The bound ingestion path shows it at full strength. `Quill::parse` conforms, then:

```
Quill::parse warnings → (none)
Quill::validate       → 4 × Error validation::type_mismatch
dry_run               → OK — this document renders
```

The primary ingestion door accepts the document silently and the editor surface calls it fatally invalid.

## The change

`validate_value` conforms each document value through `conform_value` at `Leniency::Render` before judging it. One predicate per type, and **a fatal `validation::*` diagnostic means the document does not render**.

Two details worth review:

- **Conforming runs per node, not per field.** Field-level would report `counts: [true, "abc"]` under `integer` items as *two* mismatches — `true` is a value the floor adopts, dragged down by a refused sibling. That is #1377 recreated in a corner. Per node costs an idempotent re-conform on the recursion and yields one diagnostic, at `counts[1]`.
- **Variant-bearing fields are peeled before the conform**, as `conform_value` peels them. Conforming first turns `classification: BOGUS` into `{value: "BOGUS"}` and moves the `enum_violation` to `main.classification.value` — a key the author never wrote, against the stated intent at `validation.rs:657`. Caught on a fixture probe; test locks the path.

The issue's matrix listed five rows; `date` is a sixth — it also unwraps a length-1 array (`config.rs:698`) where validation required `as_str()`. `date`/`datetime`/`object` "agreeing" was two strict predicates coinciding, not a working sync.

## Behavior changes for a consumer routing on codes

- A value the floor adopts raises **nothing** where it previously raised `validation::type_mismatch`. Intended.
- `grade: 5` against `values: [alpha, beta]` is now `validation::enum_violation` where it was **silent**. The old type check reached `scalar_as_string`, but the domain check needs `as_str()`, which a raw number fails. Post-conform it is the string `"5"`, out of domain. This closes the opposite direction — validated clean, did not render — and the render door already raised it.

Schema literals (`example:`, `default:`) stay strict: coercing one would let the blueprint emit a spelling it then teaches authors to write.

## Semantics this commits to

A coercible value is valid, for every consumer. A bare scalar is a spelling of a one-element list in a schemaless notation, and the schema is what disambiguates it — not a fault, at any severity. Both bindings forward `Quill::validate` verbatim with no logic of their own, so the verdict is identical on markdown, GUI, and MCP surfaces by construction, and no binding code changed.

Landing a document at a canonical resting form remains `Quill::conform`'s job, and is explicitly not a validity question.

## Verification

- 1223 tests, 62 binaries, 0 failures (`cargo test --workspace`).
- `cargo clippy -p quillmark-core` at 30 warnings, identical to the stashed baseline; none in the new test file.
- `cargo doc --no-deps --locked --workspace` clean. Also fixed an unresolved `Leniency::Render` intra-doc link that only surfaces under `--document-private-items`, so it was not gating.
- Verified against the live fixture: `usaf_memo@0.2` with `letterhead_caption` as a bare scalar returns only the three genuine `must_fill` warnings, where it previously returned a fatal `type_mismatch`.

Canon updated in `SCHEMAS.md` §"Type coercion" and `ERROR.md` (the `conform::*` and validation-warnings bullets) — a top-level scalar the strict write refuses is now reported nowhere when the floor adopts it, written down rather than left implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLduHtbkxWUnQUPnJV2UmY

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLduHtbkxWUnQUPnJV2UmY)_