### PR TITLE
feat(wasm): mapMarks, the rebase an editor had to predict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- feat(wasm): **`mapMarks(content, bundle)` answers where a `ChangeBundle`'s
+  text-moving channels leave a field's marks**, the coordinates its `markOps`
+  are written in. Each of `delta`, `islandOps` and `lineOps` rebases the marks
+  already in the field — a range's `start` takes assoc `after` and its `end`
+  `before`, a zero-width mark takes `before` — and that rule reached the
+  boundary only as a comment on a private method, so an editor deciding which
+  `markOps` to emit had to reimplement it, and one that read the range rule as
+  the whole rule drifted an anchor a character on text typed at the anchor's own
+  position. `Content::map_marks` and `Content::apply_field_change` walk one
+  channel list, so the prediction and the store cannot answer a position
+  differently. The rule is stated on `ChangeBundle` and in `BINDINGS.md`.
+
 - fix(core): **a `plaintext` field declared `inline: true` keeps the flag on the
   declaration wire.** `FieldSchema::serialize` projected the flag back out of
   the type enum with a `RichText { inline: true }` match only, so

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -13,6 +13,7 @@ import {
   exportMarkdown,
   rebase,
   mapPos,
+  mapMarks,
   parseDocPath,
   formatDocPath,
 } from '@quillmark-wasm'
@@ -866,6 +867,55 @@ card_kinds:
     expect(() =>
       doc.applyChange({ field: 'intro' }, { markOps: [{ op: 'add', start: 999, end: 1000, type: 'emph' }] }),
     ).toThrow()
+  })
+
+  it('mapMarks answers where applyChange puts a mark, at the position the assocs differ', () => {
+    const doc = blankDoc()
+    doc.revise({}, 'hello world')
+    doc.applyChange(
+      {},
+      {
+        markOps: [
+          { op: 'add', start: 6, end: 6, type: 'anchor', id: 'c1' },
+          { op: 'add', start: 6, end: 11, type: 'strong' },
+        ],
+      },
+    )
+    const before = doc.main.body
+    const bundle = { delta: { ops: [{ retain: 6 }, { insert: 'X' }, { retain: 5 }] } }
+
+    // The trap: `mapPos` answers for a position the caller holds, and a caret
+    // typing here moves past its own text. A zero-width mark in the field does
+    // not — the store rebases it `before`.
+    expect(mapPos(bundle.delta, 6, 'after')).toBe(7)
+    const predicted = mapMarks(before, bundle)
+    expect(predicted.find((m) => m.type === 'anchor')).toMatchObject({ start: 6, end: 6 })
+    expect(predicted.find((m) => m.type === 'strong')).toMatchObject({ start: 7, end: 12 })
+
+    doc.applyChange({}, bundle)
+    expect(doc.main.body.marks).toEqual(predicted)
+  })
+
+  it('mapMarks carries a mark through every text-moving channel of one bundle', () => {
+    const doc = blankDoc()
+    doc.revise({}, 'hello world')
+    doc.applyChange({}, { markOps: [{ op: 'add', start: 6, end: 6, type: 'anchor', id: 'c1' }] })
+    const before = doc.main.body
+    const bundle = {
+      delta: { ops: [{ retain: 6 }, { insert: 'X' }, { retain: 5 }] },
+      islandOps: [
+        { op: 'insert', at: 6, id: 'i1', type: 'image', loss: 'lossless', props: { url: 'u', alt: 'a' } },
+      ],
+      lineOps: [{ op: 'split', at: 6 }],
+    }
+
+    const predicted = mapMarks(before, bundle)
+    doc.applyChange({}, bundle)
+    expect(doc.main.body.marks).toEqual(predicted)
+    expect(predicted.find((m) => m.type === 'anchor')).toMatchObject({ start: 6, end: 6 })
+
+    // A bundle `applyChange` would refuse throws here rather than answering.
+    expect(() => mapMarks(before, { islandOps: [{ op: 'insert', at: 99, id: 'i2', type: 'image', props: {} }] })).toThrow()
   })
 
   it('applyChange setContinues lowers a hard break op-wise', () => {

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -24,6 +24,7 @@ import type {
 	exportMarkdown,
 	rebase,
 	mapPos,
+	mapMarks,
 	parseDocPath,
 	formatDocPath
 } from '../core/wasm.js';
@@ -42,6 +43,7 @@ export interface CoreSurface {
 	exportMarkdown: typeof exportMarkdown;
 	rebase: typeof rebase;
 	mapPos: typeof mapPos;
+	mapMarks: typeof mapMarks;
 	parseDocPath: typeof parseDocPath;
 	formatDocPath: typeof formatDocPath;
 }

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -40,7 +40,7 @@ import initCore, { Quill, Document } from '../core/wasm.js';
 // itself), a `node:fs` read under Node, whose `fetch` rejects `file:` URLs.
 // Resolution-time, so `node:fs` never enters a browser graph.
 import { toModuleSource } from '#quillmark-env';
-import { importMarkdown, exportMarkdown, rebase, mapPos } from '../core/wasm.js';
+import { importMarkdown, exportMarkdown, rebase, mapPos, mapMarks } from '../core/wasm.js';
 import { parseDocPath, formatDocPath } from '../core/wasm.js';
 
 // ── Initialization ──────────────────────────────────────────────────────────
@@ -90,6 +90,7 @@ const CORE_SURFACE = Object.freeze({
 	exportMarkdown,
 	rebase,
 	mapPos,
+	mapMarks,
 	parseDocPath,
 	formatDocPath
 });

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -418,6 +418,18 @@ export type IslandOp =
  * Within each channel ops apply in sequence against the state the earlier ones
  * left: an island `insert`'s `at` counts earlier ops' slots, and `lineOps`
  * positions and indices renumber through earlier `split`/`join`.
+ *
+ * **Mark rebase.** `delta`, `islandOps` and `lineOps` each move text, and each
+ * rebases the marks already in the field by one rule: a range mark's `start`
+ * takes assoc `after` and its `end` `before`, so an insertion at either edge
+ * grows text *outside* the span; a **zero-width** mark takes `before`, so an
+ * insertion at its own position leaves it put. That last case is the one
+ * position where the two assocs differ, and where an anchor most often sits.
+ *
+ * `markOps` name the result, so a caller emitting them predicts this rebase.
+ * `mapMarks(content, bundle)` runs it instead: pass the bundle's text-moving
+ * channels, diff the marks it returns against the ones you intend, and emit
+ * only the difference. Reproducing the rule by hand is a second copy to drift.
  */
 export interface ChangeBundle {
     delta?: Delta;
@@ -1614,6 +1626,10 @@ impl Document {
     /// Throws on an out-of-range card, a field that is not richtext, a malformed
     /// bundle, or an op that applies out of bounds; the value is unchanged on a
     /// failed apply.
+    ///
+    /// Each text-moving channel rebases the marks already in the field, by the
+    /// rule on `ChangeBundle`; `mapMarks` answers where they land, so a caller
+    /// building `markOps` need not predict it.
     #[wasm_bindgen(js_name = applyChange)]
     pub fn apply_change(
         &mut self,
@@ -1621,7 +1637,7 @@ impl Document {
         #[wasm_bindgen(unchecked_param_type = "ChangeBundle")] bundle: JsValue,
     ) -> Result<(), JsValue> {
         let addr = Addr::from_js_or_string(&addr)?;
-        let bundle = parse_change_bundle(&bundle)?;
+        let bundle = parse_change_bundle(&bundle, "applyChange")?;
         let base = self.addr_base(&addr);
         let card = self.addr_card_mut(&addr)?;
         match &addr.field {
@@ -1998,10 +2014,13 @@ fn js_to_content_with(
     })
 }
 
-fn parse_change_bundle(value: &JsValue) -> Result<quillmark_content::ChangeBundle, JsValue> {
-    let json = js_value_to_json(value.clone(), "applyChange")?;
+fn parse_change_bundle(
+    value: &JsValue,
+    ctx: &str,
+) -> Result<quillmark_content::ChangeBundle, JsValue> {
+    let json = js_value_to_json(value.clone(), ctx)?;
     quillmark_content::change_bundle_from_value(&json)
-        .map_err(|e| WasmError::from(format!("applyChange: {e}")).to_js_value())
+        .map_err(|e| WasmError::from(format!("{ctx}: {e}")).to_js_value())
 }
 
 /// Import a markdown string to canonical `Content`: the pure, document-free
@@ -2153,10 +2172,47 @@ pub fn format_doc_path(
     Ok(doc_path.to_string())
 }
 
+/// Where `bundle`'s text-moving channels (`delta`, then `islandOps`, then
+/// `lineOps`) leave `content`'s marks: the final-text coordinates the bundle's
+/// `markOps` are written in, under the rebase rule stated on `ChangeBundle`.
+/// The document-free read an editor diffs against to decide which `markOps` to
+/// emit, rather than reproducing that rule in its own language.
+///
+/// `bundle.markOps` are ignored. Marks a text move drops (out of range,
+/// zero-width formatting) are absent, as they are from the applied result.
+/// Throws on a non-content `content`, a malformed bundle, or an op that applies
+/// out of bounds: `applyChange`'s errors on the same ops.
+#[wasm_bindgen(js_name = mapMarks, unchecked_return_type = "ContentMark[]")]
+pub fn map_marks(
+    #[wasm_bindgen(unchecked_param_type = "Content")] content: JsValue,
+    #[wasm_bindgen(unchecked_param_type = "ChangeBundle")] bundle: JsValue,
+) -> Result<JsValue, JsValue> {
+    let content = js_to_content(content, "mapMarks")?;
+    let bundle = parse_change_bundle(&bundle, "mapMarks")?;
+    let marks = content
+        .map_marks(&bundle)
+        .map_err(|e| {
+            // `applyChange`'s wording on the same op, from the same variant.
+            let e = quillmark_core::EditError::ContentApply(e);
+            WasmError::from(format!("mapMarks: {e}")).to_js_value()
+        })?;
+    let out = serde_json::Value::Array(
+        marks
+            .iter()
+            .map(quillmark_content::serial::mark_to_value)
+            .collect(),
+    );
+    serialize_or_throw(&out, "mapMarks")
+}
+
 /// Map a base content position (a USV index into `Content.text`, not a UTF-16
 /// offset) through a `delta` to its new position, holding a caret stable across
 /// a `revise`. `assoc` decides the side of a same-position insertion (`"after"`
 /// moves past it). Throws on a malformed `delta`.
+///
+/// This maps a position the *caller* holds. For the marks already in a field,
+/// `mapMarks` applies the store's own assoc rule across every channel of a
+/// `ChangeBundle`.
 #[wasm_bindgen(js_name = mapPos)]
 pub fn map_pos(
     #[wasm_bindgen(unchecked_param_type = "Delta")] delta: JsValue,

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -120,6 +120,20 @@ pub enum IslandOp {
 /// for an island insert and line indices for [`LineOp::Split`] /
 /// [`LineOp::Join`], which renumber every later line. A stale frame stays in
 /// range, so the bundle applies cleanly and lands the wrong document.
+///
+/// # Mark rebase
+///
+/// `delta`, `island_ops` and `line_ops` each move text, and each rebases the
+/// marks already in the field by one rule:
+///
+/// | mark edge | [`Assoc`] | an insertion at that exact position |
+/// |---|---|---|
+/// | a range's `start` | `After` | grows text *outside* the span |
+/// | a range's `end` | `Before` | grows text *outside* the span |
+/// | a zero-width mark | `Before` | leaves the mark put |
+///
+/// `mark_ops` name the result, so a caller emitting them predicts this rebase.
+/// [`Content::map_marks`] runs it rather than reproducing it.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ChangeBundle {
     /// The text splice; the identity delta (no ops) is no text change.
@@ -446,9 +460,6 @@ impl Content {
         Ok(())
     }
 
-    /// A range mark's start biases `After` and its end `Before` (an insertion at
-    /// either edge grows text *outside* the span); a zero-width mark biases
-    /// `Before`.
     fn rebase_marks(&mut self, delta: &Delta) {
         for m in &mut self.marks {
             if m.start == m.end {
@@ -709,13 +720,38 @@ impl Content {
             return self.apply_text_delta(&bundle.delta);
         }
         let mut scratch = self.clone();
-        scratch.apply_text_delta_inner(&bundle.delta)?;
-        scratch.apply_island_ops_inner(&bundle.island_ops)?;
-        scratch.apply_line_ops_inner(&bundle.line_ops)?;
+        scratch.apply_text_channels(bundle)?;
         scratch.apply_mark_ops_inner(&bundle.mark_ops)?;
         scratch.normalize();
         *self = scratch;
         Ok(())
+    }
+
+    /// Every channel of `bundle` that moves text, in bundle order. Sole caller
+    /// of the three, so an editor reading [`map_marks`](Self::map_marks) and the
+    /// store reading [`apply_field_change`](Self::apply_field_change) cannot
+    /// answer a position differently.
+    fn apply_text_channels(&mut self, bundle: &ChangeBundle) -> Result<(), ApplyError> {
+        self.apply_text_delta_inner(&bundle.delta)?;
+        self.apply_island_ops_inner(&bundle.island_ops)?;
+        self.apply_line_ops_inner(&bundle.line_ops)
+    }
+
+    /// Where `bundle`'s text-moving channels leave the marks this content
+    /// already holds: the final-text coordinates [`ChangeBundle::mark_ops`] are
+    /// written in, under the rebase rule stated on [`ChangeBundle`].
+    ///
+    /// `bundle.mark_ops` are ignored, so an editor building them diffs its
+    /// intended marks against this instead of predicting the rebase. Marks a
+    /// text move drops (out of range, zero-width formatting) are absent, as they
+    /// are from the applied result.
+    ///
+    /// Errors are [`apply_field_change`](Self::apply_field_change)'s on the same
+    /// ops, minus those only a mark op raises.
+    pub fn map_marks(&self, bundle: &ChangeBundle) -> Result<Vec<Mark>, ApplyError> {
+        let mut scratch = self.clone();
+        scratch.apply_text_channels(bundle)?;
+        Ok(scratch.marks)
     }
 
     fn line_mut(&mut self, line: usize) -> Result<&mut Line, ApplyError> {
@@ -1143,6 +1179,153 @@ mod tests {
             .unwrap();
         assert_eq!((strong.start, strong.end), (2, 5));
         assert_eq!(rt.text, "hXello");
+    }
+
+    fn anchored(text: &str, at: Usv) -> crate::model::Normalized {
+        let mut rt = from_markdown(text).unwrap();
+        rt.apply_mark_ops(&[MarkOp::Add {
+            start: at,
+            end: at,
+            kind: MarkKind::Anchor { id: "a1".into() },
+        }])
+        .unwrap();
+        rt
+    }
+
+    fn anchor_at(rt: &Content) -> (Usv, Usv) {
+        let m = rt
+            .marks
+            .iter()
+            .find(|m| matches!(&m.kind, MarkKind::Anchor { id } if id == "a1"))
+            .expect("the anchor survives");
+        (m.start, m.end)
+    }
+
+    fn strong_at(rt: &Content) -> (Usv, Usv) {
+        let m = rt
+            .marks
+            .iter()
+            .find(|m| matches!(m.kind, MarkKind::Strong))
+            .expect("the mark survives");
+        (m.start, m.end)
+    }
+
+    /// A zero-width mark's own position is where the two assocs part, and where
+    /// an anchor most often sits. Every text-moving channel answers it `Before`.
+    #[test]
+    fn an_insert_at_a_zero_width_marks_position_leaves_it_put() {
+        let d = diff("hello world", "hello Xworld");
+        assert_eq!(d.map_pos(6, Assoc::After), 7, "the answer not taken");
+
+        let mut via_delta = anchored("hello world", 6);
+        via_delta.apply_text_delta(&d).unwrap();
+        assert_eq!(anchor_at(&via_delta), (6, 6));
+
+        let mut via_island = anchored("hello world", 6);
+        via_island
+            .apply_island_ops(&[IslandOp::Insert {
+                at: 6,
+                island: image("i1"),
+            }])
+            .unwrap();
+        assert_eq!(anchor_at(&via_island), (6, 6));
+
+        let mut via_line = anchored("hello world", 6);
+        via_line.apply_line_ops(&[LineOp::Split { at: 6 }]).unwrap();
+        assert_eq!(anchor_at(&via_line), (6, 6));
+    }
+
+    /// An insertion at either edge of a range grows text outside the span.
+    #[test]
+    fn an_insert_at_a_range_marks_edge_stays_outside_the_span() {
+        let mut at_start = from_markdown("hello world").unwrap();
+        at_start
+            .apply_mark_ops(&[MarkOp::Add {
+                start: 6,
+                end: 11,
+                kind: MarkKind::Strong,
+            }])
+            .unwrap();
+        at_start
+            .apply_text_delta(&diff("hello world", "hello Xworld"))
+            .unwrap();
+        assert_eq!(strong_at(&at_start), (7, 12));
+
+        let mut at_end = from_markdown("hello world").unwrap();
+        at_end
+            .apply_mark_ops(&[MarkOp::Add {
+                start: 0,
+                end: 5,
+                kind: MarkKind::Strong,
+            }])
+            .unwrap();
+        at_end
+            .apply_text_delta(&diff("hello world", "helloX world"))
+            .unwrap();
+        assert_eq!(strong_at(&at_end), (0, 5));
+
+        let mut at_end_island = from_markdown("hello world").unwrap();
+        at_end_island
+            .apply_mark_ops(&[MarkOp::Add {
+                start: 0,
+                end: 5,
+                kind: MarkKind::Strong,
+            }])
+            .unwrap();
+        at_end_island
+            .apply_island_ops(&[IslandOp::Insert {
+                at: 5,
+                island: image("i1"),
+            }])
+            .unwrap();
+        assert_eq!(strong_at(&at_end_island), (0, 5));
+    }
+
+    /// The reason an editor can diff against `map_marks` rather than reproduce
+    /// the rebase: both readings walk one channel list, over every channel at
+    /// once and at the position the assocs disagree on.
+    #[test]
+    fn map_marks_reports_where_apply_field_change_puts_them() {
+        let mut rt = anchored("hello world", 6);
+        rt.apply_mark_ops(&[MarkOp::Add {
+            start: 0,
+            end: 5,
+            kind: MarkKind::Strong,
+        }])
+        .unwrap();
+        let bundle = ChangeBundle {
+            delta: diff("hello world", "hello Xworld"),
+            island_ops: vec![IslandOp::Insert {
+                at: 6,
+                island: image("i1"),
+            }],
+            line_ops: vec![LineOp::Split { at: 6 }],
+            mark_ops: Vec::new(),
+        };
+
+        let predicted = rt.map_marks(&bundle).unwrap();
+        rt.apply_field_change(&bundle).unwrap();
+        assert_eq!(predicted, rt.marks);
+        assert_eq!(anchor_at(&rt), (6, 6), "the anchor never left its position");
+    }
+
+    /// `map_marks` reads; a bundle it rejects leaves the content alone.
+    #[test]
+    fn map_marks_reports_an_out_of_bounds_bundle_without_touching_the_content() {
+        let rt = anchored("hello world", 6);
+        let before = rt.clone();
+        let err = rt
+            .map_marks(&ChangeBundle {
+                island_ops: vec![IslandOp::Insert {
+                    at: 99,
+                    island: image("i1"),
+                }],
+                ..Default::default()
+            })
+            .unwrap_err();
+        assert!(matches!(err, ApplyError::IslandInsertOutOfRange { .. }));
+        assert_eq!(rt.marks, before.marks);
+        assert_eq!(rt.text, before.text);
     }
 
     #[test]

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -22,7 +22,7 @@ Placement decides where a mutation verb lives, in one sentence:
 
 `quill.writer(doc)` (mirroring core's `quill.writer(&mut doc)`) is the one schema-bound door: bare `set` / `set_all` / `reviseBody` / `reviseField` / `addCard` / `card(i)`, names and markdown in, diagnostics out. It resolves each field's type from the bound quill, so a name the schema does not declare is a typo (`UnknownField`), not a fallback.
 
-`Document` holds everything quill-free: the opaque `store*` primitive (verbatim, coercion deferred to render) and the addressed content lane: `overwrite` / `revise` / `applyChange` plus the `importMarkdown` / `exportMarkdown` / `rebase` / `mapPos` codec: which navigate by `Addr` and return `Delta` receipts but never consult a schema. **Transport** reads (`getStored` / `isFill` / `getExt`) return the stored value verbatim, need no schema, and sit on `Document` too.
+`Document` holds everything quill-free: the opaque `store*` primitive (verbatim, coercion deferred to render) and the addressed content lane: `overwrite` / `revise` / `applyChange` plus the `importMarkdown` / `exportMarkdown` / `rebase` / `mapPos` / `mapMarks` codec: which navigate by `Addr` and return `Delta` receipts but never consult a schema. **Transport** reads (`getStored` / `isFill` / `getExt`) return the stored value verbatim, need no schema, and sit on `Document` too.
 
 The **interpreting** reads (reading a field by its type) are schema-shaped questions ("this field's richtext, as markdown"), so they gain a schema-bound home: `quill.reader(doc)`, the read twin of `quill.writer(doc)` (mirroring core's `quill.reader(&doc)`).
 
@@ -73,7 +73,19 @@ The content lane's three verbs are rungs, and what sorts them is the fate of the
 
 - **overwrite** *destroys* them. Value semantics: store exactly this content, no import, no diff. A `toMarkdown → overwrite` round-trip cannot resurrect an anchor, which is why the cold-import path is spelled `overwrite(addr, importMarkdown(md))` at the call site, where the loss is visible.
 - **revise** *rebases* them. Import the markdown, diff against the current value, carry surviving anchors onto the new text, hand back the `Delta`.
-- **apply** *preserves* them. Splice ops into the content in place; anchors and island ids are untouched because the text around them is what moved.
+- **apply** *preserves* them. Splice ops into the content in place; anchors and island ids ride the splice because the text around them is what moved.
+
+**The rebase rule.** Every channel that moves text (`delta`, `islandOps`, `lineOps`) rebases the marks already in the field by one assoc rule, and `revise` carries surviving anchors by the same biases:
+
+| mark edge | assoc | an insertion at that exact position |
+|---|---|---|
+| a range's `start` | `after` | grows text outside the span |
+| a range's `end` | `before` | grows text outside the span |
+| a zero-width mark | `before` | leaves the mark put |
+
+The last row is the only position where the two assocs differ, and where an anchor most often sits.
+
+`markOps` are written in the coordinates that rebase produces. Left as prose, the rule is a prediction every editor bridge reimplements to decide which ops to emit; `mapMarks(content, bundle)` runs it instead, and a bridge diffs its intended marks against what it returns. Both readings walk one channel list (`Content::apply_text_channels`), so the store and the prediction cannot answer a position differently.
 
 **The rule governs user-field writes.** System metadata (`store_ext` / `store_seed_*`), structural operations (`insertCard` / `moveCard` / `setCardKind`), and the `remove_*` family sit outside it: `remove_*` has no lane because one verb serves every write path, and a structural op moves cards rather than writing into one. So `store_field` / `store_fields` / `store_fill` are the opaque store, `set` / `set_all` the typed writer, and a name never needs per-verb disambiguation against its neighbor (the opaque batch `store_fields` and the typed batch `set_all` are not near-homographs).
 
@@ -130,7 +142,7 @@ PyO3 bindings published as `quillmark` on PyPI. A `snake_case` surface over the 
 
 > **Scope: Tier 1 + storage + render.** Field I/O flows through `quill.writer(doc)` / `quill.reader(doc)` exclusively; `Document` is quill-free data and structure (parse, the storage DTO, `insert_card` / `remove_card` / `move_card` / `make_card`, `remove_field`, the `card` / `seed_overlay` reads, `$ext` / `$seed`).
 >
-> The opaque store (`store_field` / `store_fields` / `store_fill`) and the anchor-preserving content lane (`overwrite` / `revise` / `apply_change` + the `import_markdown` / `export_markdown` / `rebase` / `map_pos` codec) are **WASM-only by scope, not by lag**: their audience, storage/migration tooling holding no quill and live editors preserving anchor identity, is not a Python audience. A field write without a loadable quill operates on the storage DTO directly.
+> The opaque store (`store_field` / `store_fields` / `store_fill`) and the anchor-preserving content lane (`overwrite` / `revise` / `apply_change` + the `import_markdown` / `export_markdown` / `rebase` / `map_pos` / `map_marks` codec) are **WASM-only by scope, not by lag**: their audience, storage/migration tooling holding no quill and live editors preserving anchor identity, is not a Python audience. A field write without a loadable quill operates on the storage DTO directly.
 
 Every Python verb is identical to its core/WASM twin or names its one difference in the parity table above: `card=None` selectors fold the composable-card `$ext` / `remove_field` twins onto one axis, and `revise_field` discards the `Delta` (an editor receipt). No half-mirrored lane remains to drift.
 


### PR DESCRIPTION
Closes #1424.

## The contract

`Content::rebase_marks` decides where a field's existing marks land when text moves:

| mark edge | assoc | an insertion at that exact position |
|---|---|---|
| a range's `start` | `after` | grows text outside the span |
| a range's `end` | `before` | grows text outside the span |
| a zero-width mark | `before` | leaves the mark put |

**Three** channels run it, not two as #1424 states: the text delta, an `IslandOp::Insert`'s synthetic splice (`ops.rs:598`), and `split_line`/`join_line` (`ops.rs:747`, `:780`). `markOps` are written in the coordinates it produces, so an editor lowering an edit to `applyChange` has to reproduce the rule to decide which ops to emit — and it reached the boundary only as a comment on a private method.

That has already cost a bug, live at `quillmark-js` HEAD: `encode.ts:608` rebases a held anchor `mapPos(delta, pos, 'after')` then `shiftPastIslands(…, 'before')`. The island half matches the store; the delta half drifts an anchor a character on text typed at the anchor's own position, and no op is emitted to reconcile it because the diff compares its own prediction against the projection. `encode.ts:12` and `table.ts:265` both write the range rule down as the whole rule.

## The change

**`mapMarks(content, bundle)`** — a document-free codec function beside `mapPos` / `rebase` / `importMarkdown`. Returns the marks a bundle's text-moving channels leave behind: the coordinates its `markOps` are written in. A bridge diffs its intended marks against that instead of predicting. `bundle.markOps` are ignored, so it composes with a bundle mid-construction. It also retires `shiftPastIslands` downstream — that exists only because no exported mapper covered the island channel.

The anti-drift guarantee is structural:

```rust
fn apply_text_channels(&mut self, bundle: &ChangeBundle) -> Result<(), ApplyError> {
    self.apply_text_delta_inner(&bundle.delta)?;
    self.apply_island_ops_inner(&bundle.island_ops)?;
    self.apply_line_ops_inner(&bundle.line_ops)
}
```

Sole caller of the three. `apply_field_change` and `map_marks` both walk it, so the store and the prediction cannot answer a position differently.

**The rule, stated once per reader.** A table on `ChangeBundle` (Rust doc and TSDoc), the content-lane rungs in `BINDINGS.md` — whose "anchors are untouched" line read as *no decision is made*, at the one position where one is — and pointers from `applyChange` and from `mapPos`, whose `assoc` answers for a position the caller holds rather than for a mark in the field. The comment on private `rebase_marks` is deleted: it became the second copy, and the ten lines beneath it spell `Assoc::Before`/`After` directly.

**Tests.** #1424's "no test pins the rule" is too strong — `apply_text_delta_rebases_marks` already pinned range-start-`after`, and `island_insert_adds_the_slot_and_its_entry` range-end-`before` through the island channel. The real hole was the **zero-width** case at an insertion point, in any channel. Added: that case through all three channels, a range mark's edges, `map_marks` agreeing with `apply_field_change` over a bundle using every channel at once, and the read-only error path. Two JS tests cover the exported function. Mutation-checked: flipping the zero-width bias to `After` turns the Rust tests red.

## Not included

The one-word downstream fix (`encode.ts:608`, `'after'` → `'before'`) is `quillmark-js`'s call — take that, or adopt `mapMarks` and delete both prediction sites. `table.ts:277` carries the same misreading, but there `IslandOp::Set` replaces cell props wholesale, so the editor's rebase is the authority and nothing drifts.

Purely additive: a new export, no signature or behavior change, so no migration entry.

## Verification

`cargo test --workspace` green; `check-canon` green; `build-wasm.sh --ci` + `tsc --noEmit` + 254 vitest tests green. No new clippy warnings, no rustdoc broken links. Generated signature: `export function mapMarks(content: Content, bundle: ChangeBundle): ContentMark[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVuKCYBYyLFVVPHL7ptHoh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVuKCYBYyLFVVPHL7ptHoh)_